### PR TITLE
Add -version flag for reporting version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: go
 
 go:
-  - 1.7
+  - 1.7.x
 
 script:
   - bash --version
   - go test ./...
   - go test -short -race ./...
+  - shfmt -version

--- a/cmd/shfmt/main.go
+++ b/cmd/shfmt/main.go
@@ -17,10 +17,11 @@ import (
 )
 
 var (
-	write  = flag.Bool("w", false, "write result to file instead of stdout")
-	list   = flag.Bool("l", false, "list files whose formatting differs from shfmt's")
-	indent = flag.Int("i", 0, "indent: 0 for tabs (default), >0 for number of spaces")
-	posix  = flag.Bool("p", false, "parse POSIX shell code instead of bash")
+	write       = flag.Bool("w", false, "write result to file instead of stdout")
+	list        = flag.Bool("l", false, "list files whose formatting differs from shfmt's")
+	indent      = flag.Int("i", 0, "indent: 0 for tabs (default), >0 for number of spaces")
+	posix       = flag.Bool("p", false, "parse POSIX shell code instead of bash")
+	showVersion = flag.Bool("V", false, "show version and exit")
 
 	parseMode         syntax.ParseMode
 	printConfig       syntax.PrintConfig
@@ -29,10 +30,17 @@ var (
 	copyBuf = make([]byte, 32*1024)
 
 	out io.Writer
+
+	version = "v0.6.0"
 )
 
 func main() {
 	flag.Parse()
+
+	if *showVersion {
+		fmt.Println(version)
+		os.Exit(0)
+	}
 
 	out = os.Stdout
 	printConfig.Spaces = *indent

--- a/cmd/shfmt/main.go
+++ b/cmd/shfmt/main.go
@@ -35,6 +35,10 @@ var (
 )
 
 func main() {
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage of %s %s:\n", os.Args[0], version)
+		flag.PrintDefaults()
+	}
 	flag.Parse()
 
 	if *showVersion {

--- a/cmd/shfmt/main.go
+++ b/cmd/shfmt/main.go
@@ -21,7 +21,7 @@ var (
 	list        = flag.Bool("l", false, "list files whose formatting differs from shfmt's")
 	indent      = flag.Int("i", 0, "indent: 0 for tabs (default), >0 for number of spaces")
 	posix       = flag.Bool("p", false, "parse POSIX shell code instead of bash")
-	showVersion = flag.Bool("V", false, "show version and exit")
+	showVersion = flag.Bool("version", false, "show version and exit")
 
 	parseMode         syntax.ParseMode
 	printConfig       syntax.PrintConfig
@@ -35,15 +35,12 @@ var (
 )
 
 func main() {
-	flag.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Usage of %s %s:\n", os.Args[0], version)
-		flag.PrintDefaults()
-	}
 	flag.Parse()
 
 	if *showVersion {
 		fmt.Println(version)
 		os.Exit(0)
+		return
 	}
 
 	out = os.Stdout

--- a/cmd/shfmt/main.go
+++ b/cmd/shfmt/main.go
@@ -39,7 +39,6 @@ func main() {
 
 	if *showVersion {
 		fmt.Println(version)
-		os.Exit(0)
 		return
 	}
 


### PR DESCRIPTION
I'm working on getting `shfmt` added to the default preinstalled stuff on the Travis CI VMs, and I'd like to be able to include the `shfmt` version in the VM metadata.  I realize that having a hardcoded version is a bit of a pain, and I'd typically implement this as an injected string of `git describe --always --tags` or similar, but didn't want to introduce such a big change without first proposing the flag.