### PR TITLE
Fix locale issue on tests

### DIFF
--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -20,6 +20,7 @@ import (
 var hasBash44 bool
 
 func TestMain(m *testing.M) {
+	os.Setenv("LANGUAGE", "en_US.UTF8")
 	os.Setenv("LC_ALL", "en_US.UTF8")
 	hasBash44 = checkBash()
 	os.Setenv("INTERP_GLOBAL", "value")

--- a/syntax/parser_test.go
+++ b/syntax/parser_test.go
@@ -60,6 +60,7 @@ func TestParsePosix(t *testing.T) {
 var hasBash44 bool
 
 func TestMain(m *testing.M) {
+	os.Setenv("LANGUAGE", "en_US.UTF8")
 	os.Setenv("LC_ALL", "en_US.UTF8")
 	hasBash44 = checkBash()
 	os.Exit(m.Run())


### PR DESCRIPTION
Closes #89

---

Seems that Ubuntu use `LANGUAGE` instead of `LC_ALL`.