### PR TITLE
cmd/shfmt: fix panic on Stmts without Command in -exp.tojson

### DIFF
--- a/cmd/shfmt/json.go
+++ b/cmd/shfmt/json.go
@@ -30,6 +30,9 @@ func recurse(val reflect.Value) (interface{}, string) {
 		}
 		return recurse(elem)
 	case reflect.Interface:
+		if val.IsNil() {
+			return nil, ""
+		}
 		v, tname := recurse(val.Elem())
 		m := v.(map[string]interface{})
 		m["Type"] = tname


### PR DESCRIPTION
Don't recurse into nil interfaces.

```
$ echo "FOO=a" | shfmt -exp.tojson

panic: reflect: call of reflect.Value.Interface on zero Value

goroutine 1 [running]:
reflect.valueInterface(0x0, ext:0x0, 0x0, 0x1, 0xc4200451d8, 0x40e142)
	/usr/lib/go/src/reflect/value.go:930 +0x1fa
reflect.Value.Interface(0x0, ext:0x0, 0x0, 0xc420092500, 0x280)
	/usr/lib/go/src/reflect/value.go:925 +0x44
main.recurse(0x0, ext:0x0, 0x0, 0x0, 0x0, 0x0, 0x7faf80805960)
	[...]/go/src/github.com/mvdan/sh/cmd/shfmt/json.go:75 +0x485
[..]
```