### PR TITLE
interp: have a custom /dev/null implementation

### DIFF
--- a/interp/dev.go
+++ b/interp/dev.go
@@ -1,0 +1,21 @@
+package interp
+
+import (
+	"io"
+)
+
+var _ io.ReadWriteCloser = devNull{}
+
+type devNull struct{}
+
+func (devNull) Read(_ []byte) (int, error) {
+	return 0, io.EOF
+}
+
+func (devNull) Write(p []byte) (int, error) {
+	return len(p), nil
+}
+
+func (devNull) Close() error {
+	return nil
+}

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -671,10 +671,17 @@ func (r *Runner) redir(rd *syntax.Redirect) (io.Closer, error) {
 	case syntax.RdrOut, syntax.RdrAll:
 		mode = os.O_RDWR | os.O_CREATE | os.O_TRUNC
 	}
-	f, err := os.OpenFile(r.relPath(arg), mode, 0644)
-	if err != nil {
-		// TODO: print to stderr?
-		return nil, err
+	var f io.ReadWriteCloser
+	switch arg {
+	case "/dev/null":
+		f = devNull{}
+	default:
+		var err error
+		f, err = os.OpenFile(r.relPath(arg), mode, 0644)
+		if err != nil {
+			// TODO: print to stderr?
+			return nil, err
+		}
 	}
 	switch rd.Op {
 	case syntax.RdrIn:

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -1127,6 +1127,10 @@ var fileCases = []struct {
 		"mkdir a; touch a/b.x; echo */*.x; cd a; echo *.x",
 		"a/b.x\nb.x\n",
 	},
+
+	// /dev/null
+	{"echo foo >/dev/null", ""},
+	{"cat </dev/null", ""},
 }
 
 // concBuffer wraps a bytes.Buffer in a mutex so that concurrent writes


### PR DESCRIPTION
This fix reading and writing to /dev/null on Windows, where this file is not available.

It may also add a very minimal performance improvement on other plataforms, since now interp don't need to open and redirect to a real file anymore.

Reference: #141 

---

@mvdan Consider this a proposal, and feel free to reject it if you decide against it, or have a better idea about how to implement this.