### PR TITLE
interp: cd now checks for exec permissions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,6 @@ script:
   - go test -short -race ./...
   - shfmt -version
   - goveralls
+  # at least make sure the builds work
+  - GOOS=windows go install ./interp
+  - GOOS=darwin go install ./interp

--- a/interp/builtin.go
+++ b/interp/builtin.go
@@ -161,6 +161,9 @@ func (r *Runner) builtinCode(pos syntax.Pos, name string, args []string) int {
 		if err != nil || !info.IsDir() {
 			return 1
 		}
+		if !hasPermissionToDir(info) {
+			return 1
+		}
 		r.Dir = dir
 	case "wait":
 		if len(args) > 0 {

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -428,6 +428,30 @@ var fileCases = []struct {
 		`mkdir a; ln -s a b; [[ $(cd a && pwd) == $(cd b && pwd) ]]; echo $?`,
 		"1\n",
 	},
+	{
+		`mkdir a; chmod 0000 a; cd a`,
+		"exit status 1 #JUSTERR",
+	},
+	{
+		`mkdir a; chmod 0222 a; cd a`,
+		"exit status 1 #JUSTERR",
+	},
+	{
+		`mkdir a; chmod 0444 a; cd a`,
+		"exit status 1 #JUSTERR",
+	},
+	{
+		`mkdir a; chmod 0100 a; cd a`,
+		"",
+	},
+	{
+		`mkdir a; chmod 0010 a; cd a`,
+		"exit status 1 #JUSTERR",
+	},
+	{
+		`mkdir a; chmod 0001 a; cd a`,
+		"exit status 1 #JUSTERR",
+	},
 
 	// binary cmd
 	{

--- a/interp/perm_other.go
+++ b/interp/perm_other.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2017, Andrey Nering <andrey.nering@gmail.com>
+// See LICENSE for licensing information
+
+// +build !windows
+
+package interp
+
+import (
+	"os"
+	"os/user"
+	"strconv"
+	"syscall"
+)
+
+// hasPermissionToDir returns if the OS current user has execute permission
+// to the given directory
+func hasPermissionToDir(info os.FileInfo) bool {
+	st, _ := info.Sys().(*syscall.Stat_t)
+	if st == nil {
+		return true
+	}
+
+	user, err := user.Current()
+	if err != nil {
+		return false
+	}
+	perm := info.Mode().Perm()
+	uid, _ := strconv.Atoi(user.Uid)
+	gid, _ := strconv.Atoi(user.Gid)
+
+	// user (u)
+	if perm&0100 != 0 && st.Uid == uint32(uid) {
+		return true
+	}
+	// other users in group (g)
+	if perm&0010 != 0 && st.Uid != uint32(uid) && st.Gid == uint32(gid) {
+		return true
+	}
+	// remaining users (o)
+	if perm&0001 != 0 && st.Uid != uint32(uid) && st.Gid != uint32(gid) {
+		return true
+	}
+
+	return false
+}

--- a/interp/perm_win.go
+++ b/interp/perm_win.go
@@ -1,0 +1,15 @@
+// Copyright (c) 2017, Andrey Nering <andrey.nering@gmail.com>
+// See LICENSE for licensing information
+
+// +build windows
+
+package interp
+
+import (
+	"os"
+)
+
+// hasPermissionToDir is no-op on Windows
+func hasPermissionToDir(info os.FileInfo) bool {
+	return true
+}


### PR DESCRIPTION
This commit reintroduces bc1c6f7cf372d921cb3594b2d23a2cab08d5fd23, but with build tags to fix build on Windows.

Closes #148