### PR TITLE
interp: printf %% and error handling

### DIFF
--- a/interp/interp.go
+++ b/interp/interp.go
@@ -496,6 +496,7 @@ func (r *Runner) expand(format string, onlyChars bool, args ...string) string {
 				buf.WriteString(strconv.FormatUint(uint64(n), 16))
 			default:
 				r.runErr(syntax.Pos{}, "unhandled format char: %c", c)
+				return ""
 			}
 			continue
 		}
@@ -509,6 +510,7 @@ func (r *Runner) expand(format string, onlyChars bool, args ...string) string {
 	}
 	if fmt {
 		r.runErr(syntax.Pos{}, "missing format char")
+		return ""
 	}
 	return buf.String()
 }

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -507,6 +507,9 @@ func (r *Runner) expand(format string, onlyChars bool, args ...string) string {
 			buf.WriteRune(c)
 		}
 	}
+	if fmt {
+		r.runErr(syntax.Pos{}, "missing format char")
+	}
 	return buf.String()
 }
 

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -476,6 +476,8 @@ func (r *Runner) expand(format string, onlyChars bool, args ...string) string {
 				n = int(i)
 			}
 			switch c {
+			case '%':
+				buf.WriteByte('%')
 			case 's':
 				buf.WriteString(arg)
 			case 'c':

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -101,6 +101,7 @@ var fileCases = []struct {
 
 	// printf
 	{"printf foo", "foo"},
+	{"printf %%", "%"},
 	{"printf %B foo", "0:0: unhandled format char: B #JUSTERR"},
 	{"printf ' %s \n' bar", " bar \n"},
 	{"printf %s foo", "foo"},

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -102,6 +102,7 @@ var fileCases = []struct {
 	// printf
 	{"printf foo", "foo"},
 	{"printf %%", "%"},
+	{"printf %", "0:0: missing format char #JUSTERR"},
 	{"printf %B foo", "0:0: unhandled format char: B #JUSTERR"},
 	{"printf ' %s \n' bar", " bar \n"},
 	{"printf %s foo", "foo"},


### PR DESCRIPTION
```
printf "%%\n"      
printf "%"
printf "%02d\n" 1 
```

bash
```
%
x.sh: line 2: printf: `%': missing format character
01
```

gosh (before)
```

x.sh:0:0: unhandled format char: %

2d
x.sh:0:0: unhandled format char: 0
```

gosh (after)
```
%
x.sh:0:0: missing format char
x.sh:0:0: unhandled format char: 0
```