### PR TITLE
interp: handle more printf formats

### DIFF
--- a/interp/interp.go
+++ b/interp/interp.go
@@ -492,6 +492,8 @@ func (r *Runner) expand(format string, onlyChars bool, args ...string) string {
 				}
 				buf.WriteByte(b)
 				fmts = nil
+			case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
+				fmts = append(fmts, c)
 			case 's', 'd', 'i', 'u', 'o', 'x':
 				var farg interface{}
 				arg := ""

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -492,6 +492,12 @@ func (r *Runner) expand(format string, onlyChars bool, args ...string) string {
 				}
 				buf.WriteByte(b)
 				fmts = nil
+			case '+', '-', ' ':
+				if len(fmts) > 1 {
+					r.runErr(syntax.Pos{}, "invalid format char: %c", c)
+					return ""
+				}
+				fmts = append(fmts, c)
 			case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
 				fmts = append(fmts, c)
 			case 's', 'd', 'i', 'u', 'o', 'x':

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -104,7 +104,9 @@ var fileCases = []struct {
 	{"printf %%", "%"},
 	{"printf %", "0:0: missing format char #JUSTERR"},
 	{"printf %1", "0:0: missing format char #JUSTERR"},
+	{"printf %+", "0:0: missing format char #JUSTERR"},
 	{"printf %B foo", "0:0: unhandled format char: B #JUSTERR"},
+	{"printf %12-s foo", "0:0: invalid format char: - #JUSTERR"},
 	{"printf ' %s \n' bar", " bar \n"},
 	{"printf %s foo", "foo"},
 	{"printf %s", ""},
@@ -117,6 +119,11 @@ var fileCases = []struct {
 	{"printf %c,%c,%c foo àa", "f,\xc3,\x00"}, // TODO: use a rune?
 	{"printf %3s a", "  a"},
 	{"printf %3i 1", "  1"},
+	{"printf %+i%+d 1 -3", "+1-3"},
+	{"printf %-5x 10", "a    "},
+	{"printf %02x 1", "01"},
+	{"printf 'a% 5s' a", "a    a"},
+
 
 	// words and quotes
 	{"echo  foo ", "foo\n"},

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -103,6 +103,7 @@ var fileCases = []struct {
 	{"printf foo", "foo"},
 	{"printf %%", "%"},
 	{"printf %", "0:0: missing format char #JUSTERR"},
+	{"printf %1", "0:0: missing format char #JUSTERR"},
 	{"printf %B foo", "0:0: unhandled format char: B #JUSTERR"},
 	{"printf ' %s \n' bar", " bar \n"},
 	{"printf %s foo", "foo"},
@@ -114,6 +115,8 @@ var fileCases = []struct {
 	{"printf %o -3", "1777777777777777777775"},
 	{"printf %x -3", "fffffffffffffffd"},
 	{"printf %c,%c,%c foo àa", "f,\xc3,\x00"}, // TODO: use a rune?
+	{"printf %3s a", "  a"},
+	{"printf %3i 1", "  1"},
 
 	// words and quotes
 	{"echo  foo ", "foo\n"},


### PR DESCRIPTION
The idea is to let the fmt package do the heavy lifting and just translate the
format char/arg type as required. There might be hidden gotchas I've not yet
discovered, but it seems to work as expected so far.