### PR TITLE
interp: support set -a

### DIFF
--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -1015,6 +1015,8 @@ var fileCases = []struct {
 	{"set -e; [[ -o errexit ]]", ""},
 	{"[[ -o noglob ]]", "exit status 1"},
 	{"set -f; [[ -o noglob ]]", ""},
+	{"[[ -o allexport ]]", "exit status 1"},
+	{"set -a; [[ -o allexport ]]", ""},
 
 	// classic test
 	{
@@ -1202,6 +1204,18 @@ var fileCases = []struct {
 		`set -f; set +f; touch a.x; echo *.x;`,
 		"a.x\n",
 	},
+	{
+		`set -a; foo=bar; env | grep ^foo=`,
+		"foo=bar\n",
+	},
+	{
+		`set -a; foo=(b a r); env | grep ^foo=`,
+		"exit status 1",
+	},
+	{
+		`foo=bar; set -a; env | grep ^foo=`,
+		"exit status 1",
+	},
 
 	// builtin
 	{"builtin", ""},
@@ -1339,6 +1353,8 @@ var fileCases = []struct {
 	{"foo=bar; export foo; env | grep '^foo='", "foo=bar\n"},
 	{"export foo=bar; foo=baz; env | grep '^foo='", "foo=baz\n"},
 	{"export foo=bar; readonly foo=baz; env | grep '^foo='", "foo=baz\n"},
+	{"export foo=(1 2); env | grep '^foo='", "exit status 1"},
+	{"declare -A foo=([a]=b); export foo; env | grep '^foo='", "exit status 1"},
 
 	// name references
 	{"declare -n foo=bar; bar=etc; [[ -R foo ]]", ""},

--- a/interp/test.go
+++ b/interp/test.go
@@ -162,6 +162,8 @@ func (r *Runner) unTest(op syntax.UnTestOperator, x string) bool {
 			return r.stopOnCmdErr
 		case "noglob":
 			return r.noGlob
+		case "allexport":
+			return r.allExport
 		default:
 			return false
 		}


### PR DESCRIPTION
Also never export arrays.

This is what I used for testing:

```
unset X A AA
X=0
A=(a b c)
declare -A AA=([foo]=bar)
set -a
X=1
A[0]=A
AA[foo]=rab
echo $X $A ${AA[foo]}
/bin/sh -c 'echo $X $A ${AA[foo]}'
X=(a b c)
echo $X
echo ${X[1]}
/bin/sh -c 'echo $X'
```

bash
```
1 A rab
1
a
b

```

gosh
```
1 A rab
1
a
b

```

Not sure how to translate this into a proper testcase.