### PR TITLE
interp: support printf %d 1 2 3

### DIFF
--- a/interp/builtin.go
+++ b/interp/builtin.go
@@ -95,7 +95,7 @@ func (r *Runner) builtinCode(pos syntax.Pos, name string, args []string) int {
 				r.outf(" ")
 			}
 			if expand {
-				arg = r.expand(arg, true)
+				_, arg = r.expand(arg, true)
 			}
 			r.outf("%s", arg)
 		}
@@ -107,7 +107,15 @@ func (r *Runner) builtinCode(pos syntax.Pos, name string, args []string) int {
 			r.errf("usage: printf format [arguments]\n")
 			return 2
 		}
-		r.outf("%s", r.expand(args[0], false, args[1:]...))
+		format, args := args[0], args[1:]
+		for {
+			n, s := r.expand(format, false, args...)
+			r.outf("%s", s)
+			args = args[n:]
+			if n == 0 || len(args) == 0{
+				break
+			}
+		}
 	case "break":
 		if !r.inLoop {
 			r.errf("break is only useful in a loop")

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -123,6 +123,9 @@ var fileCases = []struct {
 	{"printf %-5x 10", "a    "},
 	{"printf %02x 1", "01"},
 	{"printf 'a% 5s' a", "a    a"},
+	{"printf 'nofmt' 1 2 3", "nofmt"},
+	{"printf '%d_' 1 2 3", "1_2_3_"},
+	{"printf '%02d %02d\n' 1 2 3", "01 02\n03 00\n"},
 
 	// words and quotes
 	{"echo  foo ", "foo\n"},


### PR DESCRIPTION
This makes Runner.expand return the number of arguments actually consumed by
the format. printf then just iterates r.expand until all arguments are consumed
(given it consumes arguments at all).


```
printf "%d" 1 2 3
```

bash: `123`
gosh (before): `1`
gosh (after): `123`