### PR TITLE
interp: reject invalid identifiers in the read builtin

### DIFF
--- a/interp/builtin.go
+++ b/interp/builtin.go
@@ -409,6 +409,13 @@ func (r *Runner) builtinCode(pos syntax.Pos, name string, args []string) int {
 			args = args[1:]
 		}
 
+		for _, name := range args {
+			if !syntax.ValidName(name) {
+				r.errf("invalid identifier %q\n", name)
+				return 2
+			}
+		}
+
 		line, err := r.readLine(raw)
 		if err != nil {
 			return 1
@@ -478,6 +485,7 @@ func (r *Runner) ifsFields(s string, n int, raw bool) []string {
 	case n == 1:
 		// include heading/trailing IFSs
 		fpos[0].start, fpos[0].end = 0, len(runes)
+		fpos = fpos[:1]
 	case n != -1 && n < len(fpos):
 		// combine to max n fields
 		fpos[n-1].end = fpos[len(fpos)-1].end

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -1549,6 +1549,10 @@ var fileCases = []struct {
 		"invalid option \"-X\"\nexit status 2 #JUSTERR",
 	},
 	{
+		"read 0ab",
+		"invalid identifier \"0ab\"\nexit status 2 #JUSTERR",
+	},
+	{
 		"read <<< foo; echo $REPLY",
 		"foo\n",
 	},
@@ -1561,7 +1565,7 @@ var fileCases = []struct {
 		"y\n",
 	},
 	{
-		"read a <<< foo; echo $a",
+		"read a_0 <<< foo; echo $a_0",
 		"foo\n",
 	},
 	{


### PR DESCRIPTION
Previously read was able to create variables with invalid names. Check
that the names are valid identifiers before doing anything and error if
they are not. Also add a missing reslice in ifsFields().