### PR TITLE
interp: support getopts

### DIFF
--- a/interp/builtin.go
+++ b/interp/builtin.go
@@ -435,9 +435,48 @@ func (r *Runner) builtinCode(pos syntax.Pos, name string, args []string) int {
 
 		return 0
 
+	case "getopts":
+		if len(args) < 2 {
+			r.errf("getopts: usage: getopts optstring name [arg]\n")
+			return 2
+		}
+		optind, _ := strconv.Atoi(r.getVar("OPTIND"))
+		if optind-1 != r.optState.argidx {
+			if optind < 1 {
+				optind = 1
+			}
+			r.optState = getopts{argidx: optind - 1}
+		}
+		optstr := args[0]
+		name := args[1]
+		args = args[2:]
+		if len(args) == 0 {
+			args = r.Params
+		}
+		diagnostics := !strings.HasPrefix(optstr, ":")
+
+		opt, optarg, done := r.optState.Next(optstr, args)
+
+		r.setVarString(name, string(opt))
+		r.delVar("OPTARG")
+		switch {
+		case opt == '?' && diagnostics && !done:
+			r.errf("getopts: illegal option -- %q\n", optarg)
+		case opt == ':' && diagnostics:
+			r.errf("getopts: option requires an argument -- %q\n", optarg)
+		default:
+			if optarg != "" {
+				r.setVarString("OPTARG", optarg)
+			}
+		}
+		if optind-1 != r.optState.argidx {
+			r.setVarString("OPTIND", strconv.FormatInt(int64(r.optState.argidx+1), 10))
+		}
+
+		return oneIf(done)
+
 	default:
 		// "trap", "umask", "alias", "unalias", "fg", "bg",
-		// "getopts"
 		r.runErr(pos, "unhandled builtin: %s", name)
 	}
 	return 0
@@ -552,4 +591,46 @@ func (r *Runner) relPath(path string) string {
 		path = filepath.Join(r.Dir, path)
 	}
 	return filepath.Clean(path)
+}
+
+type getopts struct {
+	argidx  int
+	runeidx int
+}
+
+func (g *getopts) Next(optstr string, args []string) (opt rune, optarg string, done bool) {
+	if len(args) == 0 || g.argidx >= len(args) {
+		return '?', "", true
+	}
+	arg := []rune(args[g.argidx])
+	if len(arg) < 2 || arg[0] != '-' || arg[1] == '-' {
+		return '?', "", true
+	}
+
+	opts := arg[1:]
+	opt = opts[g.runeidx]
+	if g.runeidx+1 < len(opts) {
+		g.runeidx += 1
+	} else {
+		g.argidx += 1
+		g.runeidx = 0
+	}
+
+	i := strings.IndexRune(optstr, opt)
+	if i < 0 {
+		// invalid option
+		return '?', string(opt), false
+	}
+
+	if i+1 < len(optstr) && optstr[i+1] == ':' {
+		if g.argidx >= len(args) {
+			// missing argument
+			return ':', string(opt), false
+		}
+		optarg = args[g.argidx]
+		g.argidx += 1
+		g.runeidx = 0
+	}
+
+	return opt, optarg, false
 }

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -83,6 +83,8 @@ type Runner struct {
 
 	dirStack []string
 
+	optState getopts
+
 	ifsJoin string
 	ifsRune func(rune) bool
 
@@ -151,6 +153,7 @@ func (r *Runner) Reset() error {
 	r.Vars["PWD"] = Variable{Value: StringVal(r.Dir)}
 	r.Vars["IFS"] = Variable{Value: StringVal(" \t\n")}
 	r.ifsUpdated()
+	r.Vars["OPTIND"] = Variable{Value: StringVal("1")}
 
 	// convert $PATH to a unix path list
 	path := r.envMap["PATH"]

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -1616,6 +1616,64 @@ var fileCases = []struct {
 		"IFS=: read a b c <<< '1\\:2:3'; echo \"$a\"; echo $b; echo $c",
 		"1:2\n3\n\n",
 	},
+
+	// getopts
+	{
+		"getopts",
+		"getopts: usage: getopts optstring name [arg]\nexit status 2",
+	},
+	{
+		"getopts abc opt -a; echo $opt; $optarg",
+		"a\n",
+	},
+	{
+		"getopts abc opt -z",
+		"getopts: illegal option -- \"z\"\n #IGNORE",
+	},
+	{
+		"getopts a: opt -a",
+		"getopts: option requires an argument -- \"a\"\n #IGNORE",
+	},
+	{
+		"getopts :abc opt -z; echo $opt; echo $OPTARG",
+		"?\nz\n",
+	},
+	{
+		"getopts :a: opt -a; echo $opt; echo $OPTARG",
+		":\na\n",
+	},
+	{
+		"getopts abc opt foo -a; echo $opt; echo $OPTIND",
+		"?\n1\n",
+	},
+	{
+		"getopts abc opt -a foo; echo $opt; echo $OPTIND",
+		"a\n2\n",
+	},
+	{
+		"OPTIND=3; getopts abc opt -a -b -c; echo $opt;",
+		"c\n",
+	},
+	{
+		"OPTIND=100; getopts abc opt -a -b -c; echo $opt;",
+		"?\n",
+	},
+	{
+		"OPTIND=foo; getopts abc opt -a -b -c; echo $opt;",
+		"a\n",
+	},
+	{
+		"while getopts ab:c opt -c -b arg -a foo; do echo $opt $OPTARG $OPTIND; done",
+		"c 2\nb arg 4\na 5\n",
+	},
+	{
+		"while getopts abc opt -ba -c foo; do echo $opt $OPTARG $OPTIND; done",
+		"b 1\na 2\nc 3\n",
+	},
+	{
+		"a() { while getopts abc: opt; do echo $opt $OPTARG; done }; a -a -b -c arg",
+		"a\nb\nc arg\n",
+	},
 }
 
 // concBuffer wraps a bytes.Buffer in a mutex so that concurrent writes


### PR DESCRIPTION
Initial attempt at the getopts builtin. Tracking state across multiple getopts
invocations is a bit ugly (necessary for -abc shortcuts) and so is detecting
intervening assignments to OPTIND. State split into a separate getopts struct in
the hope it could be used to handle options to the builtins too.