### PR TITLE
interp: reject invalid identifiers in getopts

### DIFF
--- a/interp/builtin.go
+++ b/interp/builtin.go
@@ -429,7 +429,7 @@ func (r *Runner) builtinCode(pos syntax.Pos, name string, args []string) int {
 			case "-r":
 				raw = true
 			default:
-				r.errf("invalid option %q\n", args[0])
+				r.errf("read: invalid option %q\n", args[0])
 				return 2
 			}
 			args = args[1:]
@@ -437,7 +437,7 @@ func (r *Runner) builtinCode(pos syntax.Pos, name string, args []string) int {
 
 		for _, name := range args {
 			if !syntax.ValidName(name) {
-				r.errf("invalid identifier %q\n", name)
+				r.errf("read: invalid identifier %q\n", name)
 				return 2
 			}
 		}

--- a/interp/builtin.go
+++ b/interp/builtin.go
@@ -404,7 +404,7 @@ func (r *Runner) builtinCode(pos syntax.Pos, name string, args []string) int {
 			}
 			r.builtinCode(syntax.Pos{}, "dirs", nil)
 		default:
-			r.errf("popd: invdalid argument\n")
+			r.errf("popd: invalid argument\n")
 			return 2
 		}
 	case "return":

--- a/interp/builtin.go
+++ b/interp/builtin.go
@@ -475,6 +475,10 @@ func (r *Runner) builtinCode(pos syntax.Pos, name string, args []string) int {
 		}
 		optstr := args[0]
 		name := args[1]
+		if !syntax.ValidName(name) {
+			r.errf("getopts: invalid identifier: %q\n", name)
+			return 2
+		}
 		args = args[2:]
 		if len(args) == 0 {
 			args = r.Params

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -1652,11 +1652,11 @@ var fileCases = []struct {
 	},
 	{
 		"read -X",
-		"invalid option \"-X\"\nexit status 2 #JUSTERR",
+		"read: invalid option \"-X\"\nexit status 2 #JUSTERR",
 	},
 	{
 		"read 0ab",
-		"invalid identifier \"0ab\"\nexit status 2 #JUSTERR",
+		"read: invalid identifier \"0ab\"\nexit status 2 #JUSTERR",
 	},
 	{
 		"read <<< foo; echo $REPLY",

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -1725,6 +1725,10 @@ var fileCases = []struct {
 		"getopts: usage: getopts optstring name [arg]\nexit status 2",
 	},
 	{
+		"getopts a a:b",
+		"getopts: invalid identifier: \"a:b\"\nexit status 2 #JUSTERR",
+	},
+	{
 		"getopts abc opt -a; echo $opt; $optarg",
 		"a\n",
 	},

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -570,7 +570,7 @@ var fileCases = []struct {
 	},
 	{"popd", "popd: directory stack empty\nexit status 1 #JUSTERR"},
 	{"popd -n", "popd: directory stack empty\nexit status 1 #JUSTERR"},
-	{"popd foo", "popd: invdalid argument\nexit status 2 #JUSTERR"},
+	{"popd foo", "popd: invalid argument\nexit status 2 #JUSTERR"},
 	{"old=$(dirs); mkdir a; pushd a >/dev/null; set -- $(popd); echo $#", "1\n"},
 	{
 		"old=$(dirs); mkdir a; pushd a >/dev/null; popd >/dev/null; [[ $(dirs) == $old ]]",


### PR DESCRIPTION
Like in the read builtin, make sure we don't create variables with invalid
identifiers. Also fix/improve read/popd error messages.