### PR TITLE
interp: adapt new $PATH logic with $PATHEXT

### DIFF
--- a/interp/interp.go
+++ b/interp/interp.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -1165,15 +1166,43 @@ func (r *Runner) stat(name string) (os.FileInfo, error) {
 	return os.Stat(r.relPath(name))
 }
 
-func (r *Runner) findExecutable(file string) error {
+func (r *Runner) checkStat(file string) string {
 	d, err := r.stat(file)
 	if err != nil {
-		return err
+		return ""
 	}
-	if m := d.Mode(); !m.IsDir() && m&0111 != 0 {
-		return nil
+	m := d.Mode()
+	if m.IsDir() {
+		return ""
 	}
-	return os.ErrPermission
+	if runtime.GOOS != "windows" && m&0111 == 0 {
+		return ""
+	}
+	return file
+}
+
+func winHasExt(file string) bool {
+	i := strings.LastIndex(file, ".")
+	if i < 0 {
+		return false
+	}
+	return strings.LastIndexAny(file, `:\/`) < i
+}
+
+func (r *Runner) findExecutable(file string, exts []string) string {
+	if len(exts) == 0 {
+		// non-windows
+		return r.checkStat(file)
+	}
+	if winHasExt(file) && r.checkStat(file) != "" {
+		return file
+	}
+	for _, e := range exts {
+		if f := file + e; r.checkStat(f) != "" {
+			return f
+		}
+	}
+	return ""
 }
 
 // splitList is like filepath.SplitList, but always using the unix path
@@ -1186,14 +1215,18 @@ func splitList(path string) []string {
 }
 
 func (r *Runner) lookPath(file string) string {
-	if strings.Contains(file, "/") {
-		if err := r.findExecutable(file); err == nil {
-			return file
-		}
-		return ""
+	pathList := splitList(r.getVar("PATH"))
+	chars := `/`
+	if runtime.GOOS == "windows" {
+		chars = `:\/`
+		// so that "foo" always tries "./foo"
+		pathList = append([]string{"."}, pathList...)
 	}
-	path := r.getVar("PATH")
-	for _, dir := range splitList(path) {
+	exts := r.pathExts()
+	if strings.ContainsAny(file, chars) {
+		return r.findExecutable(file, exts)
+	}
+	for _, dir := range pathList {
 		var path string
 		switch dir {
 		case "", ".":
@@ -1202,9 +1235,30 @@ func (r *Runner) lookPath(file string) string {
 		default:
 			path = filepath.Join(dir, file)
 		}
-		if err := r.findExecutable(path); err == nil {
-			return path
+		if f := r.findExecutable(path, exts); f != "" {
+			return f
 		}
 	}
 	return ""
+}
+
+func (r *Runner) pathExts() []string {
+	if runtime.GOOS != "windows" {
+		return nil
+	}
+	pathext := r.getVar("PATHEXT")
+	if pathext == "" {
+		return []string{".com", ".exe", ".bat", ".cmd"}
+	}
+	var exts []string
+	for _, e := range strings.Split(strings.ToLower(pathext), `;`) {
+		if e == "" {
+			continue
+		}
+		if e[0] != '.' {
+			e = "." + e
+		}
+		exts = append(exts, e)
+	}
+	return exts
 }


### PR DESCRIPTION
For vanilla Windows, so that executing "foo" works with "foo.exe" both
in $PATH and in the current directory. Also other edge cases from
looking at os/exec.LookPath.