### PR TITLE
syntax: add DebugPrint

### DIFF
--- a/syntax/example_walk_test.go
+++ b/syntax/example_walk_test.go
@@ -26,3 +26,54 @@ func ExampleWalk() {
 	syntax.NewPrinter().Print(os.Stdout, f)
 	// Output: echo $FOO "and $BAR"
 }
+
+func ExampleDebugPrint() {
+	in := strings.NewReader(`echo 'foo'`)
+	f, err := syntax.NewParser().Parse(in, "")
+	if err != nil {
+		return
+	}
+	syntax.DebugPrint(os.Stdout, f)
+	// Output:
+	// *syntax.File {
+	// .  Name: ""
+	// .  StmtList: syntax.StmtList {
+	// .  .  Stmts: []*syntax.Stmt (len = 1) {
+	// .  .  .  0: *syntax.Stmt {
+	// .  .  .  .  Comments: []syntax.Comment (len = 0) {}
+	// .  .  .  .  Cmd: *syntax.CallExpr {
+	// .  .  .  .  .  Assigns: []*syntax.Assign (len = 0) {}
+	// .  .  .  .  .  Args: []*syntax.Word (len = 2) {
+	// .  .  .  .  .  .  0: *syntax.Word {
+	// .  .  .  .  .  .  .  Parts: []syntax.WordPart (len = 1) {
+	// .  .  .  .  .  .  .  .  0: *syntax.Lit {
+	// .  .  .  .  .  .  .  .  .  ValuePos: 1:1
+	// .  .  .  .  .  .  .  .  .  ValueEnd: 1:5
+	// .  .  .  .  .  .  .  .  .  Value: "echo"
+	// .  .  .  .  .  .  .  .  }
+	// .  .  .  .  .  .  .  }
+	// .  .  .  .  .  .  }
+	// .  .  .  .  .  .  1: *syntax.Word {
+	// .  .  .  .  .  .  .  Parts: []syntax.WordPart (len = 1) {
+	// .  .  .  .  .  .  .  .  0: *syntax.SglQuoted {
+	// .  .  .  .  .  .  .  .  .  Left: 1:6
+	// .  .  .  .  .  .  .  .  .  Right: 1:10
+	// .  .  .  .  .  .  .  .  .  Dollar: false
+	// .  .  .  .  .  .  .  .  .  Value: "foo"
+	// .  .  .  .  .  .  .  .  }
+	// .  .  .  .  .  .  .  }
+	// .  .  .  .  .  .  }
+	// .  .  .  .  .  }
+	// .  .  .  .  }
+	// .  .  .  .  Position: 1:1
+	// .  .  .  .  Semicolon: 0:0
+	// .  .  .  .  Negated: false
+	// .  .  .  .  Background: false
+	// .  .  .  .  Coprocess: false
+	// .  .  .  .  Redirs: []*syntax.Redirect (len = 0) {}
+	// .  .  .  }
+	// .  .  }
+	// .  .  Last: []syntax.Comment (len = 0) {}
+	// .  }
+	// }
+}

--- a/syntax/walk.go
+++ b/syntax/walk.go
@@ -3,7 +3,11 @@
 
 package syntax
 
-import "fmt"
+import (
+	"fmt"
+	"io"
+	"reflect"
+)
 
 func walkStmts(sl StmtList, f func(Node) bool) {
 	for _, s := range sl.Stmts {
@@ -218,4 +222,87 @@ func Walk(node Node, f func(Node) bool) {
 	}
 
 	f(nil)
+}
+
+// DebugPrint prints the provided syntax tree, spanning multiple lines and with
+// indentation. Can be useful to investigate the content of an AST.
+func DebugPrint(w io.Writer, node Node) error {
+	p := debugPrinter{out: w}
+	p.print(reflect.ValueOf(node))
+	return p.err
+}
+
+type debugPrinter struct {
+	out   io.Writer
+	level int
+	err   error
+}
+
+func (p *debugPrinter) printf(format string, args ...interface{}) {
+	_, err := fmt.Fprintf(p.out, format, args...)
+	if err != nil && p.err == nil {
+		p.err = err
+	}
+}
+
+func (p *debugPrinter) newline() {
+	p.printf("\n")
+	for i := 0; i < p.level; i++ {
+		p.printf(".  ")
+	}
+}
+
+func (p *debugPrinter) print(x reflect.Value) {
+	switch x.Kind() {
+	case reflect.Interface:
+		if x.IsNil() {
+			p.printf("nil")
+			return
+		}
+		p.print(x.Elem())
+	case reflect.Ptr:
+		if x.IsNil() {
+			p.printf("nil")
+			return
+		}
+		p.printf("*")
+		p.print(x.Elem())
+	case reflect.Slice:
+		p.printf("%s (len = %d) {", x.Type(), x.Len())
+		if x.Len() > 0 {
+			p.level++
+			p.newline()
+			for i := 0; i < x.Len(); i++ {
+				p.printf("%d: ", i)
+				p.print(x.Index(i))
+				if i == x.Len()-1 {
+					p.level--
+				}
+				p.newline()
+			}
+		}
+		p.printf("}")
+
+	case reflect.Struct:
+		switch v := x.Interface().(type) {
+		case Pos:
+			p.printf("%v:%v", v.Line(), v.Col())
+			return
+		}
+		t := x.Type()
+		p.printf("%s {", t)
+		p.level++
+		p.newline()
+		for i := 0; i < t.NumField(); i++ {
+			p.printf("%s: ", t.Field(i).Name)
+			p.print(x.Field(i))
+			if i == x.NumField()-1 {
+				p.level--
+			}
+			p.newline()
+		}
+		p.printf("}")
+	default:
+		p.printf("%#v", x.Interface())
+	}
 }


### PR DESCRIPTION
A simpler, smaller version of ast.Fprint but for our AST. Include an
example too, which also serves as its test.

Field filtering is left out, as it seems like an overkill feature for
what is essentially a debugging function.

The reflect code isn't very complex, as our AST doesn't contain certain
types like maps and arrays, nor do any node structs contain unexported
fields.