### PR TITLE
syntax: add an option to space redirect ops

### DIFF
--- a/cmd/shfmt/main.go
+++ b/cmd/shfmt/main.go
@@ -33,6 +33,7 @@ var (
 	indent      = flag.Uint("i", 0, "")
 	binNext     = flag.Bool("bn", false, "")
 	caseIndent  = flag.Bool("ci", false, "")
+	spaceRedirs = flag.Bool("sr", false, "")
 	keepPadding = flag.Bool("kp", false, "")
 	minify      = flag.Bool("mn", false, "")
 
@@ -75,6 +76,7 @@ Printer options:
   -i uint   indent: 0 for tabs (default), >0 for number of spaces
   -bn       binary ops like && and | may start a line
   -ci       switch cases will be indented
+  -sr       redirect operators will be followed by a space
   -kp       keep column alignment paddings
   -mn       minify program to reduce its size (implies -s)
 
@@ -119,6 +121,9 @@ Utilities:
 		}
 		if *caseIndent {
 			syntax.SwitchCaseIndent(p)
+		}
+		if *spaceRedirs {
+			syntax.SpaceRedirects(p)
 		}
 		if *keepPadding {
 			syntax.KeepPadding(p)

--- a/syntax/printer_test.go
+++ b/syntax/printer_test.go
@@ -663,6 +663,26 @@ func TestPrintSwitchCaseIndent(t *testing.T) {
 	}
 }
 
+func TestPrintSpaceRedirects(t *testing.T) {
+	var tests = [...]printCase{
+		samePrint("echo foo bar > f"),
+		samePrint("echo > f foo bar"),
+		samePrint("echo >(cmd)"),
+		samePrint("echo > >(cmd)"),
+		samePrint("<< EOF\nfoo\nEOF"),
+		samePrint("echo 2> f"),
+		samePrint("echo foo bar >&1"),
+		samePrint("echo 2<&1 foo bar"),
+	}
+	parser := NewParser(KeepComments)
+	printer := NewPrinter(SpaceRedirects)
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("%03d", i), func(t *testing.T) {
+			printTest(t, parser, printer, tc.in, tc.want)
+		})
+	}
+}
+
 func TestPrintKeepPadding(t *testing.T) {
 	var tests = [...]printCase{
 		samePrint("echo foo bar"),


### PR DESCRIPTION
That is, to format them like:

	echo foo > file

This format is somewhat popular in the wild, and it is mentioned in some
prominent documents like 'man bash' and Classic Shell Scripting.

The option is very specific and doesn't clash with any other existing
options, so it shouldn't complicate the printer in the long run.

The Google Shell Style guide doesn't explicitly say how to format
redirections, so for now don't change its recommendation on the main
README file.

Don't change the default, as that would break backwards compatibility.
It's also not clear that this new format is vastly more popular than the
current one. For example, the POSIX Shell spec doesn't use spaces, and
the shfmt tool didn't have support for them.

Fixes #243.