### PR TITLE
interp: avoid redundant array copies

### DIFF
--- a/interp/builtin.go
+++ b/interp/builtin.go
@@ -536,7 +536,7 @@ func (r *Runner) builtinCode(pos syntax.Pos, name string, args []string) int {
 				}
 				break
 			}
-			for i, opt := range shellOptsTable {
+			for i, opt := range &shellOptsTable {
 				r.printOptLine(opt.name, r.opts[i])
 			}
 			break

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -116,7 +116,7 @@ func (r *Runner) strBuilder() *bytes.Buffer {
 }
 
 func (r *Runner) optByFlag(flag string) *bool {
-	for i, opt := range shellOptsTable {
+	for i, opt := range &shellOptsTable {
 		if opt.flag == flag {
 			return &r.opts[i]
 		}
@@ -132,7 +132,7 @@ func (r *Runner) optByName(name string, bash bool) *bool {
 			}
 		}
 	}
-	for i, opt := range shellOptsTable {
+	for i, opt := range &shellOptsTable {
 		if opt.name == name {
 			return &r.opts[i]
 		}
@@ -326,13 +326,13 @@ func (r *Runner) FromArgs(args ...string) ([]string, error) {
 		if flag := arg[1:]; flag == "o" {
 			args = args[1:]
 			if len(args) == 0 && enable {
-				for i, opt := range shellOptsTable {
+				for i, opt := range &shellOptsTable {
 					r.printOptLine(opt.name, r.opts[i])
 				}
 				break
 			}
 			if len(args) == 0 && !enable {
-				for i, opt := range shellOptsTable {
+				for i, opt := range &shellOptsTable {
 					setFlag := "+o"
 					if r.opts[i] {
 						setFlag = "-o"


### PR DESCRIPTION
Every range over array that binds a value does a full copy of array being iterated.
The workaround is to either use `&x` instead `x` or do index-only range.

In this case, shellOptsTable (192 bytes) is copied before each changed range stmt.
Not it does only pointer copy. Compiler optimizes accesses, so there is no
drawbacks for this. (And there is close to no difference for sizes of < 48 byte.)

See: https://github.com/cristaloleg/go-advices