### PR TITLE
syntax: replace if-else chains with expr switch stmt

### DIFF
--- a/syntax/lexer.go
+++ b/syntax/lexer.go
@@ -163,11 +163,12 @@ func (p *Parser) nextKeepSpaces() {
 			p.advanceLitDquote(r)
 		}
 	case hdocBody, hdocBodyTabs:
-		if r == '`' || r == '$' {
+		switch {
+		case r == '`' || r == '$':
 			p.tok = p.dqToken(r)
-		} else if p.hdocStop == nil {
+		case p.hdocStop == nil:
 			p.tok = _Newl
-		} else {
+		default:
 			p.advanceLitHdoc(r)
 		}
 	default: // paramExpExp:
@@ -721,13 +722,14 @@ func (p *Parser) arithmToken(r rune) token {
 }
 
 func (p *Parser) newLit(r rune) {
-	if r < utf8.RuneSelf {
+	switch {
+	case r < utf8.RuneSelf:
 		p.litBs = p.litBuf[:1]
 		p.litBs[0] = byte(r)
-	} else if r > utf8.RuneSelf {
+	case r > utf8.RuneSelf:
 		w := utf8.RuneLen(r)
 		p.litBs = append(p.litBuf[:0], p.bs[p.bsp-w:p.bsp]...)
-	} else {
+	default:
 		// don't let r == utf8.RuneSelf go to the second case as RuneLen
 		// would return -1
 		p.litBs = p.litBuf[:0]

--- a/syntax/printer.go
+++ b/syntax/printer.go
@@ -559,14 +559,15 @@ func (p *Printer) paramExp(pe *ParamExp) {
 	}
 	p.WriteString(pe.Param.Value)
 	p.wroteIndex(pe.Index)
-	if pe.Slice != nil {
+	switch {
+	case pe.Slice != nil:
 		p.WriteByte(':')
 		p.arithmExpr(pe.Slice.Offset, true, true)
 		if pe.Slice.Length != nil {
 			p.WriteByte(':')
 			p.arithmExpr(pe.Slice.Length, true, false)
 		}
-	} else if pe.Repl != nil {
+	case pe.Repl != nil:
 		if pe.Repl.All {
 			p.WriteByte('/')
 		}
@@ -578,9 +579,9 @@ func (p *Printer) paramExp(pe *ParamExp) {
 		if pe.Repl.With != nil {
 			p.word(pe.Repl.With)
 		}
-	} else if pe.Names != 0 {
+	case pe.Names != 0:
 		p.WriteString(pe.Names.String())
-	} else if pe.Exp != nil {
+	case pe.Exp != nil:
 		p.WriteString(pe.Exp.Op.String())
 		if pe.Exp.Word != nil {
 			p.word(pe.Exp.Word)


### PR DESCRIPTION
Usually this form is considered more idiomatic.
I've left if-else chains with init statements untouched
to less obvious changes.

Found with `elseif` check from go-critic linter.