### PR TITLE
interp,syntax: replace single case switches

### DIFF
--- a/interp/module.go
+++ b/interp/module.go
@@ -132,8 +132,7 @@ func DefaultOpen(ctx Ctxt, path string, flag int, perm os.FileMode) (io.ReadWrit
 
 func OpenDevImpls(next ModuleOpen) ModuleOpen {
 	return func(ctx Ctxt, path string, flag int, perm os.FileMode) (io.ReadWriteCloser, error) {
-		switch ctx.UnixPath(path) {
-		case "/dev/null":
+		if ctx.UnixPath(path) == "/dev/null" {
 			return devNull{}, nil
 		}
 		return next(ctx, path, flag, perm)

--- a/interp/module.go
+++ b/interp/module.go
@@ -132,7 +132,8 @@ func DefaultOpen(ctx Ctxt, path string, flag int, perm os.FileMode) (io.ReadWrit
 
 func OpenDevImpls(next ModuleOpen) ModuleOpen {
 	return func(ctx Ctxt, path string, flag int, perm os.FileMode) (io.ReadWriteCloser, error) {
-		if ctx.UnixPath(path) == "/dev/null" {
+		switch ctx.UnixPath(path) {
+		case "/dev/null":
 			return devNull{}, nil
 		}
 		return next(ctx, path, flag, perm)

--- a/interp/param.go
+++ b/interp/param.go
@@ -45,8 +45,7 @@ func (r *Runner) quotedElems(pe *syntax.ParamExp) []string {
 		return nil
 	}
 	val, _ := r.lookupVar(pe.Param.Value)
-	switch x := val.Value.(type) {
-	case IndexArray:
+	if x, ok := val.Value.(IndexArray); ok {
 		return x
 	}
 	return nil

--- a/syntax/walk.go
+++ b/syntax/walk.go
@@ -284,8 +284,7 @@ func (p *debugPrinter) print(x reflect.Value) {
 		p.printf("}")
 
 	case reflect.Struct:
-		switch v := x.Interface().(type) {
-		case Pos:
+		if v, ok := x.Interface().(Pos); ok {
 			p.printf("%v:%v", v.Line(), v.Col())
 			return
 		}


### PR DESCRIPTION
Usually makes code simpler.
There are no TODO notes, so I've treated
these switches as refactoring artifacts.