### PR TITLE
interp: fix classic test string matching

### DIFF
--- a/interp/builtin.go
+++ b/interp/builtin.go
@@ -290,7 +290,7 @@ func (r *Runner) builtinCode(pos syntax.Pos, name string, args []string) int {
 		if parseErr {
 			return 2
 		}
-		return oneIf(r.bashTest(expr) == "")
+		return oneIf(r.bashTest(expr, true) == "")
 	case "exec":
 		// TODO: Consider syscall.Exec, i.e. actually replacing
 		// the process. It's in theory what a shell should do,

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -602,7 +602,7 @@ func (r *Runner) cmd(cm syntax.Command) {
 		}
 	case *syntax.TestClause:
 		r.exit = 0
-		if r.bashTest(x.X) == "" && r.exit == 0 {
+		if r.bashTest(x.X, false) == "" && r.exit == 0 {
 			// to preserve exit code 2 for regex
 			// errors, etc
 			r.exit = 1

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -1310,6 +1310,10 @@ var fileCases = []struct {
 	{"[ -o errexit ]", "exit status 1"},
 	{"set -e; [ -o errexit ]", ""},
 	{"a=x b=''; [ -v a -a -v b -a ! -v c ]", ""},
+	{"[ a = a ]", ""},
+	{"[ a != a ]", "exit status 1"},
+	{"[ abc = ab* ]", "exit status 1"},
+	{"[ abc != ab* ]", ""},
 
 	// arithm
 	{


### PR DESCRIPTION
=, != behaved the same whether inside `[` or `[[`. Distinguish the two
in Runner.bashTest as `[` should not do pattern matching when matching
strings.

Fixes #271