### PR TITLE
README: Add another Dockerized shfmt / Docker repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,7 @@ See the [_js](_js) directory for more information.
 
 ### Related projects
 
-* [dockerised-shfmt] - A docker image of `shfmt`
-* [dockerized-shfmt] - Another docker image of `shfmt` with versioning and basic shell
+* Docker images - by [jamesmstone][dockerized-jamesmstone], [PeterDaveHello][dockerized-peterdavehello]
 * [format-shell] - Atom plugin for `shfmt`
 * [micro] - Editor with a built-in plugin for `shfmt`
 * [shell-format] - VS Code plugin for `shfmt`
@@ -102,8 +101,8 @@ See the [_js](_js) directory for more information.
 [arch]: https://aur.archlinux.org/packages/shfmt/
 [bash]: https://www.gnu.org/software/bash/
 [crux]: https://github.com/6c37/crux-ports-git/tree/3.3/shfmt
-[dockerised-shfmt]: https://hub.docker.com/r/jamesmstone/shfmt/
-[dockerized-shfmt]: https://github.com/PeterDaveHello/dockerized-shfmt
+[dockerized-jamesmstone]: https://hub.docker.com/r/jamesmstone/shfmt/
+[dockerized-peterdavehello]: https://github.com/PeterDaveHello/dockerized-shfmt
 [examples]: https://godoc.org/mvdan.cc/sh/syntax#pkg-examples
 [format-shell]: https://atom.io/packages/format-shell
 [go-fuzz]: https://github.com/dvyukov/go-fuzz

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ See the [_js](_js) directory for more information.
 ### Related projects
 
 * [dockerised-shfmt] - A docker image of `shfmt`
+* [dockerized-shfmt] - Another docker image of `shfmt` with versioning and basic shell
 * [format-shell] - Atom plugin for `shfmt`
 * [micro] - Editor with a built-in plugin for `shfmt`
 * [shell-format] - VS Code plugin for `shfmt`
@@ -102,6 +103,7 @@ See the [_js](_js) directory for more information.
 [bash]: https://www.gnu.org/software/bash/
 [crux]: https://github.com/6c37/crux-ports-git/tree/3.3/shfmt
 [dockerised-shfmt]: https://hub.docker.com/r/jamesmstone/shfmt/
+[dockerized-shfmt]: https://github.com/PeterDaveHello/dockerized-shfmt
 [examples]: https://godoc.org/mvdan.cc/sh/syntax#pkg-examples
 [format-shell]: https://atom.io/packages/format-shell
 [go-fuzz]: https://github.com/dvyukov/go-fuzz


### PR DESCRIPTION
This Docker repository releases with corresponding upstream version tag, updates more frequently, and also brings basic shell utils provided `busybox` which could be helpful, especially for those Docker native CI environment like GitLab CI (So that we don't need to override the entrypoint).