### PR TITLE
Setting the initial capacity of the array rather than the length

### DIFF
--- a/interp/vars.go
+++ b/interp/vars.go
@@ -39,7 +39,7 @@ func (o overlayEnviron) Each(f func(name string, vr expand.Variable) bool) {
 }
 
 func execEnv(env expand.Environ) []string {
-	list := make([]string, 32)
+	list := make([]string, 0, 32)
 	env.Each(func(name string, vr expand.Variable) bool {
 		if vr.Exported {
 			list = append(list, name+"="+vr.String())


### PR DESCRIPTION
This was causing issues on windows where the child process would start with 32 empty items and on windows the process would not get all the environment variables.

You can see the issue running
`gosh -c "cmd /C set"`

and on mac this print a bunch of white space before the variables
`gosh -c "env"`