### PR TITLE
Force to uppercase, paths contains in PATH environment variables

### DIFF
--- a/interp/interp.go
+++ b/interp/interp.go
@@ -1196,7 +1196,7 @@ func splitList(path string) []string {
 	// join "C", "/foo" into "C:/foo"
 	var fixed []string
 	for i := 0; i < len(list); i++ {
-		s := list[i]
+		s := strings.ToUpper(list[i]) //on Windows: useful when %PATH% contains path that starts with lowercase disk name
 		switch {
 		case len(s) != 1, s[0] < 'A', s[0] > 'Z':
 			// not a disk name


### PR DESCRIPTION
on Windows:
when PATH env. variable contains paths with first letter start with lowercase (drive name), does not resolve and does not find file to execute.
