### PR TITLE
Fix Params

### DIFF
--- a/interp/builtin.go
+++ b/interp/builtin.go
@@ -66,7 +66,8 @@ func (r *Runner) builtinCode(ctx context.Context, pos syntax.Pos, name string, a
 		r.setErr(ShellExitStatus(r.exit))
 		return 0 // the command's exit status does not matter
 	case "set":
-		if err := Params(args...)(r); err != nil {
+
+		if err := r.setParams(args); err != nil {
 			r.errf("set: %v\n", err)
 			return 2
 		}
@@ -630,6 +631,14 @@ func (r *Runner) relPath(path string) string {
 		path = filepath.Join(r.Dir, path)
 	}
 	return filepath.Clean(path)
+}
+
+func (r *Runner) setParams(args []string) error {
+	if err := Params(args...)(r); err != nil {
+		return err
+	}
+	r.updateExpandOpts()
+	return nil
 }
 
 type getopts struct {

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -32,7 +32,11 @@ import (
 // environment falls back to the process's environment, and not supplying the
 // standard output writer means that the output will be discarded.
 func New(opts ...func(*Runner) error) (*Runner, error) {
-	r := &Runner{usedNew: true}
+	r := &Runner{
+		usedNew: true,
+		Vars:    make(map[string]expand.Variable),
+		cmdVars: make(map[string]string),
+	}
 	for _, opt := range opts {
 		if err := opt(r); err != nil {
 			return nil, err
@@ -56,6 +60,10 @@ func New(opts ...func(*Runner) error) (*Runner, error) {
 	if r.Stdout == nil || r.Stderr == nil {
 		StdIO(r.Stdin, r.Stdout, r.Stderr)(r)
 	}
+	// Preserve shell options.
+	shellOpts := r.opts
+	r.Reset()
+	r.opts = shellOpts
 	return r, nil
 }
 

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -260,7 +260,6 @@ func Params(args ...string) func(*Runner) error {
 			args = args[1:]
 		}
 		r.Params = args
-		r.updateExpandOpts()
 		return nil
 	}
 }


### PR DESCRIPTION
This PR fixes two serious issues with `Params` passed to `runner.New`:

1. Passing `Params` causes a panic due to an untimely call to `updateExpandOpts`. This seems to be only there because `set` called from script requires it.
2. `Reset` called on first call to `Run` resets shell options. 