### PR TITLE
cmd/gosh: remove usage of global variables

### DIFF
--- a/cmd/gosh/main_test.go
+++ b/cmd/gosh/main_test.go
@@ -174,7 +174,7 @@ func TestInteractive(t *testing.T) {
 			runner, _ := interp.New(interp.StdIO(inReader, outWriter, outWriter))
 			errc := make(chan error)
 			go func() {
-				errc <- interactive(runner)
+				errc <- runInteractive(runner, inReader, outWriter, outWriter)
 			}()
 
 			if err := readString(outReader, "$ "); err != nil {


### PR DESCRIPTION
Func interactive() depends on runner.Std* which will be unexported
in a follow-up PR. To remove that dependency we pass runner and
std* directly to functions instead of using global vars.