### PR TITLE
interp: unexport Open,Exec,Stdin,Stdout,Stderr from Runner

### DIFF
--- a/interp/builtin.go
+++ b/interp/builtin.go
@@ -583,7 +583,7 @@ func (r *Runner) readLine(raw bool) ([]byte, error) {
 
 	for {
 		var buf [1]byte
-		n, err := r.Stdin.Read(buf[:])
+		n, err := r.stdin.Read(buf[:])
 		if n > 0 {
 			b := buf[0]
 			switch {


### PR DESCRIPTION
These fields are supposed to be modified via calling options
and there is little reason to read from them.

Fixes #428