### PR TITLE
interp: move KillTimeout to DefaultOpen

### DIFF
--- a/interp/example_test.go
+++ b/interp/example_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"mvdan.cc/sh/v3/expand"
 	"mvdan.cc/sh/v3/interp"
@@ -52,7 +53,7 @@ func ExampleExecModule() {
 			return interp.ExitStatus(1)
 		}
 
-		return interp.DefaultExec(ctx, args)
+		return interp.DefaultExec(2*time.Second)(ctx, args)
 	}
 	runner, _ := interp.New(
 		interp.StdIO(nil, os.Stdout, os.Stdout),

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -2670,7 +2670,7 @@ func testExecModule(ctx context.Context, args []string) error {
 		mc, _ := FromModuleContext(ctx)
 		return fn(mc, args[1:])
 	}
-	return DefaultExec(ctx, args)
+	return DefaultExec(2*time.Second)(ctx, args)
 }
 
 func testOpenModule(ctx context.Context, path string, flag int, perm os.FileMode) (io.ReadWriteCloser, error) {
@@ -2678,7 +2678,7 @@ func testOpenModule(ctx context.Context, path string, flag int, perm os.FileMode
 		path = "NUL"
 	}
 
-	return DefaultOpen(ctx, path, flag, perm)
+	return DefaultOpen()(ctx, path, flag, perm)
 }
 
 func TestRunnerRunConfirm(t *testing.T) {

--- a/interp/module_test.go
+++ b/interp/module_test.go
@@ -177,11 +177,13 @@ func TestKillTimeout(t *testing.T) {
 				var rbuf readyBuffer
 				rbuf.seenReady.Add(1)
 				ctx, cancel := context.WithCancel(context.Background())
-				r, err := New(StdIO(nil, &rbuf, &rbuf))
+				r, err := New(
+					StdIO(nil, &rbuf, &rbuf),
+					ExecModule(DefaultExec(test.killTimeout)),
+				)
 				if err != nil {
 					t.Fatal(err)
 				}
-				r.KillTimeout = test.killTimeout
 				go func() {
 					rbuf.seenReady.Wait()
 					cancel()


### PR DESCRIPTION
KillTimeout is specific to DefaultExec,
other exec implementations, like those written in go,
don't benefit from it (you can't kill a goroutine).

Also updated DefaultOpen for consistency.
This also makes Default* functions group under their
respective type in godoc.

Fixes #420.