### PR TITLE
interp: add a simple Interactive method

### DIFF
--- a/cmd/gosh/main.go
+++ b/cmd/gosh/main.go
@@ -42,7 +42,7 @@ func runAll() error {
 	}
 	if flag.NArg() == 0 {
 		if terminal.IsTerminal(int(os.Stdin.Fd())) {
-			return runInteractive(r, os.Stdin, os.Stdout, os.Stderr)
+			return r.Interactive()
 		}
 		return run(r, os.Stdin, "")
 	}

--- a/cmd/gosh/main_test.go
+++ b/cmd/gosh/main_test.go
@@ -165,6 +165,8 @@ var interactiveTests = []struct {
 	},
 }
 
+// TODO: move to the interp package
+
 func TestInteractive(t *testing.T) {
 	t.Parallel()
 	for i, tc := range interactiveTests {


### PR DESCRIPTION
Mimicking Parser.Interactive, this method implements the basics of a
full interactive shell. That's useful for many user-facing use cases,
and also as a debugging tool.

The function has zero options because the list of options it could take
is never-ending. We could start with PS1 and PS2, but we could also add
PS3, PS4, a context.Context, Parser options, et cetera.

Instead of tripling the amount of code and adding lots to the API,
suggest that advanced users simply copy the twenty lines to add their
own options and logic.