### PR TITLE
interp: use functions for exit status checks

### DIFF
--- a/cmd/gosh/main.go
+++ b/cmd/gosh/main.go
@@ -22,7 +22,7 @@ var command = flag.String("c", "", "command to be executed")
 func main() {
 	flag.Parse()
 	err := runAll()
-	if e, ok := err.(interp.ExitStatus); ok {
+	if e, ok := interp.IsExitStatus(err); ok {
 		os.Exit(int(e))
 	}
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -10,5 +10,6 @@ require (
 	golang.org/x/crypto v0.0.0-20191002192127-34f69633bfdc
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	golang.org/x/sys v0.0.0-20191008105621-543471e840be // indirect
+	golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191008105621-543471e840be h1:QAcqgptGM8IQBC9K/RC4o+O9YmqEm0diQn9QmZw/0mU=
 golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 h1:/atklqdjdhuosWIl6AIbOeHJjicWYPqR9bpxqxYG2pA=
+golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/interp/builtin.go
+++ b/interp/builtin.go
@@ -200,10 +200,8 @@ func (r *Runner) builtinCode(ctx context.Context, pos syntax.Pos, name string, a
 		if len(args) > 0 {
 			panic("wait with args not handled yet")
 		}
-		switch err := r.bgShells.Wait().(type) {
-		case nil:
-		case ExitStatus:
-		default:
+		err := r.bgShells.Wait()
+		if _, ok := IsExitStatus(err); err != nil && !ok {
 			r.setErr(err)
 		}
 	case "builtin":

--- a/interp/example_test.go
+++ b/interp/example_test.go
@@ -50,7 +50,7 @@ func ExampleExecHandler() {
 
 		if _, err := interp.LookPath(hc.Env, args[0]); err != nil {
 			fmt.Printf("%s is not installed\n", args[0])
-			return interp.ExitStatus(1)
+			return interp.NewExitStatus(1)
 		}
 
 		return interp.DefaultExecHandler(2*time.Second)(ctx, args)

--- a/interp/handler_test.go
+++ b/interp/handler_test.go
@@ -190,7 +190,7 @@ func TestKillTimeout(t *testing.T) {
 				}()
 				err = r.Run(ctx, file)
 				if test.forcedKill {
-					if _, ok := err.(ExitStatus); ok || err == nil {
+					if _, ok := IsExitStatus(err); ok || err == nil {
 						t.Error("command was not force-killed")
 					}
 				} else {


### PR DESCRIPTION
Unexport ExitStatus.
Replace with NewExitStatus() and IsExitStatus().

Fixes #426.