### PR TITLE
Add two new printer options: -knl and -bnl

### DIFF
--- a/cmd/shfmt/main.go
+++ b/cmd/shfmt/main.go
@@ -38,11 +38,12 @@ var (
 	langStr = flag.String("ln", "", "")
 	posix   = flag.Bool("p", false, "")
 
-	indent      = flag.Uint("i", 0, "")
-	binNext     = flag.Bool("bn", false, "")
-	caseIndent  = flag.Bool("ci", false, "")
-	spaceRedirs = flag.Bool("sr", false, "")
-	keepPadding = flag.Bool("kp", false, "")
+	indent          = flag.Uint("i", 0, "")
+	binNext         = flag.Bool("bn", false, "")
+	caseIndent      = flag.Bool("ci", false, "")
+	spaceRedirs     = flag.Bool("sr", false, "")
+	keepPadding     = flag.Bool("kp", false, "")
+	functionNewLine = flag.Bool("fn", false, "")
 
 	toJSON = flag.Bool("tojson", false, "")
 
@@ -91,6 +92,7 @@ Printer options:
   -ci       switch cases will be indented
   -sr       redirect operators will be followed by a space
   -kp       keep column alignment paddings
+  -fn       function opening braces are placed on a separate line
 
 Utilities:
 
@@ -116,7 +118,7 @@ Utilities:
 	}
 	flag.Visit(func(f *flag.Flag) {
 		switch f.Name {
-		case "ln", "p", "i", "bn", "ci", "sr", "kp":
+		case "ln", "p", "i", "bn", "ci", "sr", "kp", "fn":
 			useEditorConfig = false
 		}
 	})
@@ -145,6 +147,7 @@ Utilities:
 		syntax.SwitchCaseIndent(*caseIndent)(printer)
 		syntax.SpaceRedirects(*spaceRedirs)(printer)
 		syntax.KeepPadding(*keepPadding)(printer)
+		syntax.FunctionNewLine(*functionNewLine)(printer)
 	}
 
 	if os.Getenv("FORCE_COLOR") == "true" {

--- a/syntax/printer_test.go
+++ b/syntax/printer_test.go
@@ -739,6 +739,35 @@ func TestPrintSwitchCaseIndent(t *testing.T) {
 	}
 }
 
+func TestPrintFunctionNewLine(t *testing.T) {
+	t.Parallel()
+	tests := [...]printCase{
+		{
+			"foo() { bar; }",
+			"foo()\n{\n\tbar\n}",
+		},
+		{
+			"foo()\n{ bar; }",
+			"foo()\n{\n\tbar\n}",
+		},
+		{
+			"foo()\n\n{\n\n\tbar\n}",
+			"foo()\n{\n\n\tbar\n}",
+		},
+		{
+			"function foo {\n\tbar\n}",
+			"function foo()\n{\n\tbar\n}",
+		},
+	}
+	parser := NewParser(KeepComments(true))
+	printer := NewPrinter(FunctionNewLine(true))
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("%03d", i), func(t *testing.T) {
+			printTest(t, parser, printer, tc.in, tc.want)
+		})
+	}
+}
+
 func TestPrintSpaceRedirects(t *testing.T) {
 	t.Parallel()
 	tests := [...]printCase{


### PR DESCRIPTION
Hi,

I have added two new printer options for a less compact style.

`-knl` (_keyword new line_) will put keywords like "then" and "do" on a new line.

**Example:**
```
if foo
then
    bar
fi
```
`-bnl` (_brace new line_) will put braces on new lines.

**Example:**
```
foo()
{
    bar
}
```
It would be great if you would accept the patch. Let me know if there is anything I need to change.

Regards,
Morgan