### PR TITLE
Add support for pre-commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+on: [create]
+
+name: Check release tag consistency
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v1
+      with:
+        fetch-depth: 1  # no history, just HEAD
+    - name: Check pre-commit hook version tag
+      run: |
+        is_tag="$(echo ${GITHUB_REF} | grep -c '^refs/tags/')" || true
+        if [ "$is_tag" != '0' ]; then
+          # A tag was created - let's check.
+          git_tag="$(echo ${GITHUB_REF} | sed -e 's#^refs/tags/##')"
+          file='.pre-commit-hooks.yaml'
+          precommit_tag="$(awk -F: '/^ *entry:/ {print $NF}' $file)"
+          if [ "$git_tag" != "$precommit_tag" ]; then
+            echo -n "FAIL: Wrong version tag in ${file}: "
+            echo "found $precommit_tag, expected $git_tag"
+            exit 1
+          else
+            echo "PASS: Git and precommit version tags are consistent: $git_tag"
+          fi
+        else
+          # Refs that aren't tags don't need checking.
+          echo 'PASS: Created git ref that is not a tag.'
+        fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,27 @@ on: [push, pull_request]
 name: Go
 jobs:
 
+  run-pre-commits:
+    name: Run pre-commit checks
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        fetch-depth: 1  # no history, just HEAD
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: set PY
+      run: echo "::set-env name=PY::$(python -VV | sha256sum | cut -d' ' -f1)"
+    - name: Cache pre-commit Repository Store
+      uses: actions/cache@v1
+      with:
+        path: ~/.cache/pre-commit  # default pre-commit cache location
+        key: pre-commit|${{env.PY}}|${{hashFiles('.pre-commit-config.yaml')}}
+    - name: Run pre-commit checks
+      uses: pre-commit/action@v1.0.0
+
   test:
     strategy:
       matrix:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit
+    rev: v1.20.0
+    hooks:
+    -   id: validate_manifest
+
+-   repo: local
+    hooks:
+    -   id: shfmt
+        name: shfmt
+        language: docker_image
+        entry: mvdan/shfmt:v3.0.0
+        types: [shell]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+# See https://pre-commit.com for more information
+-   id: shfmt
+    name: shfmt shell scripts
+    description: Format shell scripts with shfmt running in Docker
+    language: docker_image
+    entry: mvdan/shfmt:v3.0.0
+    types: [shell]

--- a/README.md
+++ b/README.md
@@ -126,6 +126,15 @@ To build a Docker image, checkout a specific version of the repository and run:
 
 	docker build -t my:tag -f cmd/shfmt/Dockerfile .
 
+### Pre-commit
+
+To use shfmt as a [pre-commit] hook, add this to your `.pre-commit-config.yaml`:
+
+    -   repo: https://github.com/mvdan/sh
+        rev: ''  # Use the sha / tag you want to point at
+        hooks:
+        -   id: shfmt
+
 ### Related projects
 
 * Alternative docker images - by [jamesmstone][dockerized-jamesmstone], [PeterDaveHello][dockerized-peterdavehello]
@@ -157,6 +166,7 @@ To build a Docker image, checkout a specific version of the repository and run:
 [nixos]: https://github.com/NixOS/nixpkgs/blob/HEAD/pkgs/tools/text/shfmt/default.nix
 [posix shell]: https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html
 [posix-ambiguity]: https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06_03
+[pre-commit]: https://pre-commit.com/hooks.html
 [scoop]: https://github.com/ScoopInstaller/Main/blob/HEAD/bucket/shfmt.json
 [shell-format]: https://marketplace.visualstudio.com/items?itemName=foxundermoon.shell-format
 [Sublime-Pretty-Shell]: https://github.com/aerobounce/Sublime-Pretty-Shell


### PR DESCRIPTION
[pre-commit](https://pre-commit.com/) is infrastructure to easily set up running any set of tools as git pre-commits on a repo. A tool only needs to provide a hook description (.pre-commit-hook.yaml) in its repo to become usable by the pre-commit infrastructure.

Here I'm adding this hook description, which makes shfmt easily usable by pre-commit (see added example in README.md). I'm also turning pre-commit loose on this repo and configure it to run automatically on the Github Actions CI pipeline on every push and pull request.