### PR TITLE
Minimize Docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,14 @@ To build a Docker image, checkout a specific version of the repository and run:
 
 	docker build -t my:tag -f cmd/shfmt/Dockerfile .
 
+To use the Docker image, run:
+
+	docker run --rm -v $PWD:/mnt -w /mnt my:tag <shfmt arguments>
+
+E.g.:
+
+	docker run --rm -v $PWD:/mnt -w /mnt shfmt:latest -i 2 -l .
+
 ### Related projects
 
 * Alternative docker images - by [jamesmstone][dockerized-jamesmstone], [PeterDaveHello][dockerized-peterdavehello]

--- a/cmd/shfmt/Dockerfile
+++ b/cmd/shfmt/Dockerfile
@@ -1,9 +1,14 @@
-FROM golang:1.13.5-alpine3.10
+FROM golang:1.13.5-alpine3.10 as build
 
 WORKDIR /src
 COPY . .
 RUN CGO_ENABLED=0 go build -ldflags '-w -s -extldflags "-static"' ./cmd/shfmt
 
-FROM busybox:1.31.1-musl
-COPY --from=0 /src/shfmt /bin/shfmt
-ENTRYPOINT ["/bin/shfmt"]
+FROM scratch
+COPY --from=build /src/shfmt /shfmt
+ENTRYPOINT ["/shfmt"]
+
+# Usage: 
+#  docker run --rm -v $PWD:/mnt -w /mnt mvdan/shfmt:<version> <shfmt arguments>
+# E.g.:
+#  docker run --rm -v $PWD:/mnt -w /mnt mvdan/shfmt:latest -i 2 -l .


### PR DESCRIPTION
This is a proposal for a minimized Docker image that only contains the shfmt binary. It reduces the size a little by not packaging up busybox. Up to you if you want that.
```
$ docker images
REPOSITORY     TAG         IMAGE ID            CREATED             SIZE
shfmt          latest      fbf022530b4b        33 minutes ago      3.02MB
shfmt          3.0.0       4c876e317d99        38 minutes ago      4.48MB
```
Also added more usage instructions to the README.