### PR TITLE
cmd/shfmt: Make the docker container consistent

### DIFF
--- a/cmd/shfmt/Dockerfile
+++ b/cmd/shfmt/Dockerfile
@@ -6,4 +6,7 @@ RUN CGO_ENABLED=0 go build -ldflags '-w -s -extldflags "-static"' ./cmd/shfmt
 
 FROM busybox:1.31.1-musl
 COPY --from=0 /src/shfmt /bin/shfmt
-ENTRYPOINT ["/bin/shfmt"]
+
+COPY "./cmd/shfmt/docker-entrypoint.sh" "/init"
+
+ENTRYPOINT [ "/init" ]

--- a/cmd/shfmt/docker-entrypoint.sh
+++ b/cmd/shfmt/docker-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright (C) 2019 Olliver Schinagl <oliver@schinagl.nl>
+#
+# A beginning user should be able to docker run image bash (or sh) without
+# needing to learn about --entrypoint
+# https://github.com/docker-library/official-images#consistency
+
+set -eu
+
+# run command if it is not starting with a "-" and is an executable in PATH
+if [ "${#}" -gt 0 ] && \
+   [ "${1#-}" = "${1}" ] && \
+   command -v "${1}" > "/dev/null" 2>&1; then
+	exec "${@}"
+else
+	# else default to run the command
+	exec /bin/shfmt "${@}"
+fi
+
+exit 0


### PR DESCRIPTION
Docker (the org) likes to have its containers be consistent [0] and by
adding a simple entrypoint script we become compliant. This would in the
future allow it to be possible to become an 'official' container.

In any case, it also makes the application behave as expected from a
users point of view.

e.g. running the container only arguments, invokes shfmt. Adding `shfmt`
as the first argument, also still works as expected.

More importantly, it allows for starting the container with a shell by
using `/bin/sh` as an argument.

The last point is important as it allows CI's such as gitlab to use the
container 'as is' and run shfmt inside of it.

[0] https://github.com/docker-library/official-images#consistency

Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>