### PR TITLE
interp: rename sub to Subshell, and fix some bugs

### DIFF
--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -668,6 +668,22 @@ var runTests = []runTest{
 		"(fn() { :; }) & pwd >/dev/null",
 		"",
 	},
+	{
+		"x[0]=x; (echo ${x[0]}; x[0]=y; echo ${x[0]}); echo ${x[0]}",
+		"x\ny\nx\n",
+	},
+	{
+		`x["x"]=x; (x["x"]=y); echo ${x[0]}`,
+		"x\n",
+	},
+	{
+		"shopt -s expand_aliases; alias f='echo x'\nf\n(f\nalias f='echo y'\nf\n)\nf\n",
+		"x\nx\ny\nx\n",
+	},
+	{
+		"set -- a; echo $1; (echo $1; set -- b; echo $1); echo $1",
+		"a\na\nb\na\n",
+	},
 
 	// cd/pwd
 	{"[[ fo~ == 'fo~' ]]", ""},


### PR DESCRIPTION
Copy makes a copy of the given Runner, suitable for use in parallel to the original.  The copy will have the same parameters, environment variables, etc, but they can all be modified without affecting the original.

Also fixes a tiny typo in a comment in the definition of Runner ("sub" vs "Sub").

Edit/clarification: This PR started life adding a `Copy` method on `Runner`; only later was it updated to rename `sub` to `Subshell` and fix some bugs in it that `Copy` had fixed.