### PR TITLE
Fix docker deploy failure for forked repos

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,8 @@ jobs:
     if: >
       github.event_name == 'push' &&
         (github.ref == 'refs/heads/master' ||
-         startsWith(github.ref, 'refs/tags/'))
+         startsWith(github.ref, 'refs/tags/')) &&
+      github.repository == 'mvdan/sh'
     env:
       # Export environment variables for all stages.
       DOCKER_CLI_EXPERIMENTAL: enabled # for 'docker buildx'


### PR DESCRIPTION
Similar fix to #482 but for docker deploy stage of Github Actions CI.
Syncing forks should come out green from the CI again now.
