### PR TITLE
expand: always expand braces

### DIFF
--- a/expand/expand.go
+++ b/expand/expand.go
@@ -375,9 +375,10 @@ func Fields(cfg *Config, words ...*syntax.Word) ([]string, error) {
 	fields := make([]string, 0, len(words))
 	dir := cfg.envGet("PWD")
 	for _, word := range words {
-		afterBraces := []*syntax.Word{word}
-		if syntax.SplitBraces(word) {
-			afterBraces = Braces(word)
+		word := *word // make a copy, since SplitBraces replaces the Parts slice
+		afterBraces := []*syntax.Word{&word}
+		if syntax.SplitBraces(&word) {
+			afterBraces = Braces(&word)
 		}
 		for _, word2 := range afterBraces {
 			wfields, err := cfg.wordFields(word2.Parts)

--- a/expand/expand_test.go
+++ b/expand/expand_test.go
@@ -5,6 +5,7 @@ package expand
 
 import (
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -59,5 +60,33 @@ func TestConfigNils(t *testing.T) {
 				t.Fatalf("wanted %q, got %q", tc.want, got)
 			}
 		})
+	}
+}
+
+func TestFieldsIdempotency(t *testing.T) {
+	tests := []struct {
+		src  string
+		want []string
+	}{
+		{
+			"{1..4}",
+			[]string{"1", "2", "3", "4"},
+		},
+		{
+			"a{1..4}",
+			[]string{"a1", "a2", "a3", "a4"},
+		},
+	}
+	for _, tc := range tests {
+		word := parseWord(t, tc.src)
+		for j := 0; j < 2; j++ {
+			got, err := Fields(nil, word)
+			if err != nil {
+				t.Fatalf("did not want error, got %v", err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("wanted %q, got %q", tc.want, got)
+			}
+		}
 	}
 }


### PR DESCRIPTION
Currently only the first run of a syntax tree would expand braces when it splits them,
resulting in the following panic of the new test.

```
=== RUN   TestFields
=== RUN   TestFields/00-run-1
=== RUN   TestFields/00-run-2
panic: unhandled word part: *syntax.BraceExp [recovered]
        panic: unhandled word part: *syntax.BraceExp

goroutine 9 [running]:
testing.tRunner.func1(0xc0000d4300)
        /usr/lib/go/src/testing/testing.go:874 +0x3a3
panic(0x55f7e0, 0xc000062ec0)
        /usr/lib/go/src/runtime/panic.go:679 +0x1b2
mvdan.cc/sh/v3/expand.(*Config).wordFields(0x6ca540, 0xc00000fd20, 0x2, 0x2, 0x0, 0x22, 0xc000000349, 0xc00004ee60, 0x4c43de)
        /home/duncan/repos/sh/expand/expand.go:606 +0x1392
mvdan.cc/sh/v3/expand.Fields(0x6ca540, 0xc0000c7f18, 0x1, 0x1, 0x349, 0x4c43b0, 0x6676c8, 0x6b7940, 0xc00009a400)
        /home/duncan/repos/sh/expand/expand.go:383 +0x15b
mvdan.cc/sh/v3/expand.TestFields.func2(0xc0000d4300)
        /home/duncan/repos/sh/expand/expand_test.go:89 +0x73
testing.tRunner(0xc0000d4300, 0xc0000ea0c0)
        /usr/lib/go/src/testing/testing.go:909 +0xc9
created by testing.(*T).Run
        /usr/lib/go/src/testing/testing.go:960 +0x350
FAIL    mvdan.cc/sh/v3/expand   0.004s
FAIL
```