### PR TITLE
shfmt: fix behavior of -f flag for file arguments

### DIFF
--- a/cmd/shfmt/main.go
+++ b/cmd/shfmt/main.go
@@ -202,7 +202,15 @@ func walk(path string, onError func(error)) {
 		return
 	}
 	if !info.IsDir() {
-		if err := formatPath(path, false); err != nil {
+		checkShebang := false
+		if *find {
+			conf := fileutil.CouldBeScript(info)
+			if conf == fileutil.ConfNotScript {
+				return
+			}
+			checkShebang = conf == fileutil.ConfIfShebang
+		}
+		if err := formatPath(path, checkShebang); err != nil {
 			onError(err)
 		}
 		return


### PR DESCRIPTION
Ensure that invoking shfmt -f on files yields the same result as when
invoked with the directory containing the files. In other words, the
output of `shfmt -f` should only contain files which have been detected
as shell files. This changes shfmt's behavior whereby previously, given
the following file tree:

    bin
    ├── README.md
    └── script.sh

running `shfmt -f bin` would output:

    bin/script.sh

but running `shfmt -f bin/script.sh bin/README.md` would output:

    bin/script.sh
    bin/README.md

As of this commit the output for both cases is consistent.