### PR TITLE
Add support for '-' filename to mean stdin

### DIFF
--- a/cmd/shfmt/main.go
+++ b/cmd/shfmt/main.go
@@ -67,9 +67,9 @@ func main1() int {
 	flag.Usage = func() {
 		fmt.Fprint(os.Stderr, `usage: shfmt [flags] [path ...]
 
-If no arguments are given, standard input will be used. If a given path
-is a directory, it will be recursively searched for shell files - both
-by filename extension and by shebang.
+If path is a single dash ('-') or absent, standard input will be used. If a
+given path is a directory, it will be recursively searched for shell files -
+both by filename extension and by shebang.
 
   -version  show version and exit
 
@@ -155,27 +155,31 @@ Utilities:
 	} else if f, ok := out.(*os.File); ok && terminal.IsTerminal(int(f.Fd())) {
 		color = true
 	}
+	args := flag.Args()
 	if flag.NArg() == 0 {
-		if err := formatStdin(); err != nil {
-			if err != errChangedWithDiff {
-				fmt.Fprintln(os.Stderr, err)
-			}
-			return 1
-		}
-		return 0
-	}
-	if *toJSON {
-		fmt.Fprintln(os.Stderr, "-tojson can only be used with stdin/out")
-		return 1
+		args = []string{"-"}
 	}
 	status := 0
-	for _, path := range flag.Args() {
-		walk(path, func(err error) {
-			if err != errChangedWithDiff {
-				fmt.Fprintln(os.Stderr, err)
+	for _, path := range args {
+		if path == "-" {
+			if err := formatStdin(); err != nil {
+				if err != errChangedWithDiff {
+					fmt.Fprintln(os.Stderr, err)
+				}
+				return 1
 			}
-			status = 1
-		})
+		} else {
+			if *toJSON {
+				fmt.Fprintln(os.Stderr, "-tojson can only be used with stdin/out")
+				return 1
+			}
+			walk(path, func(err error) {
+				if err != errChangedWithDiff {
+					fmt.Fprintln(os.Stderr, err)
+				}
+				status = 1
+			})
+		}
 	}
 	return status
 }

--- a/cmd/shfmt/testdata/scripts/basic.txt
+++ b/cmd/shfmt/testdata/scripts/basic.txt
@@ -5,6 +5,11 @@ shfmt
 cmp stdout input.sh.golden
 ! stderr .
 
+stdin input.sh
+shfmt -
+cmp stdout input.sh.golden
+! stderr .
+
 shfmt input.sh
 cmp stdout input.sh.golden
 ! stderr .


### PR DESCRIPTION
Proposal to treat '-' on the command line as stdin, like it has been done forever by many Unix command line tools.

This came up when I was trying to run the minimal docker image with stdin and needed to override the default docker image command line argument of '-h'. I.e. `cat my.sh | docker run -i --rm shfmt` currently doesn't work since the image executes 'shfmt -h'. One option is to override some command line argument with it's default value, e.g. `cat my.sh | docker run -i --rm shfmt -i 0`. But IMHO a cleaner option would be to support the '-' filename argument, i.e. `cat my.sh | docker -i --rm shfmt -`.