### PR TITLE
Set runner exitShell to true before calling the exec handler for exec builtin

### DIFF
--- a/interp/builtin.go
+++ b/interp/builtin.go
@@ -305,8 +305,8 @@ func (r *Runner) builtinCode(ctx context.Context, pos syntax.Pos, name string, a
 			r.keepRedirs = true
 			break
 		}
-		r.exec(ctx, args)
 		r.exitShell = true
+		r.exec(ctx, args)
 		return r.exit
 	case "command":
 		show := false


### PR DESCRIPTION
Set runner exitShell to true before calling the exec handler for exec builtin, this way exec handlers could retrieve this information via runner.Exited() and take appropriate actions.

Not sure if this is the best way to handle that but in a first time it would allow to retrieve this information without dealing with statements and parsing to know if it's an exec builtin or a sub-process.