### PR TITLE
interp: copy Runner.exit in SubShell

### DIFF
--- a/interp/interp.go
+++ b/interp/interp.go
@@ -824,6 +824,7 @@ func (r *Runner) Subshell() *Runner {
 		filename:    r.filename,
 		opts:        r.opts,
 		usedNew:     r.usedNew,
+		exit:        r.exit,
 
 		origStdout: r.origStdout, // used for process substitutions
 	}

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -704,6 +704,7 @@ var runTests = []runTest{
 		"set -- a; echo $1; (echo $1; set -- b; echo $1); echo $1",
 		"a\na\nb\na\n",
 	},
+	{"false; ( echo $? )", "1\n"},
 
 	// cd/pwd
 	{"[[ fo~ == 'fo~' ]]", ""},


### PR DESCRIPTION
Other environment variables are copied in Runner.SubShell, but $? is special (stored in Runner.exit) and was missed.

This may or may not be behavior explicit in the bash manpage; tbh I haven't checked.  But it is what bash _does_:

```sh
bash-3.2$ false ; ( echo $? )
1
```