### PR TITLE
Push alpine container to the proper repository

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -141,7 +141,7 @@ jobs:
         }
 
         buildx -t "$DOCKER_BASE:$TAG"
-        buildx -t "$DOCKER_BASE-alpine:$TAG" --target alpine
+        buildx -t "$DOCKER_BASE:$TAG-alpine" --target alpine
     - name: Test multi-architecture Docker images
       run: |
         printf '%s\n' "#!/bin/sh" "echo 'hello world'" >myscript


### PR DESCRIPTION
We want the alpine container to show up as a tag, not as its own repo.

Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>

Closes #504