### PR TITLE
Fix issue with readonly and naked export.

### DIFF
--- a/interp/interp.go
+++ b/interp/interp.go
@@ -1102,7 +1102,11 @@ func (r *Runner) cmd(ctx context.Context, cm syntax.Command) {
 						vr.ReadOnly = true
 					}
 				}
-				r.setVar(name, as.Index, vr)
+				if as.Naked {
+					r.setVarInternal(name, vr)
+				} else {
+					r.setVar(name, as.Index, vr)
+				}
 			}
 		}
 	case *syntax.TimeClause:

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -2155,12 +2155,18 @@ set +o pipefail
 	// read-only vars
 	{"declare -r foo=bar; echo $foo", "bar\n"},
 	{"readonly foo=bar; echo $foo", "bar\n"},
+	{"readonly foo=bar; export foo; echo $foo", "bar\n"},
+	{"readonly foo=bar; readonly bar=foo; export foo bar; echo $bar", "foo\n"},
 	{
 		"a=b; a=c; echo $a; readonly a; a=d",
 		"c\na: readonly variable\nexit status 1 #JUSTERR",
 	},
 	{
 		"declare -r foo=bar; foo=etc",
+		"foo: readonly variable\nexit status 1 #JUSTERR",
+	},
+	{
+		"declare -r foo=bar; export foo=",
 		"foo: readonly variable\nexit status 1 #JUSTERR",
 	},
 	{


### PR DESCRIPTION
Doing the following should not return a readonly variable error

```
readonly foo=bar
export foo
```