### PR TITLE
syntax: replace Arithmetic parser with a recursive-descent parser

### DIFF
--- a/syntax/parser_arithm.go
+++ b/syntax/parser_arithm.go
@@ -1,0 +1,484 @@
+package syntax
+
+import ()
+
+// compact specifies whether we allow spaces between expressions.
+// This is true for let
+func (p *Parser) arithmExpr(compact bool) ArithmExpr {
+	return p.arithmExprComma(compact)
+}
+
+// These function names are inspired by Bash's expr.c
+
+func (p *Parser) arithmExprComma(compact bool) ArithmExpr {
+	value := p.arithmExprAssign(compact)
+	for BinAritOperator(p.tok) == Comma {
+		if compact && p.spaced {
+			return value
+		}
+		pos := p.pos
+		tok := p.tok
+		p.nextArithOp(compact)
+		y := p.arithmExprAssign(compact)
+		if y == nil {
+			p.followErrExp(pos, tok.String())
+		}
+		value = &BinaryArithm{
+			OpPos: pos,
+			Op:    BinAritOperator(tok),
+			X:     value,
+			Y:     y,
+		}
+	}
+	return value
+}
+
+func (p *Parser) arithmExprAssign(compact bool) ArithmExpr {
+	value := p.arithmExprCond(compact)
+	switch BinAritOperator(p.tok) {
+	case AddAssgn, SubAssgn, MulAssgn, QuoAssgn, RemAssgn, AndAssgn,
+		OrAssgn, XorAssgn, ShlAssgn, ShrAssgn, Assgn:
+		if !isArithName(value) {
+			p.posErr(p.pos, "%s must follow a name", p.tok.String())
+		}
+		pos := p.pos
+		tok := p.tok
+		p.nextArithOp(compact)
+		y := p.arithmExprAssign(compact)
+		if y == nil {
+			p.followErrExp(pos, tok.String())
+		}
+		return &BinaryArithm{
+			OpPos: pos,
+			Op:    BinAritOperator(tok),
+			X:     value,
+			Y:     y,
+		}
+	}
+	return value
+}
+
+func (p *Parser) arithmExprCond(compact bool) ArithmExpr {
+	value := p.arithmExprLor(compact)
+	if BinAritOperator(p.tok) == TernQuest {
+		if compact && p.spaced {
+			return value
+		}
+		questPos := p.pos
+		p.nextArithOp(compact)
+		if BinAritOperator(p.tok) == TernColon {
+			p.followErrExp(questPos, TernQuest.String())
+		}
+		trueExpr := p.arithmExpr(compact)
+		if trueExpr == nil {
+			p.followErrExp(questPos, TernQuest.String())
+		}
+		if BinAritOperator(p.tok) != TernColon {
+			p.posErr(p.pos, "ternary operator missing : after ?")
+		}
+		colonPos := p.pos
+		p.nextArithOp(compact)
+		falseExpr := p.arithmExprCond(compact)
+		if falseExpr == nil {
+			p.followErrExp(colonPos, TernColon.String())
+		}
+		return &BinaryArithm{
+			OpPos: questPos,
+			Op:    BinAritOperator(TernQuest),
+			X:     value,
+			Y: &BinaryArithm{
+				OpPos: colonPos,
+				Op:    BinAritOperator(TernColon),
+				X:     trueExpr,
+				Y:     falseExpr,
+			},
+		}
+	}
+
+	return value
+}
+
+func (p *Parser) arithmExprLor(compact bool) ArithmExpr {
+	value := p.arithmExprLand(compact)
+	for BinAritOperator(p.tok) == OrArit {
+		if compact && p.spaced {
+			return value
+		}
+		op := p.tok
+		pos := p.pos
+		p.nextArithOp(compact)
+		y := p.arithmExprLand(compact)
+		if y == nil {
+			p.followErrExp(pos, op.String())
+		}
+		value = &BinaryArithm{
+			OpPos: pos,
+			Op:    BinAritOperator(op),
+			X:     value,
+			Y:     y,
+		}
+	}
+	return value
+}
+
+func (p *Parser) arithmExprLand(compact bool) ArithmExpr {
+	value := p.arithmExprBor(compact)
+	for BinAritOperator(p.tok) == AndArit {
+		if compact && p.spaced {
+			return value
+		}
+		op := p.tok
+		pos := p.pos
+		p.nextArithOp(compact)
+		y := p.arithmExprBor(compact)
+		if y == nil {
+			p.followErrExp(pos, op.String())
+		}
+		value = &BinaryArithm{
+			OpPos: pos,
+			Op:    BinAritOperator(op),
+			X:     value,
+			Y:     y,
+		}
+	}
+	return value
+}
+
+func (p *Parser) arithmExprBor(compact bool) ArithmExpr {
+	value := p.arithmExprBxor(compact)
+	for BinAritOperator(p.tok) == Or {
+		if compact && p.spaced {
+			return value
+		}
+		op := p.tok
+		pos := p.pos
+		p.nextArithOp(compact)
+		y := p.arithmExprBxor(compact)
+		if y == nil {
+			p.followErrExp(pos, op.String())
+		}
+		value = &BinaryArithm{
+			OpPos: pos,
+			Op:    BinAritOperator(op),
+			X:     value,
+			Y:     y,
+		}
+	}
+	return value
+}
+
+func (p *Parser) arithmExprBxor(compact bool) ArithmExpr {
+	value := p.arithmExprBand(compact)
+	for BinAritOperator(p.tok) == Xor {
+		if compact && p.spaced {
+			return value
+		}
+		op := p.tok
+		pos := p.pos
+		p.nextArithOp(compact)
+		y := p.arithmExprBand(compact)
+		if y == nil {
+			p.followErrExp(pos, op.String())
+		}
+		value = &BinaryArithm{
+			OpPos: pos,
+			Op:    BinAritOperator(op),
+			X:     value,
+			Y:     y,
+		}
+	}
+	return value
+}
+
+func (p *Parser) arithmExprBand(compact bool) ArithmExpr {
+	value := p.arithmExpr5(compact)
+	for BinAritOperator(p.tok) == And {
+		if compact && p.spaced {
+			return value
+		}
+		op := p.tok
+		pos := p.pos
+		p.nextArithOp(compact)
+		y := p.arithmExpr5(compact)
+		if y == nil {
+			p.followErrExp(pos, op.String())
+		}
+		value = &BinaryArithm{
+			OpPos: pos,
+			Op:    BinAritOperator(op),
+			X:     value,
+			Y:     y,
+		}
+	}
+	return value
+}
+
+func (p *Parser) arithmExpr5(compact bool) ArithmExpr {
+	value := p.arithmExpr4(compact)
+	for BinAritOperator(p.tok) == Eql || BinAritOperator(p.tok) == Neq {
+		if compact && p.spaced {
+			return value
+		}
+		op := p.tok
+		pos := p.pos
+		p.nextArithOp(compact)
+		y := p.arithmExpr4(compact)
+		if y == nil {
+			p.followErrExp(pos, op.String())
+		}
+		value = &BinaryArithm{
+			OpPos: pos,
+			Op:    BinAritOperator(op),
+			X:     value,
+			Y:     y,
+		}
+	}
+	return value
+}
+
+func (p *Parser) arithmExpr4(compact bool) ArithmExpr {
+	value := p.arithmExprShift(compact)
+	for BinAritOperator(p.tok) == Lss ||
+		BinAritOperator(p.tok) == Gtr ||
+		BinAritOperator(p.tok) == Leq ||
+		BinAritOperator(p.tok) == Geq {
+		if compact && p.spaced {
+			return value
+		}
+		op := p.tok
+		pos := p.pos
+		p.nextArithOp(compact)
+		y := p.arithmExprShift(compact)
+		if y == nil {
+			p.followErrExp(pos, op.String())
+		}
+		value = &BinaryArithm{
+			OpPos: pos,
+			Op:    BinAritOperator(op),
+			X:     value,
+			Y:     y,
+		}
+	}
+	return value
+}
+
+func (p *Parser) arithmExprShift(compact bool) ArithmExpr {
+	value := p.arithmExpr3(compact)
+	for BinAritOperator(p.tok) == Shl ||
+		BinAritOperator(p.tok) == Shr {
+		if compact && p.spaced {
+			return value
+		}
+		op := p.tok
+		pos := p.pos
+		p.nextArithOp(compact)
+		y := p.arithmExpr3(compact)
+		if y == nil {
+			p.followErrExp(pos, op.String())
+		}
+		value = &BinaryArithm{
+			OpPos: pos,
+			Op:    BinAritOperator(op),
+			X:     value,
+			Y:     y,
+		}
+	}
+	return value
+}
+
+func (p *Parser) arithmExpr3(compact bool) ArithmExpr {
+	value := p.arithmExpr2(compact)
+	for BinAritOperator(p.tok) == Add ||
+		BinAritOperator(p.tok) == Sub {
+		if compact && p.spaced {
+			return value
+		}
+		op := p.tok
+		pos := p.pos
+		p.nextArithOp(compact)
+		y := p.arithmExpr2(compact)
+		if y == nil {
+			p.followErrExp(pos, op.String())
+		}
+		value = &BinaryArithm{
+			OpPos: pos,
+			Op:    BinAritOperator(op),
+			X:     value,
+			Y:     y,
+		}
+	}
+	return value
+}
+
+func (p *Parser) arithmExpr2(compact bool) ArithmExpr {
+	value := p.arithmExprPower(compact)
+	for BinAritOperator(p.tok) == Mul ||
+		BinAritOperator(p.tok) == Quo ||
+		BinAritOperator(p.tok) == Rem {
+		if compact && p.spaced {
+			return value
+		}
+		op := p.tok
+		pos := p.pos
+		p.nextArithOp(compact)
+		y := p.arithmExprPower(compact)
+		if y == nil {
+			p.followErrExp(pos, op.String())
+		}
+		value = &BinaryArithm{
+			OpPos: pos,
+			Op:    BinAritOperator(op),
+			X:     value,
+			Y:     y,
+		}
+	}
+	return value
+}
+
+func (p *Parser) arithmExprPower(compact bool) ArithmExpr {
+	value := p.arithmExpr1(compact)
+	if BinAritOperator(p.tok) == Pow {
+		if compact && p.spaced {
+			return value
+		}
+		op := p.tok
+		pos := p.pos
+		p.nextArithOp(compact)
+		y := p.arithmExprPower(compact)
+		if y == nil {
+			p.followErrExp(pos, op.String())
+		}
+		return &BinaryArithm{
+			OpPos: pos,
+			Op:    BinAritOperator(op),
+			X:     value,
+			Y:     y,
+		}
+	}
+
+	return value
+}
+
+func (p *Parser) arithmExpr1(compact bool) ArithmExpr {
+	p.got(_Newl)
+
+	switch UnAritOperator(p.tok) {
+	case Not, BitNegation, Plus, Minus:
+		ue := &UnaryArithm{OpPos: p.pos, Op: UnAritOperator(p.tok)}
+		p.nextArithOp(compact)
+		if ue.X = p.arithmExpr1(compact); ue.X == nil {
+			p.followErrExp(ue.OpPos, ue.Op.String())
+		}
+		return ue
+	}
+
+	return p.arithmExpr0(compact)
+}
+
+func (p *Parser) arithmExpr0(compact bool) ArithmExpr {
+	var x ArithmExpr
+	switch p.tok {
+	case addAdd, subSub:
+		ue := &UnaryArithm{OpPos: p.pos, Op: UnAritOperator(p.tok)}
+		p.nextArithOp(compact)
+		if p.tok != _LitWord {
+			p.followErr(ue.OpPos, token(ue.Op).String(), "a literal")
+		}
+		ue.X = p.arithmExpr(compact)
+		return ue
+	case leftParen:
+		pe := &ParenArithm{Lparen: p.pos}
+		p.nextArithOp(compact)
+		pe.X = p.followArithm(leftParen, pe.Lparen)
+		pe.Rparen = p.matched(pe.Lparen, leftParen, rightParen)
+		for p.got(_Newl) {
+		}
+		x = pe
+	case _LitWord:
+		l := p.getLit()
+		if p.tok != leftBrack {
+			x = p.word(p.wps(l))
+			break
+		}
+		pe := &ParamExp{Dollar: l.ValuePos, Short: true, Param: l}
+		pe.Index = p.eitherIndex()
+		x = p.word(p.wps(pe))
+	case bckQuote:
+		if p.quote == arithmExprLet && p.openBquotes > 0 {
+			return nil
+		}
+		fallthrough
+	default:
+		if w := p.getWord(); w != nil {
+			x = w
+		} else {
+			return nil
+		}
+	}
+	if compact && p.spaced {
+		return x
+	}
+	for p.got(_Newl) {
+	}
+
+	// we want real nil, not (*Word)(nil) as that
+	// sets the type to non-nil and then x != nil
+	if p.tok == addAdd || p.tok == subSub {
+		if !isArithName(x) {
+			p.curErr("%s must follow a name", p.tok.String())
+		}
+		u := &UnaryArithm{
+			Post:  true,
+			OpPos: p.pos,
+			Op:    UnAritOperator(p.tok),
+			X:     x,
+		}
+		p.nextArith(compact)
+		return u
+	}
+
+	return x
+}
+
+// nextArith consumes a token.
+// It returns true if compact and the token was followed by spaces
+func (p *Parser) nextArith(compact bool) bool {
+	p.next()
+	if compact && p.spaced {
+		return true
+	}
+	for p.got(_Newl) {
+	}
+	return false
+}
+
+func (p *Parser) nextArithOp(compact bool) {
+	pos := p.pos
+	tok := p.tok
+	if p.nextArith(compact) {
+		p.followErrExp(pos, tok.String())
+	}
+}
+
+func isArithName(left ArithmExpr) bool {
+	w, ok := left.(*Word)
+	if !ok || len(w.Parts) != 1 {
+		return false
+	}
+	switch x := w.Parts[0].(type) {
+	case *Lit:
+		return ValidName(x.Value)
+	case *ParamExp:
+		return x.nakedIndex()
+	default:
+		return false
+	}
+}
+
+func (p *Parser) followArithm(ftok token, fpos Pos) ArithmExpr {
+	x := p.arithmExpr(false)
+	if x == nil {
+		p.followErrExp(fpos, ftok.String())
+	}
+	return x
+}

--- a/syntax/parser_arithm.go
+++ b/syntax/parser_arithm.go
@@ -153,7 +153,9 @@ func (p *Parser) arithmExprPower(compact bool) ArithmExpr {
 }
 
 func (p *Parser) arithmExpr1(compact bool) ArithmExpr {
-	p.got(_Newl)
+	if !compact {
+		p.got(_Newl)
+	}
 
 	switch UnAritOperator(p.tok) {
 	case Not, BitNegation, Plus, Minus:
@@ -209,7 +211,7 @@ func (p *Parser) arithmExpr0(compact bool) ArithmExpr {
 	if compact && p.spaced {
 		return x
 	}
-	for p.got(_Newl) {
+	for !compact && p.got(_Newl) {
 	}
 
 	// we want real nil, not (*Word)(nil) as that
@@ -238,7 +240,7 @@ func (p *Parser) nextArith(compact bool) bool {
 	if compact && p.spaced {
 		return true
 	}
-	for p.got(_Newl) {
+	for !compact && p.got(_Newl) {
 	}
 	return false
 }

--- a/syntax/parser_arithm.go
+++ b/syntax/parser_arithm.go
@@ -1,7 +1,5 @@
 package syntax
 
-import ()
-
 // compact specifies whether we allow spaces between expressions.
 // This is true for let
 func (p *Parser) arithmExpr(compact bool) ArithmExpr {
@@ -384,7 +382,7 @@ func (p *Parser) arithmExpr0(compact bool) ArithmExpr {
 		if p.tok != _LitWord {
 			p.followErr(ue.OpPos, token(ue.Op).String(), "a literal")
 		}
-		ue.X = p.arithmExpr(compact)
+		ue.X = p.arithmExpr0(compact)
 		return ue
 	case leftParen:
 		pe := &ParenArithm{Lparen: p.pos}

--- a/syntax/parser_arithm.go
+++ b/syntax/parser_arithm.go
@@ -14,6 +14,9 @@ func (p *Parser) arithmExprComma(compact bool) ArithmExpr {
 		if compact && p.spaced {
 			return value
 		}
+		if value == nil {
+			p.curErr("%s must follow an expression", p.tok.String())
+		}
 		pos := p.pos
 		tok := p.tok
 		p.nextArithOp(compact)
@@ -62,6 +65,9 @@ func (p *Parser) arithmExprCond(compact bool) ArithmExpr {
 		if compact && p.spaced {
 			return value
 		}
+		if value == nil {
+			p.curErr("%s must follow an expression", p.tok.String())
+		}
 		questPos := p.pos
 		p.nextArithOp(compact)
 		if BinAritOperator(p.tok) == TernColon {
@@ -102,6 +108,9 @@ func (p *Parser) arithmExprLor(compact bool) ArithmExpr {
 		if compact && p.spaced {
 			return value
 		}
+		if value == nil {
+			p.curErr("%s must follow an expression", p.tok.String())
+		}
 		op := p.tok
 		pos := p.pos
 		p.nextArithOp(compact)
@@ -124,6 +133,9 @@ func (p *Parser) arithmExprLand(compact bool) ArithmExpr {
 	for BinAritOperator(p.tok) == AndArit {
 		if compact && p.spaced {
 			return value
+		}
+		if value == nil {
+			p.curErr("%s must follow an expression", p.tok.String())
 		}
 		op := p.tok
 		pos := p.pos
@@ -148,6 +160,9 @@ func (p *Parser) arithmExprBor(compact bool) ArithmExpr {
 		if compact && p.spaced {
 			return value
 		}
+		if value == nil {
+			p.curErr("%s must follow an expression", p.tok.String())
+		}
 		op := p.tok
 		pos := p.pos
 		p.nextArithOp(compact)
@@ -170,6 +185,9 @@ func (p *Parser) arithmExprBxor(compact bool) ArithmExpr {
 	for BinAritOperator(p.tok) == Xor {
 		if compact && p.spaced {
 			return value
+		}
+		if value == nil {
+			p.curErr("%s must follow an expression", p.tok.String())
 		}
 		op := p.tok
 		pos := p.pos
@@ -194,6 +212,9 @@ func (p *Parser) arithmExprBand(compact bool) ArithmExpr {
 		if compact && p.spaced {
 			return value
 		}
+		if value == nil {
+			p.curErr("%s must follow an expression", p.tok.String())
+		}
 		op := p.tok
 		pos := p.pos
 		p.nextArithOp(compact)
@@ -216,6 +237,9 @@ func (p *Parser) arithmExpr5(compact bool) ArithmExpr {
 	for BinAritOperator(p.tok) == Eql || BinAritOperator(p.tok) == Neq {
 		if compact && p.spaced {
 			return value
+		}
+		if value == nil {
+			p.curErr("%s must follow an expression", p.tok.String())
 		}
 		op := p.tok
 		pos := p.pos
@@ -243,6 +267,9 @@ func (p *Parser) arithmExpr4(compact bool) ArithmExpr {
 		if compact && p.spaced {
 			return value
 		}
+		if value == nil {
+			p.curErr("%s must follow an expression", p.tok.String())
+		}
 		op := p.tok
 		pos := p.pos
 		p.nextArithOp(compact)
@@ -267,6 +294,9 @@ func (p *Parser) arithmExprShift(compact bool) ArithmExpr {
 		if compact && p.spaced {
 			return value
 		}
+		if value == nil {
+			p.curErr("%s must follow an expression", p.tok.String())
+		}
 		op := p.tok
 		pos := p.pos
 		p.nextArithOp(compact)
@@ -290,6 +320,9 @@ func (p *Parser) arithmExpr3(compact bool) ArithmExpr {
 		BinAritOperator(p.tok) == Sub {
 		if compact && p.spaced {
 			return value
+		}
+		if value == nil {
+			p.curErr("%s must follow an expression", p.tok.String())
 		}
 		op := p.tok
 		pos := p.pos
@@ -316,6 +349,9 @@ func (p *Parser) arithmExpr2(compact bool) ArithmExpr {
 		if compact && p.spaced {
 			return value
 		}
+		if value == nil {
+			p.curErr("%s must follow an expression", p.tok.String())
+		}
 		op := p.tok
 		pos := p.pos
 		p.nextArithOp(compact)
@@ -338,6 +374,9 @@ func (p *Parser) arithmExprPower(compact bool) ArithmExpr {
 	if BinAritOperator(p.tok) == Pow {
 		if compact && p.spaced {
 			return value
+		}
+		if value == nil {
+			p.curErr("%s must follow an expression", p.tok.String())
 		}
 		op := p.tok
 		pos := p.pos
@@ -378,7 +417,7 @@ func (p *Parser) arithmExpr0(compact bool) ArithmExpr {
 	switch p.tok {
 	case addAdd, subSub:
 		ue := &UnaryArithm{OpPos: p.pos, Op: UnAritOperator(p.tok)}
-		p.nextArithOp(compact)
+		p.nextArith(compact)
 		if p.tok != _LitWord {
 			p.followErr(ue.OpPos, token(ue.Op).String(), "a literal")
 		}

--- a/syntax/parser_test.go
+++ b/syntax/parser_test.go
@@ -986,11 +986,11 @@ var shellTests = []errorCase{
 	},
 	{
 		in:     "echo $((a ? b))",
-		common: `1:9: ternary operator missing : after ?`,
+		common: `1:11: ternary operator missing : after ?`,
 	},
 	{
 		in:     "echo $((a : b))",
-		common: `1:9: ternary operator missing ? before :`,
+		common: `1:11: ternary operator missing ? before :`,
 	},
 	{
 		in:     "echo $((/",
@@ -998,7 +998,7 @@ var shellTests = []errorCase{
 	},
 	{
 		in:     "echo $((:",
-		common: `1:9: : must follow an expression`,
+		common: `1:9: ternary operator missing ? before :`,
 	},
 	{
 		in:     "echo $(((a)+=b))",
@@ -1338,7 +1338,7 @@ var shellTests = []errorCase{
 	},
 	{
 		in:   "let a:b",
-		bsmk: `1:5: ternary operator missing ? before :`,
+		bsmk: `1:6: ternary operator missing ? before :`,
 	},
 	{
 		in:   "let a+b=c",
@@ -2182,7 +2182,7 @@ func TestParseArithmeticError(t *testing.T) {
 	in := "3 +"
 	p := NewParser()
 	_, err := p.Arithmetic(strings.NewReader(in))
-	want := "1:3: expected an arithmetic expression, got: EOF"
+	want := "1:3: + must be followed by an expression"
 	got := fmt.Sprintf("%v", err)
 	if got != want {
 		t.Fatalf("Expected %q as an error, but got %q", want, got)

--- a/syntax/parser_test.go
+++ b/syntax/parser_test.go
@@ -2109,6 +2109,30 @@ var arithmeticTests = []struct {
 			Y:  litWord("4"),
 		},
 	},
+	{
+		"3 + 4 + 5",
+		&BinaryArithm{
+			Op: Add,
+			X: &BinaryArithm{
+				Op: Add,
+				X:  litWord("3"),
+				Y:  litWord("4"),
+			},
+			Y: litWord("5"),
+		},
+	},
+	{
+		"1 ? 0 : 2",
+		&BinaryArithm{
+			Op: TernQuest,
+			X:  litWord("1"),
+			Y: &BinaryArithm{
+				Op: TernColon,
+				X:  litWord("0"),
+				Y:  litWord("2"),
+			},
+		},
+	},
 }
 
 func TestParseArithmetic(t *testing.T) {
@@ -2135,7 +2159,7 @@ func TestParseArithmeticError(t *testing.T) {
 	in := "3 +"
 	p := NewParser()
 	_, err := p.Arithmetic(strings.NewReader(in))
-	want := "1:3: + must be followed by an expression"
+	want := "1:3: expected an arithmetic expression, got: EOF"
 	got := fmt.Sprintf("%v", err)
 	if got != want {
 		t.Fatalf("Expected %q as an error, but got %q", want, got)

--- a/syntax/parser_test.go
+++ b/syntax/parser_test.go
@@ -2133,6 +2133,29 @@ var arithmeticTests = []struct {
 			},
 		},
 	},
+	{
+		"a = 3, ++a, a--",
+		&BinaryArithm{
+			Op: Comma,
+			X: &BinaryArithm{
+				Op: Comma,
+				X: &BinaryArithm{
+					Op: Assgn,
+					X:  litWord("a"),
+					Y:  litWord("3"),
+				},
+				Y: &UnaryArithm{
+					Op: Inc,
+					X:  litWord("a"),
+				},
+			},
+			Y: &UnaryArithm{
+				Op:   Dec,
+				Post: true,
+				X:    litWord("a"),
+			},
+		},
+	},
 }
 
 func TestParseArithmetic(t *testing.T) {


### PR DESCRIPTION
Here I'm replacing the parser with a recursive-descent parser that's
modeled after the parser used in Bash. All the methods correspond to
methods in Bash's expr.c.

This fixes operator precedence problems like #579


### TODO

- [x] Fix all the error message tests

Fixes #579