### PR TITLE
syntax: Record token at which parser stops for default case.

### DIFF
--- a/syntax/parser.go
+++ b/syntax/parser.go
@@ -2274,7 +2274,7 @@ loop:
 			}
 			fallthrough
 		default:
-			p.curErr("a command can only contain words and redirects")
+			p.curErr("a command can only contain words and redirects. This command stopped at token: '%s'", p.tok)
 		}
 	}
 	if len(ce.Assigns) == 0 && len(ce.Args) == 0 {

--- a/syntax/parser.go
+++ b/syntax/parser.go
@@ -2274,7 +2274,7 @@ loop:
 			}
 			fallthrough
 		default:
-			p.curErr("a command can only contain words and redirects. This command stopped at token: '%s'", p.tok)
+			p.curErr("a command can only contain words and redirects; encountered %s", p.tok)
 		}
 	}
 	if len(ce.Assigns) == 0 && len(ce.Args) == 0 {

--- a/syntax/parser_test.go
+++ b/syntax/parser_test.go
@@ -481,7 +481,7 @@ var shellTests = []errorCase{
 	},
 	{
 		in:     "a=b foo() { bar; }",
-		common: `1:8: a command can only contain words and redirects. This command stopped at token: '('`,
+		common: `1:8: a command can only contain words and redirects; encountered (`,
 	},
 	{
 		in:     "a=b if foo; then bar; fi",
@@ -493,7 +493,7 @@ var shellTests = []errorCase{
 	},
 	{
 		in:     ">f foo() { bar; }",
-		common: `1:7: a command can only contain words and redirects. This command stopped at token: '('`,
+		common: `1:7: a command can only contain words and redirects; encountered (`,
 	},
 	{
 		in:     ">f if foo; then bar; fi",
@@ -643,7 +643,7 @@ var shellTests = []errorCase{
 	},
 	{
 		in:     "echo foo(",
-		common: `1:9: a command can only contain words and redirects. This command stopped at token: '('`,
+		common: `1:9: a command can only contain words and redirects; encountered (`,
 	},
 	{
 		in:     "echo &&",
@@ -1176,7 +1176,7 @@ var shellTests = []errorCase{
 	},
 	{
 		in:     "case i in 3) foo; 4) bar; esac",
-		common: `1:20: a command can only contain words and redirects. This command stopped at token: ')'`,
+		common: `1:20: a command can only contain words and redirects; encountered )`,
 	},
 	{
 		in:     "case i in 3&) foo;",
@@ -1259,7 +1259,7 @@ var shellTests = []errorCase{
 	{
 		in:    "]] )",
 		bsmk:  `1:1: "]]" can only be used to close a test`,
-		posix: `1:4: a command can only contain words and redirects. This command stopped at token: ')'`,
+		posix: `1:4: a command can only contain words and redirects; encountered )`,
 	},
 	{
 		in:    "((foo",
@@ -1690,7 +1690,7 @@ var shellTests = []errorCase{
 	},
 	{
 		in:    "function foo() { bar; }",
-		posix: `1:13: a command can only contain words and redirects. This command stopped at token: '('`,
+		posix: `1:13: a command can only contain words and redirects; encountered (`,
 	},
 	{
 		in:    "echo <(",

--- a/syntax/parser_test.go
+++ b/syntax/parser_test.go
@@ -481,7 +481,7 @@ var shellTests = []errorCase{
 	},
 	{
 		in:     "a=b foo() { bar; }",
-		common: `1:8: a command can only contain words and redirects`,
+		common: `1:8: a command can only contain words and redirects. This command stopped at token: '('`,
 	},
 	{
 		in:     "a=b if foo; then bar; fi",
@@ -493,7 +493,7 @@ var shellTests = []errorCase{
 	},
 	{
 		in:     ">f foo() { bar; }",
-		common: `1:7: a command can only contain words and redirects`,
+		common: `1:7: a command can only contain words and redirects. This command stopped at token: '('`,
 	},
 	{
 		in:     ">f if foo; then bar; fi",
@@ -643,7 +643,7 @@ var shellTests = []errorCase{
 	},
 	{
 		in:     "echo foo(",
-		common: `1:9: a command can only contain words and redirects`,
+		common: `1:9: a command can only contain words and redirects. This command stopped at token: '('`,
 	},
 	{
 		in:     "echo &&",
@@ -1176,7 +1176,7 @@ var shellTests = []errorCase{
 	},
 	{
 		in:     "case i in 3) foo; 4) bar; esac",
-		common: `1:20: a command can only contain words and redirects`,
+		common: `1:20: a command can only contain words and redirects. This command stopped at token: ')'`,
 	},
 	{
 		in:     "case i in 3&) foo;",
@@ -1259,7 +1259,7 @@ var shellTests = []errorCase{
 	{
 		in:    "]] )",
 		bsmk:  `1:1: "]]" can only be used to close a test`,
-		posix: `1:4: a command can only contain words and redirects`,
+		posix: `1:4: a command can only contain words and redirects. This command stopped at token: ')'`,
 	},
 	{
 		in:    "((foo",
@@ -1690,7 +1690,7 @@ var shellTests = []errorCase{
 	},
 	{
 		in:    "function foo() { bar; }",
-		posix: `1:13: a command can only contain words and redirects`,
+		posix: `1:13: a command can only contain words and redirects. This command stopped at token: '('`,
 	},
 	{
 		in:    "echo <(",


### PR DESCRIPTION
Printing the token where the parser stops can help when debugging why a shell command fails to get parsed, so I'd like to upstream a patch to do so. 

Let me know your thoughts on this.

Thanks,
Hamza