### PR TITLE
Added an option to disable line splitting

### DIFF
--- a/cmd/shfmt/main.go
+++ b/cmd/shfmt/main.go
@@ -48,6 +48,7 @@ var (
 	spaceRedirs = flag.Bool("sr", false, "")
 	keepPadding = flag.Bool("kp", false, "")
 	funcNext    = flag.Bool("fn", false, "")
+	noSplitting = flag.Bool("ns", false, "")
 
 	toJSON = flag.Bool("tojson", false, "")
 
@@ -98,6 +99,7 @@ Printer options:
   -sr       redirect operators will be followed by a space
   -kp       keep column alignment paddings
   -fn       function opening braces are placed on a separate line
+  -ns       no (line) splitting, disables adding newlines to the input
 
 Utilities:
 
@@ -131,7 +133,7 @@ Utilities:
 	}
 	flag.Visit(func(f *flag.Flag) {
 		switch f.Name {
-		case "ln", "p", "i", "bn", "ci", "sr", "kp", "fn":
+		case "ln", "p", "i", "bn", "ci", "sr", "kp", "fn", "ns":
 			useEditorConfig = false
 		}
 	})
@@ -161,6 +163,7 @@ Utilities:
 		syntax.SpaceRedirects(*spaceRedirs)(printer)
 		syntax.KeepPadding(*keepPadding)(printer)
 		syntax.FunctionNextLine(*funcNext)(printer)
+		syntax.NoSplitting(*noSplitting)(printer)
 	}
 
 	if os.Getenv("FORCE_COLOR") == "true" {


### PR DESCRIPTION
Added option `-ns` which will disable line splitting. This option is for people who just want the formatter to fix indention and spacing, people who don't want their whole code to be restructured (by having newlines added to it and by having semicolons be removed/replaced with newlines). 