### PR TITLE
Restore unified diff on -d flag

### DIFF
--- a/cmd/shfmt/main.go
+++ b/cmd/shfmt/main.go
@@ -395,6 +395,7 @@ func diffBytes(b1, b2 []byte, path string) error {
 	b := bytes.Split(b2, []byte("\n"))
 	ab := diff.Bytes(a, b)
 	e := diff.Myers(context.Background(), ab)
+	e = e.WithContextSize(3)
 	opts := []diff.WriteOpt{diff.Names(path+".orig", path)}
 	if color {
 		opts = append(opts, diff.TerminalColor())


### PR DESCRIPTION
Between the `v2.6.4` and `v3.0.0` there is a regression in the diff output.

Before it was done with the command `diff -u` but now with the package `github.com/pkg/diff` without the [WithContextSize](https://pkg.go.dev/github.com/pkg/diff@v0.0.0-20190915220856-5883b2e1a98f?tab=doc#EditScript.WithContextSize) option output a full diff which is a regression and boring.

I just add a `WithContext(3)` to restore the former behavior.