### PR TITLE
Preserve indentation on line start with -kp and space indent

### DIFF
--- a/syntax/printer.go
+++ b/syntax/printer.go
@@ -831,9 +831,8 @@ func (p *Printer) wordJoin(ws []*Word) {
 				anyNewline = true
 			}
 			p.bslashNewl()
-		} else {
-			p.spacePad(w.Pos())
 		}
+		p.spacePad(w.Pos())
 		p.word(w)
 	}
 	if anyNewline {

--- a/syntax/printer.go
+++ b/syntax/printer.go
@@ -269,13 +269,12 @@ func (p *Printer) space() {
 }
 
 func (p *Printer) spacePad(pos Pos) {
-	if p.cols.lineStart && (!p.keepPadding || p.indentSpaces == 0) {
-		// Never add padding at the start of a line unless keepPadding
-		// is set and we are indenting with spaces, since this may
-		// result in broken indentation or mixing of spaces and tabs.
+	if p.cols.lineStart && p.indentSpaces == 0 {
+		// Never add padding at the start of a line unless we are indenting
+		// with spaces, since this may result in mixing of spaces and tabs.
 		return
 	}
-	if p.wantSpace && !p.cols.lineStart {
+	if p.wantSpace {
 		p.WriteByte(' ')
 		p.wantSpace = false
 	}

--- a/syntax/printer_test.go
+++ b/syntax/printer_test.go
@@ -862,14 +862,14 @@ func TestPrintKeepPaddingSpaces(t *testing.T) {
 	tests := [...]printCase{
 		samePrint("array=('one'\n        # 'two'\n        'three')"),
 		samePrint("    abc=123"),
+		samePrint("foo \\\n  bar \\\n    baz"),
+		samePrint("{\n  foo\n    bar\n}"),
+		samePrint("# foo\n  # bar"),
 	}
 	parser := NewParser(KeepComments(true))
 	printer := NewPrinter(KeepPadding(true), Indent(2))
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("%03d", i), func(t *testing.T) {
-			// ensure that Reset does properly reset colCounter
-			printer.WriteByte('x')
-			printer.Reset(nil)
 			printTest(t, parser, printer, tc.in, tc.want)
 		})
 	}


### PR DESCRIPTION
I went through a few scripts that caused me trouble, and with this patch they all seem to behave fine.

Reflected in tests all the gotchas that I stumbled upon, namely my initial example, a simple indented line, comments.

If you can think of more edge cases, please let me know 🙂 
If I find some examples where this logic fails, I will return with another PR 😄 

Fixes #471 