### PR TITLE
interp: $@ and $* always exist

### DIFF
--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -297,6 +297,7 @@ var runTests = []runTest{
 	{`set -- b c; echo a"$@"d`, "ab cd\n"},
 	{`count() { echo $#; }; set --; count "$@"`, "0\n"},
 	{`count() { echo $#; }; set -- ""; count "$@"`, "1\n"},
+	{`count() { echo $#; }; set -- ""; shift; count "$@"`, "0\n"},
 	{`count() { echo $#; }; a=(); count "${a[@]}"`, "0\n"},
 	{`count() { echo $#; }; a=(""); count "${a[@]}"`, "1\n"},
 	{`echo $1 $3; set -- a b c; echo $1 $3`, "\na c\n"},

--- a/interp/vars.go
+++ b/interp/vars.go
@@ -70,7 +70,13 @@ func (r *Runner) lookupVar(name string) expand.Variable {
 	case "#":
 		vr.Kind, vr.Str = expand.String, strconv.Itoa(len(r.Params))
 	case "@", "*":
-		vr.Kind, vr.List = expand.Indexed, r.Params
+		vr.Kind = expand.Indexed
+		if r.Params == nil {
+			// r.Params may be nil but positional parameters always exist
+			vr.List = []string{}
+		} else {
+			vr.List = r.Params
+		}
 	case "?":
 		vr.Kind, vr.Str = expand.String, strconv.Itoa(r.lastExit)
 	case "$":


### PR DESCRIPTION
The interpreter had a bug where the empty expansion is not removed in a
call when a shift operation caused it to become empty. This is due to
shift's behavior of setting interp.Runner.Params to nil when no more
positional parameters are left.

Unfortunately, looking up $@ and $* returns a value with with List set
to interp.Runner.Params, meaning the List field can be nil when the
variable claims to be set. This breaks expand's expectation of List type
existence meaning non-zero values are available, as seen in
`quotedElemFields`.

This changes interp's environment lookup to always return a non-nil
[]string for $@ and $*, satisfying expand's expectations.

Fixes #606.