### PR TITLE
WIP: interp: add default variable test

### DIFF
--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -3046,6 +3046,11 @@ func TestRunnerOpts(t *testing.T) {
 			"foo\nunset: unbound variable\nexit status 1",
 		},
 		{
+			opts(Params("-u", "--", "foo")),
+			"echo $@; echo ${unset:-default}",
+			"foo\ndefault\n",
+		},
+		{
 			opts(Params("foo")),
 			"set >/dev/null; echo $@",
 			"foo\n",


### PR DESCRIPTION
If a variable is accessed, but the pattern also provides a default
value, `set -u` should not throw an error.