### PR TITLE
interp: LookPathDir

### DIFF
--- a/interp/builtin.go
+++ b/interp/builtin.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -389,7 +388,7 @@ func (r *Runner) builtinCode(ctx context.Context, pos syntax.Pos, name string, a
 			last = 0
 			if r.Funcs[arg] != nil || isBuiltin(arg) {
 				r.outf("%s\n", arg)
-			} else if path, err := exec.LookPath(arg); err == nil {
+			} else if path, err := LookPath(r.Dir, expandEnv{r}, arg); err == nil {
 				r.outf("%s\n", path)
 			} else {
 				last = 1

--- a/interp/builtin.go
+++ b/interp/builtin.go
@@ -229,7 +229,7 @@ func (r *Runner) builtinCode(ctx context.Context, pos syntax.Pos, name string, a
 		args := fp.args()
 		for _, arg := range args {
 			if mode == "-p" {
-				if path, err := LookPath(expandEnv{r}, arg); err == nil {
+				if path, err := LookPath(r.Dir, expandEnv{r}, arg); err == nil {
 					r.outf("%s\n", path)
 				} else {
 					anyNotFound = true
@@ -258,7 +258,7 @@ func (r *Runner) builtinCode(ctx context.Context, pos syntax.Pos, name string, a
 				r.outf("%s is a shell builtin\n", arg)
 				continue
 			}
-			if path, err := LookPath(expandEnv{r}, arg); err == nil {
+			if path, err := LookPath(r.Dir, expandEnv{r}, arg); err == nil {
 				r.outf("%s is %s\n", arg, path)
 				continue
 			}

--- a/interp/builtin.go
+++ b/interp/builtin.go
@@ -228,7 +228,7 @@ func (r *Runner) builtinCode(ctx context.Context, pos syntax.Pos, name string, a
 		args := fp.args()
 		for _, arg := range args {
 			if mode == "-p" {
-				if path, err := LookPath(r.Dir, expandEnv{r}, arg); err == nil {
+				if path, err := LookPathDir(r.Dir, expandEnv{r}, arg); err == nil {
 					r.outf("%s\n", path)
 				} else {
 					anyNotFound = true
@@ -257,7 +257,7 @@ func (r *Runner) builtinCode(ctx context.Context, pos syntax.Pos, name string, a
 				r.outf("%s is a shell builtin\n", arg)
 				continue
 			}
-			if path, err := LookPath(r.Dir, expandEnv{r}, arg); err == nil {
+			if path, err := LookPathDir(r.Dir, expandEnv{r}, arg); err == nil {
 				r.outf("%s is %s\n", arg, path)
 				continue
 			}
@@ -388,7 +388,7 @@ func (r *Runner) builtinCode(ctx context.Context, pos syntax.Pos, name string, a
 			last = 0
 			if r.Funcs[arg] != nil || isBuiltin(arg) {
 				r.outf("%s\n", arg)
-			} else if path, err := LookPath(r.Dir, expandEnv{r}, arg); err == nil {
+			} else if path, err := LookPathDir(r.Dir, expandEnv{r}, arg); err == nil {
 				r.outf("%s\n", path)
 			} else {
 				last = 1

--- a/interp/example_test.go
+++ b/interp/example_test.go
@@ -50,7 +50,7 @@ func ExampleExecHandler() {
 			return nil
 		}
 
-		if _, err := interp.LookPath(hc.Dir, hc.Env, args[0]); err != nil {
+		if _, err := interp.LookPathDir(hc.Dir, hc.Env, args[0]); err != nil {
 			fmt.Printf("%s is not installed\n", args[0])
 			return interp.NewExitStatus(1)
 		}

--- a/interp/example_test.go
+++ b/interp/example_test.go
@@ -50,7 +50,7 @@ func ExampleExecHandler() {
 			return nil
 		}
 
-		if _, err := interp.LookPath(hc.Env, args[0]); err != nil {
+		if _, err := interp.LookPath(hc.Dir, hc.Env, args[0]); err != nil {
 			fmt.Printf("%s is not installed\n", args[0])
 			return interp.NewExitStatus(1)
 		}

--- a/interp/handler.go
+++ b/interp/handler.go
@@ -68,7 +68,7 @@ type ExecHandlerFunc func(ctx context.Context, args []string) error
 func DefaultExecHandler(killTimeout time.Duration) ExecHandlerFunc {
 	return func(ctx context.Context, args []string) error {
 		hc := HandlerCtx(ctx)
-		path, err := LookPath(hc.Dir, hc.Env, args[0])
+		path, err := LookPathDir(hc.Dir, hc.Env, args[0])
 		if err != nil {
 			fmt.Fprintln(hc.Stderr, err)
 			return NewExitStatus(127)
@@ -212,12 +212,17 @@ func splitList(path string) []string {
 	return fixed
 }
 
-// LookPath is similar to os/exec.LookPath, with the difference that it uses the
+// LookPath is deprecated. See LookPathDir.
+func LookPath(env expand.Environ, file string) (string, error) {
+	return LookPathDir(env.Get("PWD").String(), env, file)
+}
+
+// LookPathDir is similar to os/exec.LookPath, with the difference that it uses the
 // provided environment. env is used to fetch relevant environment variables
 // such as PWD and PATH.
 //
 // If no error is returned, the returned path must be valid.
-func LookPath(cwd string, env expand.Environ, file string) (string, error) {
+func LookPathDir(cwd string, env expand.Environ, file string) (string, error) {
 	pathList := splitList(env.Get("PATH").String())
 	chars := `/`
 	if runtime.GOOS == "windows" {

--- a/interp/handler.go
+++ b/interp/handler.go
@@ -222,8 +222,6 @@ func LookPath(cwd string, env expand.Environ, file string) (string, error) {
 	chars := `/`
 	if runtime.GOOS == "windows" {
 		chars = `:\/`
-		// so that "foo" always tries "./foo"
-		pathList = append([]string{"."}, pathList...)
 	}
 	exts := pathExts(env)
 	if strings.ContainsAny(file, chars) {


### PR DESCRIPTION
The main motivation is to make the cwd more explicit. Previously it was implied by assuming that a "PWD" environment variable exists.