### PR TITLE
Added webi to install methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ For more information, see [its manpage](cmd/shfmt/shfmt.1.scd), which can be
 viewed directly as Markdown or rendered with [scdoc].
 
 Packages are available on [Alpine], [Arch], [Docker], [FreeBSD], [Homebrew],
-[MacPorts], [NixOS], [Scoop], [Snapcraft], and [Void].
+[MacPorts], [NixOS], [Scoop], [Snapcraft], [Void] and [webi].
 
 ### gosh
 
@@ -155,4 +155,5 @@ Other noteworthy integrations include:
 [sublime-pretty-shell]: https://github.com/aerobounce/Sublime-Pretty-Shell
 [vim-shfmt]: https://github.com/z0mbix/vim-shfmt
 [void]: https://github.com/void-linux/void-packages/blob/HEAD/srcpkgs/shfmt/template
+[webi]: https://webinstall.dev/shfmt/
 [pre-commit]: https://pre-commit.com


### PR DESCRIPTION
Webi can be used to effortlessly install developer tools with easy-to-remember URLs and shfmt has been added to the list of tools that can be installed using webi.

For more info, visit website https://webinstall.dev/shfmt/
or github repo  https://github.com/webinstall/webi-installers/tree/master/shfmt