### PR TITLE
interp: expand array arguments

### DIFF
--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -388,6 +388,14 @@ var runTests = []runTest{
 	{"a=bar; echo ${#a} ${#a[@]}", "3 1\n"},
 	{"a=世界; echo ${#a}", "2\n"},
 	{"a=(a bcd); echo ${#a} ${#a[@]} ${#a[*]} ${#a[1]}", "1 2 2 3\n"},
+	{
+		"a=($(echo a bcd)); echo ${#a} ${#a[@]} ${#a[*]} ${#a[1]}",
+		"1 2 2 3\n",
+	},
+	{
+		"a=([0]=$(echo a b) $(echo c d)); echo ${#a} ${#a[@]} ${#a[*]} ${#a[0]}",
+		"3 3 3 3\n",
+	},
 	{"set -- a bc; echo ${#@} ${#*} $#", "2 2 2\n"},
 	{
 		"echo ${!a}; echo more",


### PR DESCRIPTION
Bash array values are generally expanded. For example:

```
$ x=($(echo a b)); echo ${x[0]}
a
```

The exception is when an index is provided. Those values are taken
literally.

```
$ x=([0]=$(echo a b)); echo ${x[0]}
a b
```

The runner expands values in `assignVal` and did so by mapping the
expression index to the array index. A fixed mapping fails when a value
generates more than one field. Hence the code interpreted all array
values as literal.

This change iterates over the elements, expanding literally or with
fields, while keeping track of the implicit index. The result is then
flattened down at the computed indexes.

Fixes #671