### PR TITLE
interp: local vars are mutable

### DIFF
--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -564,6 +564,10 @@ var runTests = []runTest{
 		`a=""; a+=(b); echo ${a[@]} ${#a[@]}`,
 		"b 2\n",
 	},
+	{
+		"f() { local a; a=bad; a=good; echo $a; }; f",
+		"good\n",
+	},
 
 	// if
 	{

--- a/interp/vars.go
+++ b/interp/vars.go
@@ -66,6 +66,7 @@ func (o *overlayEnviron) Set(name string, vr expand.Variable) error {
 		}
 	}
 	// modifying the entire variable
+	vr.Local = prev.Local || vr.Local
 	o.values[name] = vr
 	return nil
 }


### PR DESCRIPTION
Local variables should be mutable but f4c774a accidentally made them
immutable. A new assignment is made with a new `expand.Variable` struct,
which defaults the Local flag to false. Failing to preserve the
localness of an overlayed variable means future sets are incorrectly
forwarded to the global scope.

Fixes #674