### PR TITLE
expand: expand.ListEnviron prefers last value

### DIFF
--- a/expand/environ.go
+++ b/expand/environ.go
@@ -140,7 +140,8 @@ func (f funcEnviron) Get(name string) Variable {
 func (f funcEnviron) Each(func(name string, vr Variable) bool) {}
 
 // ListEnviron returns an Environ with the supplied variables, in the form
-// "key=value". All variables will be exported.
+// "key=value". All variables will be exported. The last value in pairs is used
+// if multiple values are present.
 //
 // On Windows, where environment variable names are case-insensitive, the
 // resulting variable names will all be uppercase.
@@ -161,7 +162,19 @@ func listEnvironWithUpper(upper bool, pairs ...string) Environ {
 			}
 		}
 	}
-	sort.Strings(list)
+
+	sort.SliceStable(list, func(i, j int) bool {
+		isep := strings.IndexByte(list[i], '=')
+		jsep := strings.IndexByte(list[j], '=')
+		if isep < 0 {
+			isep = 0
+		}
+		if jsep < 0 {
+			jsep = 0
+		}
+		return list[i][:isep] < list[j][:jsep]
+	})
+
 	last := ""
 	for i := 0; i < len(list); {
 		s := list[i]

--- a/expand/environ_test.go
+++ b/expand/environ_test.go
@@ -32,8 +32,8 @@ func TestListEnviron(t *testing.T) {
 		},
 		{
 			name:  "DuplicateNames",
-			pairs: []string{"A=b", "A=x", "c=", "c=y"},
-			want:  []string{"A=x", "c=y"},
+			pairs: []string{"A=x", "A=b", "c=", "c=y"},
+			want:  []string{"A=b", "c=y"},
 		},
 		{
 			name:  "NoName",


### PR DESCRIPTION
`expand.ListEnviron` does not specify which value is selected when there
are duplicate name=value pairs. The test implied there was last-entry
ordering, but in reality it's lexicographical ordering. This tweaks the
test to better show the as-implemented behavior, even if it's not
guaranteed behavior.