### PR TITLE
Add Bash 5.1 parameter transformations

### DIFF
--- a/syntax/filetests_test.go
+++ b/syntax/filetests_test.go
@@ -2421,7 +2421,7 @@ var fileTests = []testCase{
 	},
 	{
 		Strs: []string{`${a@E} ${b@a} ${@@Q} ${!ref@P}`},
-		bsmk: call(
+		bash: call(
 			word(&ParamExp{
 				Param: lit("a"),
 				Exp: &Expansion{
@@ -2449,6 +2449,25 @@ var fileTests = []testCase{
 				Exp: &Expansion{
 					Op:   OtherParamOps,
 					Word: litWord("P"),
+				},
+			}),
+		),
+	},
+	{
+		Strs: []string{`${a@Q} ${b@#}`},
+		mksh: call(
+			word(&ParamExp{
+				Param: lit("a"),
+				Exp: &Expansion{
+					Op:   OtherParamOps,
+					Word: litWord("Q"),
+				},
+			}),
+			word(&ParamExp{
+				Param: lit("b"),
+				Exp: &Expansion{
+					Op:   OtherParamOps,
+					Word: litWord("#"),
 				},
 			}),
 		),

--- a/syntax/parser.go
+++ b/syntax/parser.go
@@ -1379,7 +1379,7 @@ func (p *Parser) paramExpExp() *Expansion {
 			p.curErr("@ expansion operator requires a literal")
 		}
 		switch p.val {
-		case "Q", "E", "P", "A", "a":
+		case "Q", "E", "P", "A", "a", "U", "u", "L", "K":
 		default:
 			p.curErr("invalid @ expansion operator")
 		}

--- a/syntax/parser.go
+++ b/syntax/parser.go
@@ -1379,7 +1379,15 @@ func (p *Parser) paramExpExp() *Expansion {
 			p.curErr("@ expansion operator requires a literal")
 		}
 		switch p.val {
-		case "Q", "E", "P", "A", "a", "U", "u", "L", "K":
+		case "a", "u", "A", "E", "K", "L", "P", "U":
+			if !p.lang.isBash() {
+				p.langErr(p.pos, "this expansion operator", LangBash)
+			}
+		case "#":
+			if p.lang != LangMirBSDKorn {
+				p.langErr(p.pos, "this expansion operator", LangMirBSDKorn)
+			}
+		case "Q":
 		default:
 			p.curErr("invalid @ expansion operator")
 		}

--- a/syntax/parser_test.go
+++ b/syntax/parser_test.go
@@ -1897,6 +1897,42 @@ var shellTests = []errorCase{
 		posix: `1:11: this expansion operator is a bash/mksh feature`,
 	},
 	{
+		in:   "echo ${foo@a}",
+		mksh: `1:12: this expansion operator is a bash feature`,
+	},
+	{
+		in:   "echo ${foo@u}",
+		mksh: `1:12: this expansion operator is a bash feature`,
+	},
+	{
+		in:   "echo ${foo@A}",
+		mksh: `1:12: this expansion operator is a bash feature`,
+	},
+	{
+		in:   "echo ${foo@E}",
+		mksh: `1:12: this expansion operator is a bash feature`,
+	},
+	{
+		in:   "echo ${foo@K}",
+		mksh: `1:12: this expansion operator is a bash feature`,
+	},
+	{
+		in:   "echo ${foo@L}",
+		mksh: `1:12: this expansion operator is a bash feature`,
+	},
+	{
+		in:   "echo ${foo@P}",
+		mksh: `1:12: this expansion operator is a bash feature`,
+	},
+	{
+		in:   "echo ${foo@U}",
+		mksh: `1:12: this expansion operator is a bash feature`,
+	},
+	{
+		in:   "echo ${foo@#}",
+		bash: `1:12: this expansion operator is a mksh feature`,
+	},
+	{
 		in:     "`\"`\\",
 		common: "1:3: reached EOF without closing quote `",
 	},

--- a/syntax/parser_test.go
+++ b/syntax/parser_test.go
@@ -1930,7 +1930,7 @@ var shellTests = []errorCase{
 	},
 	{
 		in:   "echo ${foo@#}",
-		bash: `1:12: this expansion operator is a mksh feature`,
+		bash: `1:12: this expansion operator is a mksh feature #NOERR`,
 	},
 	{
 		in:     "`\"`\\",


### PR DESCRIPTION
Per the NEWS:

dd. New `U', `u', and `L' parameter transformations to convert to uppercase,
    convert first character to uppercase, and convert to lowercase,
    respectively.

hh. New `K' parameter transformation to display associative arrays as key-
    value pairs.