### PR TITLE
Add -bn to flags for Google's shell style

### DIFF
--- a/cmd/shfmt/shfmt.1.scd
+++ b/cmd/shfmt/shfmt.1.scd
@@ -99,7 +99,7 @@ For CI, one can use a variant where formatting changes are just shown as diffs:
 The following formatting flags closely resemble Google's shell style defined in
 <https://google.github.io/styleguide/shell.xml>:
 
-	shfmt -i 2 -ci
+	shfmt -i 2 -ci -bn
 
 Below is a sample EditorConfig file as defined by <https://editorconfig.org/>,
 showing how to set any option:


### PR DESCRIPTION
You need `-bn` to get Google style with shfmt. This commit changes the
man page to reflect that.

Google's shell style guide says long pipelines:

    should be split at one pipe segment per line with the pipe on the
    newline and a 2 space indent for the next section of the pipe. This
    applies to a chain of commands combined using | as well as to
    logical compounds using || and &&.

        # All fits on one line
        command1 | command2

        # Long commands
        command1 \
          | command2 \
          | command3 \
          | command4

See https://google.github.io/styleguide/shellguide.html#s5.3-pipelines