### PR TITLE
interp/api: set GID

### DIFF
--- a/interp/api.go
+++ b/interp/api.go
@@ -444,6 +444,13 @@ func (r *Runner) Reset() {
 			Str:      strconv.Itoa(os.Getuid()),
 		})
 	}
+	if !r.writeEnv.Get("GID").IsSet() {
+		r.setVar("GID", nil, expand.Variable{
+			Kind:     expand.String,
+			ReadOnly: true,
+			Str:      strconv.Itoa(os.Getgid()),
+		})
+	}
 	r.setVarString("PWD", r.Dir)
 	r.setVarString("IFS", " \t\n")
 	r.setVarString("OPTIND", "1")

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -2756,6 +2756,19 @@ var runTestsUnix = []runTest{
 		`mkdir a; chmod 0001 a; cd a && test $UID -ne 0`,
 		"exit status 1 #JUSTERR",
 	},
+	{
+		`unset UID`,
+		"UID: readonly variable\n #IGNORE",
+	},
+	// GID is not set in bash
+	{
+		`unset GID`,
+		"GID: readonly variable\n #IGNORE",
+	},
+	{
+		`[[ -z $GID ]] && echo "GID not set"`,
+		"exit status 1 #JUSTERR #IGNORE",
+	},
 
 	// Unix-y PATH
 	{


### PR DESCRIPTION
Set GID environment variable analog to UID.

Rel: https://github.com/go-task/task/issues/561

Signed-off-by: Marcello Sylvester Bauer <sylv@sylv.io>