### PR TITLE
interp: source script from PATH

### DIFF
--- a/interp/builtin.go
+++ b/interp/builtin.go
@@ -334,14 +334,22 @@ func (r *Runner) builtinCode(ctx context.Context, pos syntax.Pos, name string, a
 			r.errf("%v: source: need filename\n", pos)
 			return 2
 		}
-		f, err := r.open(ctx, args[0], os.O_RDONLY, 0, false)
+		path, err := scriptFromPathDir(r.Dir, r.writeEnv, args[0])
+		if err != nil {
+			// If the script was not found in PATH or there was any error, pass
+			// the source path to the open handler so it has a chance to look
+			// at files it manages (eg: virtual filesystem), and also allow
+			// it to look for the sourced script in the current directory.
+			path = args[0]
+		}
+		f, err := r.open(ctx, path, os.O_RDONLY, 0, false)
 		if err != nil {
 			r.errf("source: %v\n", err)
 			return 1
 		}
 		defer f.Close()
 		p := syntax.NewParser()
-		file, err := p.Parse(f, args[0])
+		file, err := p.Parse(f, path)
 		if err != nil {
 			r.errf("source: %v\n", err)
 			return 1

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -2086,6 +2086,12 @@ set +o pipefail
 		"bar\n",
 	},
 
+	// source from PATH
+	{
+		"mkdir test; echo 'echo foo' >test/a; PATH=$PWD/test source a; . test/a",
+		"foo\nfoo\n",
+	},
+
 	// source with set and shift
 	{
 		"echo 'set -- d e f' >a; source a; echo $@",


### PR DESCRIPTION
The shell behavior regarding script sourcing is to look first
into PATH when the filename doesn't contain any path separator then
look for the script in the current working directory.
If the filename contain a path separator, then the script is sourced
from the current working directory.