### PR TITLE
interp: initial support for `set -o xtrace`

### DIFF
--- a/interp/api.go
+++ b/interp/api.go
@@ -350,6 +350,7 @@ var shellOptsTable = [...]struct {
 	{'n', "noexec"},
 	{'f', "noglob"},
 	{'u', "nounset"},
+	{'x', "xtrace"},
 	{' ', "pipefail"},
 }
 
@@ -369,6 +370,7 @@ const (
 	optNoExec
 	optNoGlob
 	optNoUnset
+	optXTrace
 	optPipeFail
 
 	optExpandAliases

--- a/interp/trace.go
+++ b/interp/trace.go
@@ -1,0 +1,147 @@
+package interp
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+
+	"mvdan.cc/sh/v3/expand"
+	"mvdan.cc/sh/v3/syntax"
+)
+
+// tracer prints expressions like a shell would do if its
+// options '-o' is set to either 'xtrace' or its shorthand, '-x'.
+type tracer struct {
+	buf          bytes.Buffer
+	printer      *syntax.Printer
+	stdout       io.Writer
+	isFirstPrint bool
+}
+
+func (r *Runner) tracer() *tracer {
+	if !r.opts[optXTrace] {
+		return nil
+	}
+
+	return &tracer{
+		printer:      syntax.NewPrinter(),
+		stdout:       r.stdout,
+		isFirstPrint: true,
+	}
+}
+
+func (t *tracer) setFirstPrint(isFirstPrint bool) {
+	if t == nil {
+		return
+	}
+
+	t.isFirstPrint = isFirstPrint
+}
+
+// string writes s to tracer.buf if tracer is non-nil,
+// prepending "+" if tracer.isFirstPrint is true.
+func (t *tracer) string(s string) {
+	if t == nil {
+		return
+	}
+
+	if t.isFirstPrint {
+		t.buf.WriteString("+ ")
+	}
+	t.buf.WriteString(s)
+}
+
+func (t *tracer) stringf(f string, a ...interface{}) {
+	if t == nil {
+		return
+	}
+
+	t.string(fmt.Sprintf(f, a...))
+}
+
+// expr prints x to tracer.buf if tracer is non-nil,
+// prepending "+" if tracer.isFirstPrint is true.
+func (t *tracer) expr(x syntax.Node) {
+	if t == nil {
+		return
+	}
+
+	if t.isFirstPrint {
+		t.buf.WriteString("+ ")
+	}
+	if err := t.printer.Print(&t.buf, x); err != nil {
+		panic(err)
+	}
+}
+
+// flush writes the contents of tracer.buf to the tracer.stdout.
+func (t *tracer) flush() {
+	if t == nil {
+		return
+	}
+
+	t.stdout.Write(t.buf.Bytes())
+}
+
+// newLineFlush is like flush, but with extra new line before tracer.buf gets flushed.
+func (t *tracer) newLineFlush() {
+	if t == nil {
+		return
+	}
+
+	t.buf.WriteString("\n")
+	t.flush()
+	// reset state
+	t.buf.Reset()
+	t.isFirstPrint = true
+}
+
+// call prints a command and its arguments with varying formats depending on the cmd type,
+// for example, built-in command's arguments are printed enclosed in single quotes,
+// otherwise, call defaults to printing with double quotes.
+func (t *tracer) call(cmd string, args ...string) {
+	if t == nil {
+		return
+	}
+
+	s := strings.Join(args, " ")
+	if strings.TrimSpace(s) == "" {
+		// fields may be empty for function () {} declarations
+		t.string(cmd)
+	} else if isBuiltin(cmd) {
+		if cmd == "set" {
+			// TODO: only first occurence of set is not printed, succeeding calls are printed
+			return
+		}
+
+		qs, err := syntax.Quote(s, syntax.LangBash)
+		if err != nil { // should never happen
+			panic(err)
+		}
+		t.stringf("%s %s", cmd, qs)
+	} else {
+		t.stringf("%s %s", cmd, s)
+	}
+}
+
+func (t *tracer) wordParts(wp []syntax.WordPart, name string, vr expand.Variable) {
+	if t == nil {
+		return
+	}
+
+	for _, p := range wp {
+		switch p.(type) {
+		case *syntax.ArithmExp:
+			t.stringf("%s=%s", name, vr)
+		case *syntax.DblQuoted, *syntax.SglQuoted, *syntax.Lit:
+			qs, err := syntax.Quote(vr.String(), syntax.LangBash)
+			if err != nil { // should never happen
+				panic(err)
+			}
+			t.stringf("%s=%s", name, qs)
+		case *syntax.ParamExp, *syntax.ProcSubst, *syntax.ExtGlob, *syntax.BraceExp:
+			// TODO
+		}
+	}
+}


### PR DESCRIPTION
or its shorthand, `set -x`:
https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html
```
-x
Print a trace of simple commands, for commands, case commands, select
commands, and arithmetic for commands and their arguments or associated
word lists after they are expanded and before they are executed.
```

this PR is an incomplete implementation- expressions like `if`, `expr`
and `while` among others, will silently be ignored. all trace-related
code are contained in the `interp/trace.go` file

NOTE: side-by-side comparison with bash during development, might not
behave properly when mksh and sh is used

fixes #396