### PR TITLE
Fix a problem with numbered environment variables

### DIFF
--- a/expand/environ.go
+++ b/expand/environ.go
@@ -168,9 +168,13 @@ func listEnvironWithUpper(upper bool, pairs ...string) Environ {
 		jsep := strings.IndexByte(list[j], '=')
 		if isep < 0 {
 			isep = 0
+		} else {
+			isep += 1
 		}
 		if jsep < 0 {
 			jsep = 0
+		} else {
+			jsep += 1
 		}
 		return list[i][:isep] < list[j][:jsep]
 	})

--- a/expand/environ_test.go
+++ b/expand/environ_test.go
@@ -68,3 +68,15 @@ func TestListEnviron(t *testing.T) {
 		})
 	}
 }
+
+func TestGetWithSameSubPrefix(t *testing.T) {
+	gotEnv := ListEnviron("GREETING=text1", "GREETING2=text2")
+	got := gotEnv.Get("GREETING2").String()
+	if got != "text2" {
+		t.Fatalf("ListEnviron.Get(GREETING2) wanted text2, got %q", got)
+	}
+	got = gotEnv.Get("GREETING").String()
+	if got != "text1" {
+		t.Fatalf("ListEnviron.Get(GREETING) wanted text1, got %q", got)
+	}
+}


### PR DESCRIPTION
I found this problem here: go-task/task#586

I traced it to here. For some reason, the sorting + the binary search, were
behaving wrong. The inclusion of the `=` sign in the ordering looks like fixes
the problem. I'm not 100% sure why, maybe is again, an upstream bug.

I added a unit test to reproduce the problem.