### PR TITLE
interp: fix off-by-one bug when printing arrays

### DIFF
--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -409,6 +409,13 @@ var runTests = []runTest{
 	{"a=b; a+=c x+=y; echo $a $x", "bc y\n"},
 	{`a=" x  y"; b=$a c="$a"; echo $b; echo $c`, "x y\nx y\n"},
 	{`a=" x  y"; b=$a c="$a"; echo "$b"; echo "$c"`, " x  y\n x  y\n"},
+	{`arr=("foo" "bar" "lala" "foobar"); echo ${arr[@]:2}; echo ${arr[*]:2}`, "lala foobar\nlala foobar\n"},
+	{`arr=("foo" "bar" "lala" "foobar"); echo ${arr[@]:2:4}; echo ${arr[*]:1:4}`, "lala foobar\nbar lala foobar\n"},
+	{`arr=("foo" "bar"); echo ${arr[@]}; echo ${arr[*]}`, "foo bar\nfoo bar\n"},
+	{`arr=("foo"); echo ${arr[@]:99}`, "\n"},
+	{`echo ${arr[@]:1:99}; echo ${arr[*]:1:99}`, "\n\n"},
+	{`arr=(0 1 2 3 4 5 6 7 8 9 0 a b c d e f g h); echo ${arr[@]:3:4}`, "3 4 5 6\n"},
+	{`echo ${foo[@]}; echo ${foo[*]}`, "\n\n"},
 	// TODO: reenable once we figure out the broken pipe error
 	//{`$ENV_PROG | while read line; do if test -z "$line"; then echo empty; fi; break; done`, ""}, // never begin with an empty element
 

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -1202,7 +1202,7 @@ var runTests = []runTest{
 		"bar\n",
 	},
 	{
-		">a; echo foo >>b; wc -c <a >>b; cat b",
+		">a; echo foo >>b; wc -c <a >>b; cat b | tr -d ' '",
 		"foo\n0\n",
 	},
 	{
@@ -1210,11 +1210,11 @@ var runTests = []runTest{
 		"",
 	},
 	{
-		"echo foo >a; wc -c <a",
+		"echo foo >a; wc -c <a | tr -d ' '",
 		"4\n",
 	},
 	{
-		"echo foo >>a; echo bar &>>a; wc -c <a",
+		"echo foo >>a; echo bar &>>a; wc -c <a | tr -d ' '",
 		"8\n",
 	},
 	{
@@ -1934,8 +1934,8 @@ var runTests = []runTest{
 	},
 	{"set -o noexec; echo foo", ""},
 	{"set +o noexec; echo foo", "foo\n"},
-	{"set -e; set -o | grep -E 'errexit|noexec' | wc -l", "2\n"},
-	{"set -e; set -o | grep -E 'errexit|noexec' | grep 'on$' | wc -l", "1\n"},
+	{"set -e; set -o | grep -E 'errexit|noexec' | wc -l | tr -d ' '", "2\n"},
+	{"set -e; set -o | grep -E 'errexit|noexec' | grep 'on$' | wc -l | tr -d ' '", "1\n"},
 	{
 		"set -a; set +o",
 		`set -o allexport
@@ -1999,13 +1999,13 @@ set +o pipefail
 	},
 
 	// shopt
-	{"set -e; shopt -o | grep -E 'errexit|noexec' | wc -l", "2\n"},
-	{"set -e; shopt -o | grep -E 'errexit|noexec' | grep 'on$' | wc -l", "1\n"},
+	{"set -e; shopt -o | grep -E 'errexit|noexec' | wc -l | tr -d ' '", "2\n"},
+	{"set -e; shopt -o | grep -E 'errexit|noexec' | grep 'on$' | wc -l | tr -d ' '", "1\n"},
 	{"shopt -s -o noexec; echo foo", ""},
 	{"shopt -so noexec; echo foo", ""},
 	{"shopt -u -o noexec; echo foo", "foo\n"},
-	{"shopt -u globstar; shopt globstar | grep 'off$' | wc -l", "1\n"},
-	{"shopt -s globstar; shopt globstar | grep 'off$' | wc -l", "0\n"},
+	{"shopt -u globstar; shopt globstar | grep 'off$' | wc -l | tr -d ' '", "1\n"},
+	{"shopt -s globstar; shopt globstar | grep 'off$' | wc -l | tr -d ' '", "0\n"},
 
 	// IFS
 	{`echo -n "$IFS"`, " \t\n"},
@@ -2578,10 +2578,10 @@ set +o pipefail
 	{"cat </dev/null", ""},
 
 	// time - real would be slow and flaky; see TestElapsedString
-	{"{ time; } |& wc", "      4       6      42\n"},
-	{"{ time echo -n; } |& wc", "      4       6      42\n"},
-	{"{ time -p; } |& wc", "      3       6      29\n"},
-	{"{ time -p echo -n; } |& wc", "      3       6      29\n"},
+	{"{ time; } |& wc | tr -s ' '", " 4 6 42\n"},
+	{"{ time echo -n; } |& wc | tr -s ' '", " 4 6 42\n"},
+	{"{ time -p; } |& wc | tr -s ' '", " 3 6 29\n"},
+	{"{ time -p echo -n; } |& wc | tr -s ' '", " 3 6 29\n"},
 
 	// exec
 	{"exec", ""},

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -1382,15 +1382,15 @@ var runTests = []runTest{
 		"exit status 1",
 	},
 	{
-		"touch -d @1 a b; [[ a -nt b || a -ot b ]]",
+		"touch -t 202111050000 a b; [[ a -nt b || a -ot b ]]",
 		"exit status 1",
 	},
 	{
-		"touch -d @1 a; touch -d @2 b; [[ a -nt b ]]",
+		"touch -t 202111050000 a; touch -t 202111060000 b; [[ a -nt b ]]",
 		"exit status 1",
 	},
 	{
-		"touch -d @1 a; touch -d @2 b; [[ a -ot b ]]",
+		"touch -t 202111050000 a; touch -t 202111060000 b; [[ a -ot b ]]",
 		"",
 	},
 	{
@@ -1590,11 +1590,11 @@ var runTests = []runTest{
 		"1:1: -lt must be followed by a word\nexit status 2 #JUSTERR",
 	},
 	{
-		"touch -d @1 a; touch -d @2 b; [ a -nt b ]",
+		"touch -t 202111050000 a; touch -t 202111060000 b; [ a -nt b ]",
 		"exit status 1",
 	},
 	{
-		"touch -d @1 a; touch -d @2 b; [ a -ot b ]",
+		"touch -t 202111050000 a; touch -t 202111060000 b; [ a -ot b ]",
 		"",
 	},
 	{

--- a/syntax/parser_test.go
+++ b/syntax/parser_test.go
@@ -155,8 +155,8 @@ func TestParseBats(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	os.Setenv("LANGUAGE", "en_US.UTF8")
-	os.Setenv("LC_ALL", "en_US.UTF8")
+	os.Setenv("LANGUAGE", "en_US.UTF-8")
+	os.Setenv("LC_ALL", "en_US.UTF-8")
 	os.Exit(m.Run())
 }
 
@@ -215,6 +215,7 @@ var extGlobRe = regexp.MustCompile(`[@?*+!]\(`)
 
 func confirmParse(in, cmd string, wantErr bool) func(*testing.T) {
 	return func(t *testing.T) {
+		t.Helper()
 		t.Parallel()
 		var opts []string
 		if cmd == "bash" && extGlobRe.MatchString(in) {


### PR DESCRIPTION
prior to this PR, we slice the elements of `variable.Str` but that's
buggy; the package `expand` expands the bash array `arr=(x y z)`
as `"x y z"`, a string with space between members. when accesing via
indexes, in effect we get `str[2] == "y"`

this PR fixes the bug by making use of the expanded `variable.List`
field instead to access the elements of the bash array

fixes #746