### PR TITLE
Add example for docker-based pre-commit hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,19 @@ repo configuration like:
         args: [-w]
         types: [shell]
 ```
+An alternative configuration for running shfmt via the official shfmt docker image is:
+```yaml
+  - repo: local
+    hooks:
+      - id: shfmt
+        name: Format Shell Script Files
+        description: Runs shfmt Docker image to format Shell Script files
+        minimum_pre_commit_version: 2.4.0
+        language: docker_image
+        types: [shell]
+        entry: mvdan/shfmt
+        args: [-w]
+```
 
 ### Related projects
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ An alternative configuration for running shfmt via the official shfmt docker ima
         minimum_pre_commit_version: 2.4.0
         language: docker_image
         types: [shell]
-        entry: mvdan/shfmt
+        entry: mvdan/shfmt:v3.4.0
         args: [-w]
 ```
 

--- a/README.md
+++ b/README.md
@@ -103,13 +103,14 @@ repo configuration like:
         args: [-w]
         types: [shell]
 ```
+
 An alternative configuration for running shfmt via the official shfmt docker image is:
+
 ```yaml
   - repo: local
     hooks:
       - id: shfmt
-        name: Format Shell Script Files
-        description: Runs shfmt Docker image to format Shell Script files
+        name: shfmt
         minimum_pre_commit_version: 2.4.0
         language: docker_image
         types: [shell]


### PR DESCRIPTION
This adds an example for running shfmt in a local pre-commit hook using the official shfmt docker image for cases where golang is not installed.