### PR TITLE
interp: fix variables scope in functions

### DIFF
--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -2304,6 +2304,10 @@ set +o pipefail
 	{"export foo=(1 2); $ENV_PROG | grep '^foo='", "exit status 1"},
 	{"declare -A foo=([a]=b); export foo; $ENV_PROG | grep '^foo='", "exit status 1"},
 	{"export foo=(b c); foo=x; $ENV_PROG | grep '^foo='", "exit status 1"},
+	{"foo() { bar=foo; export bar; }; foo; $ENV_PROG | grep ^bar=", "bar=foo\n"},
+	{"foo() { export bar; }; bar=foo; foo; $ENV_PROG | grep ^bar=", "bar=foo\n"},
+	{"foo() { export bar; }; foo; bar=foo; $ENV_PROG | grep ^bar=", "bar=foo\n"},
+	{"foo() { export bar=foo; }; foo; readonly bar; $ENV_PROG | grep ^bar=", "bar=foo\n"},
 
 	// local
 	{
@@ -2430,6 +2434,18 @@ set +o pipefail
 	{
 		"readonly foo=bar; foo=etc",
 		"foo: readonly variable\nexit status 1 #JUSTERR",
+	},
+	{
+		"foo() { bar=foo; readonly bar; }; foo; bar=bar",
+		"bar: readonly variable\nexit status 1 #JUSTERR",
+	},
+	{
+		"foo() { readonly bar; }; foo; bar=foo",
+		"bar: readonly variable\nexit status 1 #JUSTERR",
+	},
+	{
+		"foo() { readonly bar=foo; }; foo; export bar; $ENV_PROG | grep '^bar='",
+		"bar=foo\n",
 	},
 
 	// multiple var modes at once


### PR DESCRIPTION
Variables declared as exported or readonly in functions
without assignment are not correctly propagated to the
global scope, this snippet should return a `bar: readonly variable`
error:

```
_foo() {
    bar=foo
    readonly bar
}

_foo
bar=bar
```

This snippet should also export `bar` variable correctly:

```
_foo() {
    export bar
}

_foo
bar=foo
env | grep ^bar=
```