### PR TITLE
builtin(cd): Support hyphen-minus operand

### DIFF
--- a/interp/builtin.go
+++ b/interp/builtin.go
@@ -214,6 +214,12 @@ func (r *Runner) builtinCode(ctx context.Context, pos syntax.Pos, name string, a
 			path = r.envGet("HOME")
 		case 1:
 			path = args[0]
+
+			// replicate the commonly implemented behavior of `cd -`
+			// ref: https://www.man7.org/linux/man-pages/man1/cd.1p.html#OPERANDS
+			if len(path) == 1 && path[0] == '-' {
+				path = r.envGet("OLDPWD")
+			}
 		default:
 			r.errf("usage: cd [dir]\n")
 			return 2

--- a/interp/builtin.go
+++ b/interp/builtin.go
@@ -217,7 +217,7 @@ func (r *Runner) builtinCode(ctx context.Context, pos syntax.Pos, name string, a
 
 			// replicate the commonly implemented behavior of `cd -`
 			// ref: https://www.man7.org/linux/man-pages/man1/cd.1p.html#OPERANDS
-			if len(path) == 1 && path[0] == '-' {
+			if path == "-" {
 				path = r.envGet("OLDPWD")
 			}
 		default:

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -929,7 +929,7 @@ var runTests = []runTest{
 		"1\n",
 	},
 	{
-		`orig="$PWD"; mkdir a && cd a && cd - && [[ "$PWD" == "$orig" ]]`,
+		`orig="$PWD"; mkdir a; cd a; cd -; [[ "$PWD" == "$orig" ]]`,
 		"",
 	},
 

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -928,6 +928,10 @@ var runTests = []runTest{
 		`mkdir a; ln -s a b; [[ "$(cd a && pwd -P)" == "$(cd b && pwd -L)" ]]; echo $?`,
 		"1\n",
 	},
+	{
+		`orig="$PWD"; mkdir a && cd a && cd - && [[ "$PWD" == "$orig" ]]`,
+		"",
+	},
 
 	// dirs/pushd/popd
 	{"set -- $(dirs); echo $# ${#DIRSTACK[@]}", "1 1\n"},


### PR DESCRIPTION
Hi, thanks for this amazing package, I'm relying on it for cross platform build automation tasks.

And I came across the unexpected behavior of `cd -`, which errored when there is no directory named `-`, instead of chdir into last working directory.

In this pull request, the existence of directory named `-` in the current working directory is not checked as the man page says `cd -` is actually an alias of `cd ${OLDPWD}`, so to my understanding, a directory named `-` is ignored in this case (and I can confirm ash, zsh, bash on macos and linux all have this behavior).
