### PR TITLE
interp: fix negative elapsed time

### DIFF
--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -3713,6 +3713,8 @@ func TestElapsedString(t *testing.T) {
 			true,
 			"610.00",
 		},
+		{31 * time.Second, false, "0m31.000s"},
+		{102 * time.Second, false, "1m42.000s"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.in.String(), func(t *testing.T) {

--- a/interp/runner.go
+++ b/interp/runner.go
@@ -709,7 +709,7 @@ func elapsedString(d time.Duration, posix bool) string {
 		return fmt.Sprintf("%.2f", d.Seconds())
 	}
 	min := int(d.Minutes())
-	sec := math.Remainder(d.Seconds(), 60.0)
+	sec := math.Mod(d.Seconds(), 60.0)
 	return fmt.Sprintf("%dm%.3fs", min, sec)
 }
 


### PR DESCRIPTION
Change the operation to calculate the elapsed seconds from `Remainder` to `Mod`, as `Remainder` can return negative values.

Let me know if we need more test cases :)

Fixes #767