### PR TITLE
lexer: allow extglob wildcards as function names

### DIFF
--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -3117,6 +3117,20 @@ hello, world
 hello, world
 `,
 	},
+	{
+		// globbing wildcard as function name
+		`@() { echo "$@"; }; @ lala; function +() { echo "$@"; }; + foo`,
+		"lala\nfoo\n",
+	},
+	{
+		`      @() { echo "$@"; }; @ lala;`,
+		"lala\n",
+	},
+	{
+		// globbing wildcard as function name but with space after the name
+		`+ () { echo "$@"; }; + foo; @ () { echo "$@"; }; @ lala; ? () { echo "$@"; }; ? bar`,
+		"foo\nlala\nbar\n",
+	},
 }
 
 var runTestsWindows = []runTest{


### PR DESCRIPTION
the lexer assumes an extglob token if any of the wildcards expressions
(such as `@`, and `+`) are succeeded by a left parenthesis but that
proves to be an issue if the wildcard is used as a function name.

example input:
```
$ cat in.sh
@() {
  echo "$@";
}
```

`bash` and `gosh` comparison:
```
$ bash ./in.sh
hello
$ ./gosh in.sh
in.sh:5:1: "}" can only be used to close a block
```

given `in.sh`, gosh reports about a syntax error - this is because
a closing bracket is found while the lexer isn't assuming a function
block

fix the issue by assuming a function if one of the conditions below is
true:
* if the expression is found at the beginning of the statement or if its
  preceded by a "function"
* if `(` is immediately succeeded by a `)` - although this is a valid
  bash syntax, we'll operate on the likelihood that it is a function

fixes #739