### PR TITLE
Check for empty paths in builtin test

### DIFF
--- a/interp/builtin.go
+++ b/interp/builtin.go
@@ -853,6 +853,9 @@ func (r *Runner) readLine(raw bool) ([]byte, error) {
 }
 
 func (r *Runner) changeDir(path string) int {
+	if path == "" {
+		path = "."
+	}
 	path = r.absPath(path)
 	info, err := r.stat(path)
 	if err != nil || !info.IsDir() {
@@ -867,11 +870,18 @@ func (r *Runner) changeDir(path string) int {
 	return 0
 }
 
-func (r *Runner) absPath(path string) string {
+func absPath(dir, path string) string {
+	if path == "" {
+		return ""
+	}
 	if !filepath.IsAbs(path) {
-		path = filepath.Join(r.Dir, path)
+		path = filepath.Join(dir, path)
 	}
 	return filepath.Clean(path)
+}
+
+func (r *Runner) absPath(path string) string {
+	return absPath(r.Dir, path)
 }
 
 // flagParser is used to parse builtin flags.

--- a/interp/handler.go
+++ b/interp/handler.go
@@ -276,7 +276,7 @@ type OpenHandlerFunc func(ctx context.Context, path string, flag int, perm os.Fi
 func DefaultOpenHandler() OpenHandlerFunc {
 	return func(ctx context.Context, path string, flag int, perm os.FileMode) (io.ReadWriteCloser, error) {
 		mc := HandlerCtx(ctx)
-		if !filepath.IsAbs(path) {
+		if path != "" && !filepath.IsAbs(path) {
 			path = filepath.Join(mc.Dir, path)
 		}
 		return os.OpenFile(path, flag, perm)

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -192,13 +192,6 @@ type concBuffer struct {
 	sync.Mutex
 }
 
-func absPath(dir, path string) string {
-	if !filepath.IsAbs(path) {
-		path = filepath.Join(dir, path)
-	}
-	return filepath.Clean(path)
-}
-
 func (c *concBuffer) Write(p []byte) (int, error) {
 	c.Lock()
 	n, err := c.buf.Write(p)
@@ -858,6 +851,10 @@ var runTests = []runTest{
 	{"[[ a == [ab ]]", "exit status 1"},
 	{`HOME='/*'; echo ~; echo "$HOME"`, "/*\n/*\n"},
 	{`test -d ~`, ""},
+	{
+		`for flag in b c d e f g h k L p r s S u w x; do test -$flag ""; echo -n "$flag$? "; done`,
+		`b1 c1 d1 e1 f1 g1 h1 k1 L1 p1 r1 s1 S1 u1 w1 x1 `,
+	},
 	{`foo=~; test -d $foo`, ""},
 	{`foo=~; test -d "$foo"`, ""},
 	{`foo='~'; test -d $foo`, "exit status 1"},
@@ -880,6 +877,10 @@ var runTests = []runTest{
 	},
 	{
 		`w="$HOME"; cd; [[ $PWD == "$w" ]]`,
+		"",
+	},
+	{
+		`mkdir test.cd; cd test.cd; cd ''; [[ "$PWD" == "$OLDPWD" ]]`,
 		"",
 	},
 	{


### PR DESCRIPTION
`test -d ""` succeeds when it should fail. Checking all the flags which take a path in `gosh` (ignoring G and O which are not yet implemented):

```sh
for flag in b c d e f g h k L p r s S u w x; do
    test -$flag ""
    echo -n "$flag$? "
done
```

Results in `b1 c1 d0 e0 f1 g1 h1 k1 L1 p1 r0 s0 S1 u1 w1 x1`. Some are correctly failing, but for the wrong reasons.

`absPath` is updated to check for empty paths and return them untouched. `changeDir` was relying on the old behavior, so it now explicitly implements the same behavior as bash, dash, mksh, and zsh, where a `cd ''` is equivalent to a `cd .`. (This was also the previous behavior in gosh.)

Shell behavior was surveyed with:

```sh

try() {
	local cmd="$1" want="$2"
	for shell in bash csh dash gosh ksh mksh posh sh tcsh zsh; do
		local got
		got="$($shell -c "$cmd" 2>&1)"
		if [ "$got" != "$want" ]; then
			printf "~   FAIL: %s\n" "$shell: $cmd"
			printf "    want: %s\n" "$want"
			printf "     got: %s\n" "$got"
			echo
		fi
	done
}

try 'cd /; cd /tmp; cd ""; echo $? $PWD $OLDPWD' '0 /tmp /tmp'

try 'for flag in b c d e f g h k L p r s S u w x; do test -$flag ""; echo -n "$flag$? "; done' \
    'b1 c1 d1 e1 f1 g1 h1 k1 L1 p1 r1 s1 S1 u1 w1 x1 '
```

Closes #781 