### PR TITLE
Add interp.ReadDirHandler for intercepting glob expansion.

### DIFF
--- a/interp/handler.go
+++ b/interp/handler.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -299,5 +300,18 @@ func DefaultOpenHandler() OpenHandlerFunc {
 			path = filepath.Join(mc.Dir, path)
 		}
 		return os.OpenFile(path, flag, perm)
+	}
+}
+
+// ReadDirHandlerFunc is a handler which reads directories. It is called during
+// shell globbing, if enabled.
+//
+// TODO(v4): if this is kept in v4, it most likely needs to use fs.DirEntry for efficiency
+type ReadDirHandlerFunc func(ctx context.Context, path string) ([]os.FileInfo, error)
+
+// DefaultReadDirHandler returns a ReadDirHandlerFunc used by default. It uses ioutil.ReadDir().
+func DefaultReadDirHandler() ReadDirHandlerFunc {
+	return func(ctx context.Context, path string) ([]os.FileInfo, error) {
+		return ioutil.ReadDir(path)
 	}
 }

--- a/interp/runner.go
+++ b/interp/runner.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"math/rand"
 	"os"
@@ -144,7 +143,9 @@ func (r *Runner) updateExpandOpts() {
 	if r.opts[optNoGlob] {
 		r.ecfg.ReadDir = nil
 	} else {
-		r.ecfg.ReadDir = ioutil.ReadDir
+		r.ecfg.ReadDir = func(s string) ([]os.FileInfo, error) {
+			return r.readDirHandler(r.handlerCtx(context.Background()), s)
+		}
 	}
 	r.ecfg.GlobStar = r.opts[optGlobStar]
 	r.ecfg.NullGlob = r.opts[optNullGlob]


### PR DESCRIPTION
I believe this is one of the last locations where the interpreter can bypass sandboxing, though there are a few explicit calls to `os.*` that remain.

As an aside related to #630,  it would be amazing if for v4 the interp package could be refactored to solely (or as close as possible) interact through the `fs.FS` interface. This would then allow the interpreter to be completely sandboxed. For example the existing [Runner.stat()](https://github.com/alecthomas/sh/blob/master/interp/runner.go#L901) function, and so on. This would also remove the need for `OpenHandler` and `ReadDirHandler`.