### PR TITLE
syntax: support backquoted inline comments

### DIFF
--- a/syntax/filetests_test.go
+++ b/syntax/filetests_test.go
@@ -4492,6 +4492,25 @@ var fileTestsKeepComments = []testCase{
 			}},
 		},
 	},
+	{
+		Strs: []string{
+			"$(\n\t# foo\n)",
+			"`\n\t# foo\n`",
+			"`# foo\n`",
+		},
+		common: &CmdSubst{
+			Last: []Comment{{Text: " foo"}},
+		},
+	},
+	{
+		Strs: []string{
+			"`# foo`",
+			"` # foo`",
+		},
+		common: &CmdSubst{
+			Last: []Comment{{Text: " foo"}},
+		},
+	},
 }
 
 func fullProg(v interface{}) *File {

--- a/syntax/lexer.go
+++ b/syntax/lexer.go
@@ -267,10 +267,18 @@ skipSpace:
 		case '#':
 			r = p.rune()
 			p.newLit(r)
-			for r != '\n' && r != utf8.RuneSelf {
-				if r == escNewl {
+		runeLoop:
+			for {
+				switch r {
+				case '\n', utf8.RuneSelf:
+					break runeLoop
+				case escNewl:
 					p.litBs = append(p.litBs, '\\', '\n')
-					break
+					break runeLoop
+				case '`':
+					if p.backquoteEnd() {
+						break runeLoop
+					}
 				}
 				r = p.rune()
 			}

--- a/syntax/printer.go
+++ b/syntax/printer.go
@@ -627,6 +627,12 @@ func (p *Printer) wordPart(wp, next WordPart) {
 			p.nestedStmts(x.Stmts, x.Last, x.Right)
 			p.wantSpace = false
 			p.semiRsrv("}", x.Right)
+		// Special case: `# inline comment`
+		case x.Backquotes && len(x.Stmts) == 0 &&
+			len(x.Last) == 1 && x.Right.Line() == p.line:
+			p.WriteString("`#")
+			p.WriteString(x.Last[0].Text)
+			p.WriteString("`")
 		default:
 			p.WriteString("$(")
 			p.wantSpace = len(x.Stmts) > 0 && startsWithLparen(x.Stmts[0])

--- a/syntax/printer_test.go
+++ b/syntax/printer_test.go
@@ -20,7 +20,7 @@ func TestPrintCompact(t *testing.T) {
 	parserMirBSD := NewParser(KeepComments(true), Variant(LangMirBSDKorn))
 	parserBats := NewParser(KeepComments(true), Variant(LangBats))
 	printer := NewPrinter()
-	for _, c := range fileTests {
+	for _, c := range append(fileTests, fileTestsKeepComments...) {
 		t.Run("", func(t *testing.T) {
 			in := c.Strs[0]
 			parser := parserPosix
@@ -239,6 +239,7 @@ var printTests = []printCase{
 	samePrint("#before\nfoo && bar"),
 	samePrint("foo | bar # inline"),
 	samePrint("foo && bar # inline"),
+	samePrint("foo `# inline` \\\n\tbar"),
 	samePrint("for a in 1 2; do\n\n\tbar\ndone"),
 	{
 		"a \\\n\t&& b",
@@ -1078,7 +1079,7 @@ func TestPrintOptionsNotBroken(t *testing.T) {
 		{"SingleLine", []PrinterOption{SingleLine(true)}},
 	} {
 		printer := NewPrinter(opts.list...)
-		for i, tc := range fileTests {
+		for i, tc := range append(fileTests, fileTestsNoPrint...) {
 			t.Run(fmt.Sprintf("File%s%03d", opts.name, i), func(t *testing.T) {
 				parser := parserPosix
 				if tc.Bats != nil {


### PR DESCRIPTION
(see commit message)

Fixes #342.
Fixes #636.