### PR TITLE
readme: document trunk

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ The following editor integrations wrap `shfmt`:
 - [shell-format] - VS Code plugin
 - [shfmt.el] - Emacs package
 - [Sublime-Pretty-Shell] - Sublime Text 3 plugin
+- [Trunk] - Universal linter VS Code plugin (also available as a [cli](https://trunk.io/products/check) and [GitHub action](https://github.com/trunk-io/trunk-action))
 - [vim-shfmt] - Vim plugin
 
 Other noteworthy integrations include:
@@ -139,6 +140,7 @@ Other noteworthy integrations include:
 [shfmt.el]: https://github.com/purcell/emacs-shfmt/
 [snapcraft]: https://snapcraft.io/shfmt
 [sublime-pretty-shell]: https://github.com/aerobounce/Sublime-Pretty-Shell
+[trunk]: https://marketplace.visualstudio.com/items?itemName=Trunk.io
 [vim-shfmt]: https://github.com/z0mbix/vim-shfmt
 [void]: https://github.com/void-linux/void-packages/blob/HEAD/srcpkgs/shfmt/template
 [webi]: https://webinstall.dev/shfmt/

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The following editor integrations wrap `shfmt`:
 - [shell-format] - VS Code plugin
 - [shfmt.el] - Emacs package
 - [Sublime-Pretty-Shell] - Sublime Text 3 plugin
-- [Trunk] - Universal linter VS Code plugin (also available as a [cli](https://trunk.io/products/check) and [GitHub action](https://github.com/trunk-io/trunk-action))
+- [Trunk] - Universal linter, available as a CLI, VS Code plugin, and GitHub action
 - [vim-shfmt] - Vim plugin
 
 Other noteworthy integrations include:
@@ -140,7 +140,7 @@ Other noteworthy integrations include:
 [shfmt.el]: https://github.com/purcell/emacs-shfmt/
 [snapcraft]: https://snapcraft.io/shfmt
 [sublime-pretty-shell]: https://github.com/aerobounce/Sublime-Pretty-Shell
-[trunk]: https://marketplace.visualstudio.com/items?itemName=Trunk.io
+[trunk]: https://trunk.io/products/check
 [vim-shfmt]: https://github.com/z0mbix/vim-shfmt
 [void]: https://github.com/void-linux/void-packages/blob/HEAD/srcpkgs/shfmt/template
 [webi]: https://webinstall.dev/shfmt/


### PR DESCRIPTION
Trunk is a recently launched universal linter which integrates with a wide variety of linters and formatters, `shfmt` included.

We're big fans of `shfmt` and figured that you might find our tool to be interesting enough to include it here.