### PR TITLE
syntax: support escaped newlines with CRLF

### DIFF
--- a/syntax/lexer.go
+++ b/syntax/lexer.go
@@ -80,9 +80,14 @@ retry:
 				goto retry
 			}
 			if b == '\\' {
-				if p.r != '\\' && p.peekByte('\n') {
+				if p.r == '\\' {
+				} else if p.peekByte('\n') {
 					p.bsp++
 					p.w, p.r = 1, escNewl
+					return escNewl
+				} else if p.peekBytes("\r\n") {
+					p.bsp += 2
+					p.w, p.r = 2, escNewl
 					return escNewl
 				}
 				if p.openBquotes > 0 && bquotes < p.openBquotes &&
@@ -373,7 +378,7 @@ func (p *Parser) peekBytes(s string) bool {
 		p.fill()
 	}
 	bw := p.bsp + len(s)
-	return bw < len(p.bs) && bytes.HasPrefix(p.bs[p.bsp:bw], []byte(s))
+	return bw <= len(p.bs) && bytes.HasPrefix(p.bs[p.bsp:bw], []byte(s))
 }
 
 func (p *Parser) peekByte(b byte) bool {

--- a/syntax/parser_test.go
+++ b/syntax/parser_test.go
@@ -227,6 +227,9 @@ func confirmParse(in, cmd string, wantErr bool) func(*testing.T) {
 		t.Helper()
 		t.Parallel()
 		var opts []string
+		if strings.Contains(in, "\\\r\n") {
+			t.Skip("shells do not generally support CRLF line endings")
+		}
 		if cmd == "bash" && extGlobRe.MatchString(in) {
 			// otherwise bash refuses to parse these
 			// properly. Also avoid -n since that too makes

--- a/syntax/printer_test.go
+++ b/syntax/printer_test.go
@@ -79,6 +79,7 @@ var printTests = []printCase{
 	samePrint("#"),
 	samePrint("#c1\\\n#c2"),
 	samePrint("#\\\n#"),
+	{"#\\\r\n#", "#\\\n#"},
 	samePrint("{\n\t# foo \\\n}"),
 	samePrint("foo\\\\\nbar"),
 	samePrint("a=b # inline\nbar"),


### PR DESCRIPTION
(see commit message)

Fixes #795.