### PR TITLE
interp: Initial support for fs.FS.

### DIFF
--- a/interp/builtin.go
+++ b/interp/builtin.go
@@ -261,7 +261,7 @@ func (r *Runner) builtinCode(ctx context.Context, pos syntax.Pos, name string, a
 		args := fp.args()
 		for _, arg := range args {
 			if mode == "-p" {
-				if path, err := LookPathDir(r.Dir, r.writeEnv, arg); err == nil {
+				if path, err := LookPathDirFS(r.fs, r.Dir, r.writeEnv, arg); err == nil {
 					r.outf("%s\n", path)
 				} else {
 					anyNotFound = true
@@ -310,7 +310,7 @@ func (r *Runner) builtinCode(ctx context.Context, pos syntax.Pos, name string, a
 				}
 				continue
 			}
-			if path, err := LookPathDir(r.Dir, r.writeEnv, arg); err == nil {
+			if path, err := LookPathDirFS(r.fs, r.Dir, r.writeEnv, arg); err == nil {
 				if mode == "-t" {
 					r.out("file\n")
 				} else {
@@ -341,7 +341,7 @@ func (r *Runner) builtinCode(ctx context.Context, pos syntax.Pos, name string, a
 			r.errf("%v: source: need filename\n", pos)
 			return 2
 		}
-		path, err := scriptFromPathDir(r.Dir, r.writeEnv, args[0])
+		path, err := scriptFromPathDir(r.fs, r.Dir, r.writeEnv, args[0])
 		if err != nil {
 			// If the script was not found in PATH or there was any error, pass
 			// the source path to the open handler so it has a chance to look
@@ -455,7 +455,7 @@ func (r *Runner) builtinCode(ctx context.Context, pos syntax.Pos, name string, a
 			last = 0
 			if r.Funcs[arg] != nil || isBuiltin(arg) {
 				r.outf("%s\n", arg)
-			} else if path, err := LookPathDir(r.Dir, r.writeEnv, arg); err == nil {
+			} else if path, err := LookPathDirFS(r.fs, r.Dir, r.writeEnv, arg); err == nil {
 				r.outf("%s\n", path)
 			} else {
 				last = 1

--- a/interp/example_test.go
+++ b/interp/example_test.go
@@ -50,7 +50,7 @@ func ExampleExecHandler() {
 			return nil
 		}
 
-		if _, err := interp.LookPathDir(hc.Dir, hc.Env, args[0]); err != nil {
+		if _, err := interp.LookPathDirFS(hc.FS, hc.Dir, hc.Env, args[0]); err != nil {
 			fmt.Printf("%s is not installed\n", args[0])
 			return interp.NewExitStatus(1)
 		}

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -427,7 +427,7 @@ var runTests = []runTest{
 	{`arr=(0 1 2 3 4 5 6 7 8 9 0 a b c d e f g h); echo ${arr[@]:3:4}`, "3 4 5 6\n"},
 	{`echo ${foo[@]}; echo ${foo[*]}`, "\n\n"},
 	// TODO: reenable once we figure out the broken pipe error
-	//{`$ENV_PROG | while read line; do if test -z "$line"; then echo empty; fi; break; done`, ""}, // never begin with an empty element
+	// {`$ENV_PROG | while read line; do if test -z "$line"; then echo empty; fi; break; done`, ""}, // never begin with an empty element
 
 	// inline variables have special scoping
 	{
@@ -2435,10 +2435,10 @@ set +o pipefail
 		"xxx xxx\n",
 	},
 	// TODO: figure this one out
-	//{
+	// {
 	//        "declare -n foo=bar bar=baz; foo=xxx; echo $foo $bar; echo $baz",
 	//        "xxx xxx\nxxx\n",
-	//},
+	// },
 
 	// read-only vars
 	{"declare -r foo=bar; echo $foo", "bar\n"},
@@ -2903,7 +2903,7 @@ var runTestsUnix = []runTest{
 	},
 	{
 		"cd /; sure/is/missing",
-		"stat /sure/is/missing: no such file or directory\nexit status 127 #JUSTERR",
+		"stat //sure/is/missing: no such file or directory\nexit status 127 #JUSTERR",
 	},
 	{
 		"echo '#!/bin/sh\necho b' >a; chmod 0755 a; PATH=; a",


### PR DESCRIPTION
I haven't added any tests yet, this is just a first pass to see if this
is a good idea.

I converted all the obvious filesystem I could find that made sense.
There are a few issues though:

1. Yet another variant of LookPath called LookPathDirFS was added.
2. fs.FS is read-only, so there will still be a split of responsibilities between the FS and OpenHandler
3. fs.FS does not allow "rooted" paths, so these paths are remapped, eg. "/" => ".", "/etc/passwd" => "etc/passwd" - returned errors that include the path will use these remapped forms.