### PR TITLE
interp: fix unset global inside function

### DIFF
--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -2389,6 +2389,10 @@ set +o pipefail
 		"x=after\nbefore\n",
 	},
 
+	// unset global from inside function
+	{"f() { unset foo; echo $foo; }; foo=bar; f", "\n"},
+	{"f() { unset foo; }; foo=bar; f; echo $foo", "\n"},
+
 	// name references
 	{"declare -n foo=bar; bar=etc; [[ -R foo ]]", ""},
 	{"declare -n foo=bar; bar=etc; [ -R foo ]", ""},


### PR DESCRIPTION
In dc2e11e `unset` of a global var inside a function was broken, as the special handling of `export` or `readonly` in function scope introduced in that commit also incorrectly captured `unset`, calling a parent.Set with the previous value.

Ensure we do not capture unset in the function scope global handling.

Unset of a global can fall-through this code. Globals are unset correctly further down the Set function, so we do not need to invoke a parent.Set at all.

Fixes mvdan#806