### PR TITLE
interp: run "Confirm" tests on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,8 +30,10 @@ jobs:
     
     - name: Install dockexec
       run: go install mvdan.cc/dockexec@latest
+      if: matrix.os == 'ubuntu-latest'
     - name: Test bash interpreter
-      run: go test ./interp/. -run TestRunnerRunConfirm -exec='dockexec bash:5.1'
+      run: go test ./interp/. -run TestRunnerRunConfirm -exec='dockexec bash:5.1 -e=CGO_ENABLED=0'
+      if: matrix.os == 'ubuntu-latest'
 
   test-linux-alpine:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
 
     - name: Run confirm tests with Bash 5.1
-      run: | 
+      run: |
         go install mvdan.cc/dockexec@latest
         CGO_ENABLED=0 go test -run TestRunnerRunConfirm -exec 'dockexec bash:5.1' ./interp
       if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,11 @@ jobs:
     - name: gofmt check
       run: diff <(echo -n) <(gofmt -d .)
       if: matrix.os == 'ubuntu-latest'
+    
+    - name: Install dockexec
+      run: go install mvdan.cc/dockexec@latest
+    - name: Test bash interpreter
+      run: go test ./interp/. -run TestRunnerRunConfirm -exec='dockexec bash:5.1'
 
   test-linux-alpine:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
         ./configure
         make
         sudo make install
+      if: matrix.os == 'ubuntu-latest'
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,12 +22,9 @@ jobs:
         ./configure
         make
         sudo make install
-        echo $BASH_VERSION
       if: matrix.os == 'ubuntu-latest'
     - name: Checkout code
       uses: actions/checkout@v2
-    - name: Test 2
-      run: go test -v ./interp/. -run TestRunnerRunConfirm
     - name: Test
       run: go test -count=1 ./...
     - name: Test with -short -race

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,9 +22,12 @@ jobs:
         ./configure
         make
         sudo make install
+        echo $BASH_VERSION
       if: matrix.os == 'ubuntu-latest'
     - name: Checkout code
       uses: actions/checkout@v2
+    - name: Test 2
+      run: go test -v ./interp/. -run TestRunnerRunConfirm
     - name: Test
       run: go test -count=1 ./...
     - name: Test with -short -race

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,11 +28,10 @@ jobs:
       run: diff <(echo -n) <(gofmt -d .)
       if: matrix.os == 'ubuntu-latest'
 
-    - name: Install dockexec
-      run: go install mvdan.cc/dockexec@latest
-      if: matrix.os == 'ubuntu-latest'
-    - name: Test interpreter confirm
-      run: CGO_ENABLED=0 go test -run TestRunnerRunConfirm -exec 'dockexec bash:5.1' ./interp/.
+    - name: Run confirm tests with Bash 5.1
+      run: | 
+        go install mvdan.cc/dockexec@latest
+        CGO_ENABLED=0 go test -run TestRunnerRunConfirm -exec 'dockexec bash:5.1' ./interp
       if: matrix.os == 'ubuntu-latest'
 
   test-linux-alpine:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,15 +14,6 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: ${{ matrix.go-version }}
-    - name: Install bash 5.1
-      run: |
-        wget http://ftp.gnu.org/gnu/bash/bash-5.1.tar.gz
-        tar xf bash-5.1.tar.gz
-        cd bash-5.1
-        ./configure
-        make
-        sudo make install
-      if: matrix.os == 'ubuntu-latest'
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Test
@@ -35,6 +26,13 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
     - name: gofmt check
       run: diff <(echo -n) <(gofmt -d .)
+      if: matrix.os == 'ubuntu-latest'
+
+    - name: Install dockexec
+      run: go install mvdan.cc/dockexec@latest
+      if: matrix.os == 'ubuntu-latest'
+    - name: Test interpreter confirm
+      run: CGO_ENABLED=0 go test -run TestRunnerRunConfirm -exec 'dockexec bash:5.1' ./interp/.
       if: matrix.os == 'ubuntu-latest'
 
   test-linux-alpine:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,14 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: ${{ matrix.go-version }}
+    - name: Install bash 5.1
+      run: |
+        wget http://ftp.gnu.org/gnu/bash/bash-5.1.tar.gz
+        tar xf bash-5.1.tar.gz
+        cd bash-5.1
+        ./configure
+        make
+        sudo make install
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Test
@@ -26,13 +34,6 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
     - name: gofmt check
       run: diff <(echo -n) <(gofmt -d .)
-      if: matrix.os == 'ubuntu-latest'
-    
-    - name: Install dockexec
-      run: go install mvdan.cc/dockexec@latest
-      if: matrix.os == 'ubuntu-latest'
-    - name: Test bash interpreter
-      run: go test ./interp/. -run TestRunnerRunConfirm -exec='dockexec bash:5.1 -e=CGO_ENABLED=0'
       if: matrix.os == 'ubuntu-latest'
 
   test-linux-alpine:


### PR DESCRIPTION
update bash directly instead of use dockexec since got `no such file` error
close #785 