### PR TITLE
interp: surface exit codes from command substitutions

### DIFF
--- a/interp/api.go
+++ b/interp/api.go
@@ -81,6 +81,8 @@ type Runner struct {
 	ecfg *expand.Config
 	ectx context.Context // just so that Runner.Subshell can use it again
 
+	lastExpandExit int // used to surface exit codes while expanding fields
+
 	// didReset remembers whether the runner has ever been reset. This is
 	// used so that Reset is automatically called when running any program
 	// or node for the first time on a Runner.

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -1187,6 +1187,22 @@ var runTests = []runTest{
 		"echo foo_interp_missing >f; echo $(<f; echo bar_interp_missing)",
 		"bar_interp_missing\n",
 	},
+	{
+		"$(false); echo $?; $(exit 3); echo $?; $(true); echo $?",
+		"1\n3\n0\n",
+	},
+	{
+		"foo=$(false); echo $?; echo foo $(false); echo $?",
+		"1\nfoo\n0\n",
+	},
+	{
+		"$(false) $(true); echo $?; $(true) $(false); echo $?",
+		"0\n1\n",
+	},
+	{
+		"foo=$(false) $(true); echo $?; foo=$(true) $(false); echo $?",
+		"1\n0\n",
+	},
 
 	// pipes
 	{


### PR DESCRIPTION
(see commit message)

Fixes #828.