### PR TITLE
syntax: strip escaped newlines from all non-quoted words

### DIFF
--- a/syntax/printer_test.go
+++ b/syntax/printer_test.go
@@ -332,6 +332,22 @@ var printTests = []printCase{
 	samePrint("\"foo\\\n  bar\""),
 	samePrint("'foo\\\n  bar'"),
 	samePrint("v=\"\\\nfoo\""),
+	{
+		"v=foo\\\nbar",
+		"v=foobar",
+	},
+	{
+		"v='foo'\\\n'bar'",
+		"v='foo''bar'",
+	},
+	{
+		"v=\\\n\"foo\"",
+		"v=\"foo\"",
+	},
+	{
+		"v=\\\nfoo\\\n$bar",
+		"v=foo$bar",
+	},
 	samePrint("\"\\\n\\\nfoo\\\n\\\n\""),
 	samePrint("'\\\n\\\nfoo\\\n\\\n'"),
 	{


### PR DESCRIPTION
(see commit message)

Fixes #832.