### PR TITLE
Separate comment from sub-shell opening parenthesis with a space

### DIFF
--- a/syntax/printer.go
+++ b/syntax/printer.go
@@ -1392,6 +1392,14 @@ func (p *Printer) assigns(assigns []*Assign) {
 	p.decLevel()
 }
 
+type wantSpaceState uint8
+
+const (
+	spaceNotRequired wantSpaceState = iota
+	spaceRequired                   // we should generally print a space or a newline next
+	spaceWritten                    // we have just written a space or newline
+)
+
 // extraIndenter ensures that all lines in a '<<-' heredoc body have at least
 // baseIndent leading tabs. Those that had more tab indentation than the first
 // heredoc line will keep that relative indentation.

--- a/syntax/printer.go
+++ b/syntax/printer.go
@@ -1285,41 +1285,6 @@ func (p *Printer) ifClause(ic *IfClause, elif bool) {
 	p.semiRsrv("fi", ic.FiPos)
 }
 
-func startsWithLparen(node Node) bool {
-	switch node := node.(type) {
-	case *Stmt:
-		return startsWithLparen(node.Cmd)
-	case *BinaryCmd:
-		return startsWithLparen(node.X)
-	case *Subshell:
-		return true // keep ( (
-	case *ArithmCmd:
-		return true // keep ( ((
-	}
-	return false
-}
-
-func startsWithComment(node Node) bool {
-	var stmts []*Stmt
-	switch node := node.(type) {
-	case *CmdSubst:
-		if node.TempFile || node.ReplyVar {
-			return false
-		}
-		stmts = node.Stmts
-	case *Subshell:
-		stmts = node.Stmts
-	}
-
-	if len(stmts) == 0 || len(stmts[0].Comments) == 0 {
-		return false
-	}
-	cline := stmts[0].Comments[0].Pos().Line()
-
-	// Comment is before the first statement on the same line as node.
-	return cline < stmts[0].Pos().Line() && cline == node.Pos().Line()
-}
-
 func (p *Printer) stmtList(stmts []*Stmt, last []Comment) {
 	sep := p.wantNewline || (len(stmts) > 0 && stmts[0].Pos().Line() > p.line)
 	for i, s := range stmts {
@@ -1484,4 +1449,39 @@ func (p *Printer) assigns(assigns []*Assign) {
 		p.wantSpace = true
 	}
 	p.decLevel()
+}
+
+func startsWithLparen(node Node) bool {
+	switch node := node.(type) {
+	case *Stmt:
+		return startsWithLparen(node.Cmd)
+	case *BinaryCmd:
+		return startsWithLparen(node.X)
+	case *Subshell:
+		return true // keep ( (
+	case *ArithmCmd:
+		return true // keep ( ((
+	}
+	return false
+}
+
+func startsWithComment(node Node) bool {
+	var stmts []*Stmt
+	switch node := node.(type) {
+	case *CmdSubst:
+		if node.TempFile || node.ReplyVar {
+			return false
+		}
+		stmts = node.Stmts
+	case *Subshell:
+		stmts = node.Stmts
+	}
+
+	if len(stmts) == 0 || len(stmts[0].Comments) == 0 {
+		return false
+	}
+	cline := stmts[0].Comments[0].Pos().Line()
+
+	// Comment is before the first statement on the same line as node.
+	return cline < stmts[0].Pos().Line() && cline == node.Pos().Line()
 }

--- a/syntax/printer.go
+++ b/syntax/printer.go
@@ -634,7 +634,11 @@ func (p *Printer) wordPart(wp, next WordPart) {
 			p.WriteString("`")
 		default:
 			p.WriteString("$(")
-			p.wantSpace = len(x.Stmts) > 0 && startsWithLparen(x.Stmts[0])
+			if len(x.Stmts) > 0 && startsWithLparen(x.Stmts[0]) {
+				p.wantSpace = true
+			} else {
+				p.wantSpace = false
+			}
 			if startsWithComment(x) {
 				p.WriteByte(' ')
 			}
@@ -861,7 +865,11 @@ func (p *Printer) testExprSameLine(expr TestExpr) {
 		p.testExprSameLine(x.X)
 	case *ParenTest:
 		p.WriteByte('(')
-		p.wantSpace = startsWithLparen(x.X)
+		if startsWithLparen(x.X) {
+			p.wantSpace = true
+		} else {
+			p.wantSpace = false
+		}
 		p.testExpr(x.X)
 		p.WriteByte(')')
 	}
@@ -1059,7 +1067,11 @@ func (p *Printer) command(cmd Command, redirs []*Redirect) (startRedirs int) {
 		p.ifClause(x, false)
 	case *Subshell:
 		p.WriteByte('(')
-		p.wantSpace = len(x.Stmts) > 0 && startsWithLparen(x.Stmts[0])
+		if len(x.Stmts) > 0 && startsWithLparen(x.Stmts[0]) {
+			p.wantSpace = true
+		} else {
+			p.wantSpace = false
+		}
 		if len(p.pendingComments) > 0 || startsWithComment(x) {
 			p.WriteByte(' ')
 		}
@@ -1170,7 +1182,11 @@ func (p *Printer) command(cmd Command, redirs []*Redirect) (startRedirs int) {
 			p.spacePad(ci.Pos())
 			p.casePatternJoin(ci.Patterns)
 			p.WriteByte(')')
-			p.wantSpace = !p.minify
+			if !p.minify {
+				p.wantSpace = true
+			} else {
+				p.wantSpace = false
+			}
 
 			bodyPos := stmtsPos(ci.Stmts, ci.Last)
 			bodyEnd := stmtsEnd(ci.Stmts, ci.Last)

--- a/syntax/printer_test.go
+++ b/syntax/printer_test.go
@@ -552,6 +552,34 @@ var printTests = []printCase{
 		"foo() # inline\n{\n\tbar\n}",
 		"foo() { # inline\n\tbar\n}",
 	},
+	{
+		"foo() #before\n(\n\tbar #inline\n)",
+		"foo() ( #before\n\tbar #inline\n)",
+	},
+	{
+		"foo() (#before\n\tbar #inline\n)",
+		"foo() ( #before\n\tbar #inline\n)",
+	},
+	{
+		"foo()\n#before-1\n(#before-2\n\tbar #inline\n)",
+		"foo() ( #before-1\n\t#before-2\n\tbar #inline\n)",
+	},
+	{
+		"(#before\n\tbar #inline\n)",
+		"( #before\n\tbar #inline\n)",
+	},
+	{
+		"(\n#before\n\tbar #inline\n)",
+		"(\n\t#before\n\tbar #inline\n)",
+	},
+	{
+		"foo=$(#before\n\tbar #inline\n)",
+		"foo=$( #before\n\tbar #inline\n)",
+	},
+	{
+		"foo=`#before\nbar`",
+		"foo=$( #before\n\tbar\n)",
+	},
 	samePrint("if foo; then\n\tbar\n\t# comment\nfi"),
 	samePrint("if foo; then\n\tbar\n# else commented out\nfi"),
 	samePrint("if foo; then\n\tx\nelse\n\tbar\n\t# comment\nfi"),


### PR DESCRIPTION
Also applies to sub-shell functions and command substitutions (including the deprecated legacy back-tick syntax).

Fixes #839.