### PR TITLE
interp: use custom handler for os.stat/os.Lstat operations

### DIFF
--- a/interp/builtin.go
+++ b/interp/builtin.go
@@ -225,7 +225,7 @@ func (r *Runner) builtinCode(ctx context.Context, pos syntax.Pos, name string, a
 			r.errf("usage: cd [dir]\n")
 			return 2
 		}
-		return r.changeDir(path)
+		return r.changeDir(ctx, path)
 	case "wait":
 		if len(args) > 0 {
 			panic("wait with args not handled yet")
@@ -493,13 +493,13 @@ func (r *Runner) builtinCode(ctx context.Context, pos syntax.Pos, name string, a
 				return 1
 			}
 			newtop := swap()
-			if code := r.changeDir(newtop); code != 0 {
+			if code := r.changeDir(ctx, newtop); code != 0 {
 				return code
 			}
 			r.builtinCode(ctx, syntax.Pos{}, "dirs", nil)
 		case 1:
 			if change {
-				if code := r.changeDir(args[0]); code != 0 {
+				if code := r.changeDir(ctx, args[0]); code != 0 {
 					return code
 				}
 				r.dirStack = append(r.dirStack, r.Dir)
@@ -528,7 +528,7 @@ func (r *Runner) builtinCode(ctx context.Context, pos syntax.Pos, name string, a
 			r.dirStack = r.dirStack[:len(r.dirStack)-1]
 			if change {
 				newtop := r.dirStack[len(r.dirStack)-1]
-				if code := r.changeDir(newtop); code != 0 {
+				if code := r.changeDir(ctx, newtop); code != 0 {
 					return code
 				}
 			} else {
@@ -852,12 +852,12 @@ func (r *Runner) readLine(raw bool) ([]byte, error) {
 	}
 }
 
-func (r *Runner) changeDir(path string) int {
+func (r *Runner) changeDir(ctx context.Context, path string) int {
 	if path == "" {
 		path = "."
 	}
 	path = r.absPath(path)
-	info, err := r.stat(path)
+	info, err := r.stat(ctx, path)
 	if err != nil || !info.IsDir() {
 		return 1
 	}

--- a/interp/handler.go
+++ b/interp/handler.go
@@ -318,12 +318,11 @@ func DefaultReadDirHandler() ReadDirHandlerFunc {
 
 // StatHandlerFunc is a handler which gets the file stat. the first argument provides directory to use as
 // basedir if name is relative path
-type StatHandlerFunc func(ctx context.Context, cwd string, name string, followSymlinks bool) (os.FileInfo, error)
+type StatHandlerFunc func(ctx context.Context, name string, followSymlinks bool) (os.FileInfo, error)
 
 // DefaultStatHandler returns a StatHandlerFunc used by default. It uses os.Stat()
 func DefaultStatHandler() StatHandlerFunc {
-	return func(ctx context.Context, cwd string, name string, followSymlinks bool) (os.FileInfo, error) {
-		path := absPath(cwd, name)
+	return func(ctx context.Context, path string, followSymlinks bool) (os.FileInfo, error) {
 		if !followSymlinks {
 			return os.Lstat(path)
 		} else {

--- a/interp/handler.go
+++ b/interp/handler.go
@@ -315,3 +315,15 @@ func DefaultReadDirHandler() ReadDirHandlerFunc {
 		return ioutil.ReadDir(path)
 	}
 }
+
+// StatHandlerFunc is a handler which gets the file stat. the first argument provides directory to use as
+// basedir if name is relative path
+type StatHandlerFunc func(cwd string, name string) (os.FileInfo, error)
+
+// DefaultStatHandler returns a StatHandlerFunc used by default. It uses os.Stat()
+func DefaultStatHandler() StatHandlerFunc {
+	return func(cwd string, name string) (os.FileInfo, error) {
+		path := absPath(cwd, name)
+		return os.Stat(path)
+	}
+}

--- a/interp/handler.go
+++ b/interp/handler.go
@@ -318,13 +318,13 @@ func DefaultReadDirHandler() ReadDirHandlerFunc {
 
 // StatHandlerFunc is a handler which gets the file stat. the first argument provides directory to use as
 // basedir if name is relative path
-type StatHandlerFunc func(cwd string, name string, lstat bool) (os.FileInfo, error)
+type StatHandlerFunc func(cwd string, name string, followSymlinks bool) (os.FileInfo, error)
 
 // DefaultStatHandler returns a StatHandlerFunc used by default. It uses os.Stat()
 func DefaultStatHandler() StatHandlerFunc {
-	return func(cwd string, name string, lstat bool) (os.FileInfo, error) {
+	return func(cwd string, name string, followSymlinks bool) (os.FileInfo, error) {
 		path := absPath(cwd, name)
-		if lstat {
+		if !followSymlinks {
 			return os.Lstat(path)
 		} else {
 			return os.Stat(path)

--- a/interp/handler.go
+++ b/interp/handler.go
@@ -318,12 +318,16 @@ func DefaultReadDirHandler() ReadDirHandlerFunc {
 
 // StatHandlerFunc is a handler which gets the file stat. the first argument provides directory to use as
 // basedir if name is relative path
-type StatHandlerFunc func(cwd string, name string) (os.FileInfo, error)
+type StatHandlerFunc func(cwd string, name string, lstat bool) (os.FileInfo, error)
 
 // DefaultStatHandler returns a StatHandlerFunc used by default. It uses os.Stat()
 func DefaultStatHandler() StatHandlerFunc {
-	return func(cwd string, name string) (os.FileInfo, error) {
+	return func(cwd string, name string, lstat bool) (os.FileInfo, error) {
 		path := absPath(cwd, name)
-		return os.Stat(path)
+		if lstat {
+			return os.Lstat(path)
+		} else {
+			return os.Stat(path)
+		}
 	}
 }

--- a/interp/handler.go
+++ b/interp/handler.go
@@ -318,11 +318,11 @@ func DefaultReadDirHandler() ReadDirHandlerFunc {
 
 // StatHandlerFunc is a handler which gets the file stat. the first argument provides directory to use as
 // basedir if name is relative path
-type StatHandlerFunc func(cwd string, name string, followSymlinks bool) (os.FileInfo, error)
+type StatHandlerFunc func(ctx context.Context, cwd string, name string, followSymlinks bool) (os.FileInfo, error)
 
 // DefaultStatHandler returns a StatHandlerFunc used by default. It uses os.Stat()
 func DefaultStatHandler() StatHandlerFunc {
-	return func(cwd string, name string, followSymlinks bool) (os.FileInfo, error) {
+	return func(ctx context.Context, cwd string, name string, followSymlinks bool) (os.FileInfo, error) {
 		path := absPath(cwd, name)
 		if !followSymlinks {
 			return os.Lstat(path)

--- a/interp/runner.go
+++ b/interp/runner.go
@@ -916,5 +916,9 @@ func (r *Runner) open(ctx context.Context, path string, flags int, mode os.FileM
 }
 
 func (r *Runner) stat(name string) (os.FileInfo, error) {
-	return r.statHandler(r.Dir, name)
+	return r.statHandler(r.Dir, name, false)
+}
+
+func (r *Runner) lstat(name string) (os.FileInfo, error) {
+	return r.statHandler(r.Dir, name, true)
 }

--- a/interp/runner.go
+++ b/interp/runner.go
@@ -915,10 +915,10 @@ func (r *Runner) open(ctx context.Context, path string, flags int, mode os.FileM
 	return f, err
 }
 
-func (r *Runner) stat(name string) (os.FileInfo, error) {
-	return r.statHandler(r.Dir, name, true)
+func (r *Runner) stat(ctx context.Context, path string) (os.FileInfo, error) {
+	return r.statHandler(ctx, r.Dir, path, true)
 }
 
-func (r *Runner) lstat(name string) (os.FileInfo, error) {
-	return r.statHandler(r.Dir, name, false)
+func (r *Runner) lstat(ctx context.Context, path string) (os.FileInfo, error) {
+	return r.statHandler(ctx, r.Dir, path, false)
 }

--- a/interp/runner.go
+++ b/interp/runner.go
@@ -915,10 +915,12 @@ func (r *Runner) open(ctx context.Context, path string, flags int, mode os.FileM
 	return f, err
 }
 
-func (r *Runner) stat(ctx context.Context, path string) (os.FileInfo, error) {
-	return r.statHandler(ctx, r.Dir, path, true)
+func (r *Runner) stat(ctx context.Context, name string) (os.FileInfo, error) {
+	path := absPath(r.Dir, name)
+	return r.statHandler(ctx, path, true)
 }
 
-func (r *Runner) lstat(ctx context.Context, path string) (os.FileInfo, error) {
-	return r.statHandler(ctx, r.Dir, path, false)
+func (r *Runner) lstat(ctx context.Context, name string) (os.FileInfo, error) {
+	path := absPath(r.Dir, name)
+	return r.statHandler(ctx, path, false)
 }

--- a/interp/runner.go
+++ b/interp/runner.go
@@ -916,9 +916,9 @@ func (r *Runner) open(ctx context.Context, path string, flags int, mode os.FileM
 }
 
 func (r *Runner) stat(name string) (os.FileInfo, error) {
-	return r.statHandler(r.Dir, name, false)
+	return r.statHandler(r.Dir, name, true)
 }
 
 func (r *Runner) lstat(name string) (os.FileInfo, error) {
-	return r.statHandler(r.Dir, name, true)
+	return r.statHandler(r.Dir, name, false)
 }

--- a/interp/runner.go
+++ b/interp/runner.go
@@ -916,5 +916,5 @@ func (r *Runner) open(ctx context.Context, path string, flags int, mode os.FileM
 }
 
 func (r *Runner) stat(name string) (os.FileInfo, error) {
-	return os.Stat(r.absPath(name))
+	return r.statHandler(r.Dir, name)
 }

--- a/interp/test.go
+++ b/interp/test.go
@@ -46,7 +46,7 @@ func (r *Runner) bashTest(ctx context.Context, expr syntax.TestExpr, classic boo
 			}
 			return ""
 		}
-		if r.binTest(x.Op, r.bashTest(ctx, x.X, classic), r.bashTest(ctx, x.Y, classic)) {
+		if r.binTest(ctx, x.Op, r.bashTest(ctx, x.X, classic), r.bashTest(ctx, x.Y, classic)) {
 			return "1"
 		}
 		return ""
@@ -59,7 +59,7 @@ func (r *Runner) bashTest(ctx context.Context, expr syntax.TestExpr, classic boo
 	return ""
 }
 
-func (r *Runner) binTest(op syntax.BinTestOperator, x, y string) bool {
+func (r *Runner) binTest(ctx context.Context, op syntax.BinTestOperator, x, y string) bool {
 	switch op {
 	case syntax.TsReMatch:
 		re, err := regexp.Compile(y)
@@ -69,22 +69,22 @@ func (r *Runner) binTest(op syntax.BinTestOperator, x, y string) bool {
 		}
 		return re.MatchString(x)
 	case syntax.TsNewer:
-		info1, err1 := r.stat(x)
-		info2, err2 := r.stat(y)
+		info1, err1 := r.stat(ctx, x)
+		info2, err2 := r.stat(ctx, y)
 		if err1 != nil || err2 != nil {
 			return false
 		}
 		return info1.ModTime().After(info2.ModTime())
 	case syntax.TsOlder:
-		info1, err1 := r.stat(x)
-		info2, err2 := r.stat(y)
+		info1, err1 := r.stat(ctx, x)
+		info2, err2 := r.stat(ctx, y)
 		if err1 != nil || err2 != nil {
 			return false
 		}
 		return info1.ModTime().Before(info2.ModTime())
 	case syntax.TsDevIno:
-		info1, err1 := r.stat(x)
-		info2, err2 := r.stat(y)
+		info1, err1 := r.stat(ctx, x)
+		info2, err2 := r.stat(ctx, y)
 		if err1 != nil || err2 != nil {
 			return false
 		}
@@ -112,40 +112,40 @@ func (r *Runner) binTest(op syntax.BinTestOperator, x, y string) bool {
 	}
 }
 
-func (r *Runner) statMode(name string, mode os.FileMode) bool {
-	info, err := r.stat(name)
+func (r *Runner) statMode(ctx context.Context, name string, mode os.FileMode) bool {
+	info, err := r.stat(ctx, name)
 	return err == nil && info.Mode()&mode != 0
 }
 
 func (r *Runner) unTest(ctx context.Context, op syntax.UnTestOperator, x string) bool {
 	switch op {
 	case syntax.TsExists:
-		_, err := r.stat(x)
+		_, err := r.stat(ctx, x)
 		return err == nil
 	case syntax.TsRegFile:
-		info, err := r.stat(x)
+		info, err := r.stat(ctx, x)
 		return err == nil && info.Mode().IsRegular()
 	case syntax.TsDirect:
-		return r.statMode(x, os.ModeDir)
+		return r.statMode(ctx, x, os.ModeDir)
 	case syntax.TsCharSp:
-		return r.statMode(x, os.ModeCharDevice)
+		return r.statMode(ctx, x, os.ModeCharDevice)
 	case syntax.TsBlckSp:
-		info, err := r.stat(x)
+		info, err := r.stat(ctx, x)
 		return err == nil && info.Mode()&os.ModeDevice != 0 &&
 			info.Mode()&os.ModeCharDevice == 0
 	case syntax.TsNmPipe:
-		return r.statMode(x, os.ModeNamedPipe)
+		return r.statMode(ctx, x, os.ModeNamedPipe)
 	case syntax.TsSocket:
-		return r.statMode(x, os.ModeSocket)
+		return r.statMode(ctx, x, os.ModeSocket)
 	case syntax.TsSmbLink:
-		info, err := r.lstat(x)
+		info, err := r.lstat(ctx, x)
 		return err == nil && info.Mode()&os.ModeSymlink != 0
 	case syntax.TsSticky:
-		return r.statMode(x, os.ModeSticky)
+		return r.statMode(ctx, x, os.ModeSticky)
 	case syntax.TsUIDSet:
-		return r.statMode(x, os.ModeSetuid)
+		return r.statMode(ctx, x, os.ModeSetuid)
 	case syntax.TsGIDSet:
-		return r.statMode(x, os.ModeSetgid)
+		return r.statMode(ctx, x, os.ModeSetgid)
 	// case syntax.TsGrpOwn:
 	// case syntax.TsUsrOwn:
 	// case syntax.TsModif:
@@ -165,7 +165,7 @@ func (r *Runner) unTest(ctx context.Context, op syntax.UnTestOperator, x string)
 		_, err := exec.LookPath(r.absPath(x))
 		return err == nil
 	case syntax.TsNoEmpty:
-		info, err := r.stat(x)
+		info, err := r.stat(ctx, x)
 		return err == nil && info.Size() > 0
 	case syntax.TsFdTerm:
 		fd := atoi(x)

--- a/interp/test.go
+++ b/interp/test.go
@@ -138,7 +138,7 @@ func (r *Runner) unTest(ctx context.Context, op syntax.UnTestOperator, x string)
 	case syntax.TsSocket:
 		return r.statMode(x, os.ModeSocket)
 	case syntax.TsSmbLink:
-		info, err := os.Lstat(r.absPath(x))
+		info, err := r.lstat(x)
 		return err == nil && info.Mode()&os.ModeSymlink != 0
 	case syntax.TsSticky:
 		return r.statMode(x, os.ModeSticky)


### PR DESCRIPTION
This feature allows intercepting the os.stat/os.Lstat operations in the interp to provide more flexible usage.