### PR TITLE
syntax: simplify unset-or-null with null default to just unset

### DIFF
--- a/syntax/simplify.go
+++ b/syntax/simplify.go
@@ -16,6 +16,7 @@ import "bytes"
 //     Remove redundant quotes                  [[ "$var" == str ]]
 //     Merge negations with unary operators     [[ ! -n $var ]]
 //     Use single quotes to shorten literals    "\$foo"
+//     Remove redundant param expansion colons  ${foo:-}
 func Simplify(n Node) bool {
 	s := simplifier{}
 	Walk(n, s.visit)
@@ -37,6 +38,10 @@ func (s *simplifier) visit(node Node) bool {
 		x.Index = s.removeParensArithm(x.Index)
 		// don't inline params - same as above.
 
+		if x.Exp != nil && x.Exp.Op == DefaultUnsetOrNull && x.Exp.Word == nil {
+			s.modified = true
+			x.Exp.Op = DefaultUnset
+		}
 		if x.Slice == nil {
 			break
 		}

--- a/syntax/simplify_test.go
+++ b/syntax/simplify_test.go
@@ -67,6 +67,10 @@ var simplifyTests = [...]simplifyTest{
 	{"\"fo\\`o\"", "'fo`o'"},
 	noSimple(`fo"o"bar`),
 	noSimple(`foo""bar`),
+
+	// param expansions
+	{`${foo:-}`, `${foo-}`},
+	noSimple(`${foo:-bar}`),
 }
 
 func TestSimplify(t *testing.T) {


### PR DESCRIPTION
If the default for an unset-or-null parameter expansion is null, the or-null part of the expansion is redundant and can be removed. The result is null on match either way.