### PR TITLE
interp: make `read` cancellable via Run's ctx

### DIFF
--- a/interp/api.go
+++ b/interp/api.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -669,14 +668,8 @@ func (r *Runner) Run(ctx context.Context, node syntax.Node) error {
 	if !r.didReset {
 		r.Reset()
 	}
-	if r.stdin != nil {
-		log.Printf("r.stdin is not nil, ctx is %p", ctx)
-		if _, ok := r.stdin.(Canceler); !ok {
-			log.Printf("setting r.stdin to a NewCancelableReader")
-			r.stdin = NewCancelableReader(ctx, r.stdin)
-		}
-	}
-	defer log.Printf("Run returning, ctx is %p", ctx)
+	// log.Printf("Runner.run: stdin: %p", r.stdin)
+	// defer log.Printf("Run returning, ctx is %p", ctx)
 	r.fillExpandConfig(ctx)
 	r.err = nil
 	r.shellExited = false

--- a/interp/api.go
+++ b/interp/api.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -669,10 +670,13 @@ func (r *Runner) Run(ctx context.Context, node syntax.Node) error {
 		r.Reset()
 	}
 	if r.stdin != nil {
+		log.Printf("r.stdin is not nil, ctx is %p", ctx)
 		if _, ok := r.stdin.(Canceler); !ok {
+			log.Printf("setting r.stdin to a NewCancelableReader")
 			r.stdin = NewCancelableReader(ctx, r.stdin)
 		}
 	}
+	defer log.Printf("Run returning, ctx is %p", ctx)
 	r.fillExpandConfig(ctx)
 	r.err = nil
 	r.shellExited = false

--- a/interp/api.go
+++ b/interp/api.go
@@ -668,6 +668,11 @@ func (r *Runner) Run(ctx context.Context, node syntax.Node) error {
 	if !r.didReset {
 		r.Reset()
 	}
+	if r.stdin != nil {
+		if _, ok := r.stdin.(Canceler); !ok {
+			r.stdin = NewCancelableReader(ctx, r.stdin)
+		}
+	}
 	r.fillExpandConfig(ctx)
 	r.err = nil
 	r.shellExited = false

--- a/interp/builtin.go
+++ b/interp/builtin.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -944,6 +945,7 @@ func (r *Runner) readLine(raw bool) ([]byte, error) {
 				esc = false
 			}
 		}
+		log.Printf("readline err: %v", err)
 		if err == io.EOF && len(line) > 0 {
 			return line, nil
 		}

--- a/interp/builtin.go
+++ b/interp/builtin.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -926,19 +925,19 @@ func (r *Runner) readLine(raw bool) ([]byte, error) {
 		return nil, errors.New("interp: can't read, there's no stdin")
 	}
 
-	log.Printf("readLine")
+	// log.Printf("readLine")
 	stdin := r.stdin
 	if eofWriter, ok := stdin.(*EofWriter); ok {
-		log.Printf("readLine starting NewEofReader")
-		cr, err := NewEofReader(r.ectx, eofWriter)
+		// log.Printf("readLine starting NewEofReader")
+		eofReader, err := NewEofReader(r.ectx, eofWriter)
 		if err != nil {
 			return nil, err
 		}
-		stdin = cr
+		stdin = eofReader
 		defer func() {
-			if !cr.eof {
-				log.Printf("readLine: eofWriter.EOF()")
-				eofWriter.EOF()
+			if !eofReader.Eof() {
+				// log.Printf("readLine: eofWriter.EOF()")
+				eofWriter.SendEof()
 			}
 		}()
 
@@ -956,7 +955,7 @@ func (r *Runner) readLine(raw bool) ([]byte, error) {
 	for {
 		var buf [1]byte
 		n, err := stdin.Read(buf[:])
-		log.Printf("readline read %q, %d, %v", buf[:n], n, err)
+		// log.Printf("readline read %q, %d, %v", buf[:n], n, err)
 		if n > 0 {
 			b := buf[0]
 			switch {

--- a/interp/builtin.go
+++ b/interp/builtin.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -925,26 +926,10 @@ func (r *Runner) readLine(raw bool) ([]byte, error) {
 		return nil, errors.New("interp: can't read, there's no stdin")
 	}
 
-	// log.Printf("readLine")
+	log.Printf("readLine")
 	stdin := r.stdin
 	if eofWriter, ok := stdin.(*EofWriter); ok {
-		// log.Printf("readLine starting NewEofReader")
-		eofReader, err := eofWriter.NewReader(r.ectx)
-		if err != nil {
-			return nil, err
-		}
-		stdin = eofReader
-		defer func() {
-			// log.Printf("readLine: eofWriter.EOF()")
-			eofWriter.CloseReader()
-		}()
-
-		// go func() {
-		// 	log.Printf("readLine cancel goroutine sleeping 5s")
-		// 	time.Sleep(5 * time.Second)
-		// 	log.Printf("readLine cancelling the EofReader")
-		// 	cr.Cancel()
-		// }()
+		stdin = eofWriter.R
 	}
 
 	var line []byte
@@ -953,7 +938,7 @@ func (r *Runner) readLine(raw bool) ([]byte, error) {
 	for {
 		var buf [1]byte
 		n, err := stdin.Read(buf[:])
-		// log.Printf("readline read %q, %d, %v", buf[:n], n, err)
+		log.Printf("readline read %q, %d, %v", buf[:n], n, err)
 		if n > 0 {
 			b := buf[0]
 			switch {

--- a/interp/builtin.go
+++ b/interp/builtin.go
@@ -929,16 +929,14 @@ func (r *Runner) readLine(raw bool) ([]byte, error) {
 	stdin := r.stdin
 	if eofWriter, ok := stdin.(*EofWriter); ok {
 		// log.Printf("readLine starting NewEofReader")
-		eofReader, err := NewEofReader(r.ectx, eofWriter)
+		eofReader, err := eofWriter.NewReader(r.ectx)
 		if err != nil {
 			return nil, err
 		}
 		stdin = eofReader
 		defer func() {
-			if !eofReader.Eof() {
-				// log.Printf("readLine: eofWriter.EOF()")
-				eofWriter.SendEof()
-			}
+			// log.Printf("readLine: eofWriter.EOF()")
+			eofWriter.CloseReader()
 		}()
 
 		// go func() {

--- a/interp/handler.go
+++ b/interp/handler.go
@@ -100,15 +100,13 @@ func DefaultExecHandler(killTimeout time.Duration) ExecHandlerFunc {
 		}
 
 		stdin := hc.Stdin
-		var eofReader io.ReadCloser
 		eofWriter, ok := stdin.(*EofWriter)
 		if ok {
-			eofReader, err = eofWriter.NewReader(ctx)
+			log.Printf("DefaultExecHandler: %s: eofReader: %p", path, eofWriter.R)
+			stdin, err = eofWriter.GetReader()
 			if err != nil {
 				return err
 			}
-			log.Printf("DefaultExecHandler: %s: eofReader: %p", path, eofReader)
-			stdin = eofReader
 		}
 
 		cmd := exec.Cmd{
@@ -153,10 +151,9 @@ func DefaultExecHandler(killTimeout time.Duration) ExecHandlerFunc {
 			// 	log.Printf("eofWriter.EOF error: %v", eofErr)
 			// }
 		}
-		if eofWriter != nil {
-			log.Printf("interp/handler: EofWriter.CloseReader(), %p", eofReader)
-			eofWriter.CloseReader()
-		}
+		// if eofWriter != nil {
+		// 	eofWriter.CloseReader()
+		// }
 
 		switch x := err.(type) {
 		case *exec.ExitError:

--- a/interp/handler.go
+++ b/interp/handler.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -107,6 +108,7 @@ func DefaultExecHandler(killTimeout time.Duration) ExecHandlerFunc {
 			Stderr: hc.Stderr,
 		}
 
+		log.Printf("cmd.Start: %s", path)
 		err = cmd.Start()
 		if err == nil {
 			if done := ctx.Done(); done != nil {
@@ -129,7 +131,13 @@ func DefaultExecHandler(killTimeout time.Duration) ExecHandlerFunc {
 				}()
 			}
 
+			// if stdin, ok := hc.Stdin.(Canceler); ok {
+			// 	log.Printf("cmd: cancel stdin read")
+			// 	stdin.Cancel()
+			// }
+			log.Printf("cmd.Wait")
 			err = cmd.Wait()
+			log.Printf("cmd.Wait done")
 		}
 
 		switch x := err.(type) {

--- a/interp/reader.go
+++ b/interp/reader.go
@@ -3,6 +3,7 @@ package interp
 import (
 	"context"
 	"io"
+	"log"
 	"sync"
 )
 
@@ -13,21 +14,47 @@ var _ Canceler = (*CancelableReaderTTY)(nil)
 var _ fder = (*CancelableReaderTTY)(nil)
 
 type CancelableReader struct {
+	// Don't allow overlapping reads
+	readMux sync.Mutex
+
+	// Context for the whole reader.  Cancelling this cancels the whole reader.
 	ctx    context.Context
 	cancel context.CancelFunc
-	in     chan []byte
-	out    chan readResult
-	err    error
-	r      io.Reader
-	once   sync.Once
+
+	// Protect access to rdCtx/rdCancel
+	ctxMux sync.Mutex
+
+	// Context for a single Read.  Cancelling this cancels a single Read.
+	rdCtx    context.Context
+	rdCancel context.CancelFunc
+
+	// run's input queue
+	in chan *readReq
+
+	// The reader we're wrapping
+	r io.Reader
+
+	// Only start run() once.
+	once sync.Once
+
+	// Counters that help keep track of stuff during debugging.
+	readId int
+	runId  int
 }
 
+// If r has an Fd method, we should too.
 type CancelableReaderTTY struct {
-	CancelableReader
+	*CancelableReader
 }
 
 type Canceler interface {
 	Cancel()
+}
+
+type readReq struct {
+	ctx context.Context
+	buf []byte
+	out chan readResult
 }
 
 type readResult struct {
@@ -35,76 +62,236 @@ type readResult struct {
 	err error
 }
 
+var (
+	mux    sync.RWMutex
+	allCRs = map[io.Reader]io.Reader{}
+)
+
 func NewCancelableReader(ctx context.Context, r io.Reader) io.Reader {
-	ctx, cancel := context.WithCancel(ctx)
-	c := CancelableReader{
-		r:      r,
-		ctx:    ctx,
-		cancel: cancel,
-		in:     make(chan []byte),
-		out:    make(chan readResult),
+	// If there's already a CancelableReader for this r, return it.
+	mux.RLock()
+	c, ok := allCRs[r]
+	mux.RUnlock()
+	if ok {
+		log.Printf("Reusing CancelableReader from %p", r)
+		return c
 	}
+	log.Printf("Starting new CancelableReader for %p", r)
+
+	ctx, cancel := context.WithCancel(ctx)
+	rdCtx, rdCancel := context.WithCancel(ctx)
+
+	log.Printf("Setting rdCtx to %p", rdCtx)
+	c = &CancelableReader{
+		r:        r,
+		ctx:      ctx,
+		cancel:   cancel,
+		rdCtx:    rdCtx,
+		rdCancel: rdCancel,
+		in:       make(chan *readReq),
+	}
+
 	// Make sure [[ -t 0 ]] still works
 	if _, ok := r.(fder); ok {
-		return &CancelableReaderTTY{
-			CancelableReader: c,
+		c = &CancelableReaderTTY{
+			CancelableReader: c.(*CancelableReader),
 		}
 	}
-	return &c
+
+	mux.Lock()
+	allCRs[r] = c
+	mux.Unlock()
+
+	// Clean up allCRs
+	go func() {
+		<-ctx.Done()
+		mux.Lock()
+		delete(allCRs, r)
+		mux.Unlock()
+	}()
+
+	return c
 }
 
 // Read implements the io.Reader interface
 func (c *CancelableReader) Read(p []byte) (int, error) {
-	c.once.Do(func() { go c.begin() })
+	if err := c.ctx.Err(); err != nil {
+		return 0, err
+	}
 
-	// Send the buffer over to the reader goroutine
+	c.readMux.Lock()
+	defer c.readMux.Unlock()
+
+	id := c.readId
+	c.readId++
+
+	log.Printf("CancelableReader.Read: id %v with p %p of cap %d", id, p, cap(p))
+
+	c.ctxMux.Lock()
+
+	// Sometimes the user cancels the read before even calling it.
+	if c.rdCtx.Err() != nil {
+		log.Printf("rdCtx %p err is '%v'", c.rdCtx, c.rdCtx.Err())
+		c.rdCtx, c.rdCancel = context.WithCancel(c.ctx)
+		log.Printf("CancelableReader.Read: id %v: rdCtx is already cancelled; setting it to %p",
+			id, c.rdCtx)
+		c.ctxMux.Unlock()
+		return 0, io.EOF
+	}
+
+	c.rdCancel()
+	rdCtx, rdCancel := context.WithCancel(c.ctx)
+	c.rdCtx, c.rdCancel = rdCtx, rdCancel
+	log.Printf("starting read: set rdCtx to %p", c.rdCtx)
+
+	c.ctxMux.Unlock()
+
+	defer func() {
+		c.ctxMux.Lock()
+
+		// Clean up rdCtx, in case we haven't yet.
+		rdCancel()
+		// Allow cancelling the next Read before it starts.
+		c.rdCtx, c.rdCancel = context.WithCancel(c.ctx)
+
+		log.Printf("ending read: set rdCtx to %p", c.rdCtx)
+		c.ctxMux.Unlock()
+	}()
+
+	c.once.Do(func() { go c.run(id) })
+
+	// Allocate a private buffer: if we start a read and then they cancel
+	// it, we don't want to be writing on a buffer we don't own any more.
+	buf := make([]byte, len(p))
+
+	req := &readReq{ctx: rdCtx, buf: buf, out: make(chan readResult)}
+
+	// Send the request over to the reader goroutine
 	select {
-	case c.in <- p:
-	case <-c.ctx.Done():
-		return 0, c.ctx.Err()
+	case c.in <- req:
+		log.Printf("CancelableReader.Read: (from %v) sent buffer p %p of len %d", id, p, len(buf))
+
+	case <-rdCtx.Done():
+		log.Printf("CancelableReader.Read: (from %v) ctx done 1 with p %p of len %d", id, p, len(buf))
+		// If the outer context has not been cancelled, just return EOF.  If we
+		// don't return *some* error, they'll just call Read again.
+		if c.ctx.Err() == nil {
+			return 0, io.EOF
+		}
+		return 0, rdCtx.Err()
 	}
 
 	// Get the output from the reader goroutine.
 	select {
-	case res, ok := <-c.out:
-		if !ok {
-			return 0, c.err
+	case res := <-req.out:
+		// Hope they don't cancel before we return!  Or if they do, hope they
+		// don't do anything with p, 'cause we're about to write on it.
+
+		log.Printf("CancelableReader.Read: (from %v) got results %q, %d, %v, p %p",
+			id, buf[:res.n], res.n, res.err, p)
+		if res.n > 0 {
+			copy(p, buf[:res.n])
+		}
+		if res.err != nil {
+			log.Printf("CancelableReader.Read: (from %v) c.cancel()", id)
+			c.cancel()
 		}
 		return res.n, res.err
-	case <-c.ctx.Done():
-		return 0, c.ctx.Err()
+
+	case <-rdCtx.Done():
+		log.Printf("CancelableReader.Read: (from %v) ctx done 2, p %p of len %d",
+			id, p, len(p))
+		if c.ctx.Err() == nil {
+			return 0, io.EOF
+		}
+		return 0, rdCtx.Err()
 	}
 }
 
 // Close implements the io.Closer interface.
 func (c *CancelableReader) Close() error {
-	close(c.in)
+	if err := c.ctx.Err(); err != nil {
+		return err
+	}
+	c.cancel()
 	if closer, ok := c.r.(io.Closer); ok {
 		return closer.Close()
 	}
 	return nil
 }
 
-func (c *CancelableReader) begin() {
+func (c *CancelableReader) run(rn int) {
+	log.Printf("CancelableReader.run starting (from %v)", rn)
+	defer log.Printf("CancelableReader.run exiting (from %v)", rn)
+
+	type typeahead struct {
+		data []byte // n is implicitly len(data)
+		err  error
+	}
+	var ta *typeahead
+
 	for c.ctx.Err() == nil {
+		id := c.runId
+		c.runId++
+
+		log.Printf("CancelableReader.run: (from %v) select", id)
+
+		var n int
+		var err error
+		var req *readReq
+
 		select {
-		case buf, ok := <-c.in:
-			if !ok {
-				return
+		case req = <-c.in:
+			// If we have typeahead info left over from the previous read, return
+			// it.
+			if ta != nil {
+				log.Printf("CancelableReader.run: (from %v) using typeahead, len %d",
+					id, len(ta.data))
+				n = copy(req.buf, ta.data)
+				if n < len(ta.data) {
+					// We didn't return all the typeahead that we actually have.  err remains nil
+					ta.data = ta.data[n:]
+					log.Printf("CancelableReader.run: (from %v) %d bytes of typeahead remain",
+						id, len(ta.data))
+				} else {
+					log.Printf("CancelableReader.run: (from %v) clearing typeahead", id)
+					err = ta.err
+					ta = nil
+				}
+				break
 			}
-			n, err := c.r.Read(buf)
-			select {
-			case c.out <- readResult{n: n, err: err}:
-			case <-c.ctx.Done():
-				return
-			}
+
+			log.Printf("CancelableReader.run: (from %v) calling Read buf %p", id, req.buf)
+			n, err = c.r.Read(req.buf)
+			log.Printf("CancelableReader.run: (from %v) Read returned on buf %p: %d, %v, active: %t",
+				id, req.buf[:n], n, err, req.ctx.Err() == nil)
 		case <-c.ctx.Done():
+			log.Printf("CancelableReader.run: (from %v) ctx done 3", id)
+			return
+		}
+
+		select {
+		case req.out <- readResult{n: n, err: err}:
+			log.Printf("CancelableReader.run: (from %v) sent results in buf %p: %d, %v", id, req.buf[:n], n, err)
+		case <-req.ctx.Done():
+			// Cancelled before we could send the response.  Save it in the
+			// typeahead buffer.
+			log.Printf("CancelableReader.run: (from %v) ctx done 4 (buf %p); storing typeahead", id, req.buf[:n])
+			buf2 := make([]byte, n)
+			copy(buf2, req.buf[:n])
+			ta = &typeahead{
+				data: buf2,
+				err:  err,
+			}
 		}
 	}
 }
 
 func (c *CancelableReader) Cancel() {
-	c.cancel()
+	c.ctxMux.Lock()
+	log.Printf("cancel: ctx is %p, cancel is %p", c.rdCtx, c.rdCancel)
+	c.rdCancel()
+	c.ctxMux.Unlock()
 }
 
 func (ct *CancelableReaderTTY) Fd() uintptr {

--- a/interp/reader.go
+++ b/interp/reader.go
@@ -2,256 +2,205 @@ package interp
 
 import (
 	"context"
-	"errors"
+	"encoding/binary"
 	"io"
 	"log"
-	"sync"
-	"sync/atomic"
+	"os"
 )
 
-var _ io.Reader = (*CancelableReader)(nil)
-var _ io.Reader = (*CancelableReaderTTY)(nil)
-var _ Canceler = (*CancelableReader)(nil)
-var _ Canceler = (*CancelableReaderTTY)(nil)
-var _ fder = (*CancelableReaderTTY)(nil)
+const (
+	Data = iota
+	EOF
+)
 
-type CancelableReader struct {
-	// Don't allow overlapping reads
-	readMux sync.Mutex
-	closed  int32
+type EofWriter struct {
+	// wr io.Reader
+	pw *os.File
+	pr *os.File
+}
 
+type EofReader struct {
 	ctx    context.Context
 	cancel context.CancelFunc
-	// rdCtx    context.Context
-	// rdCancel context.CancelFunc
 
-	// run's input queue
-	in  chan *readReq
-	out chan *readResult
+	// The wrapped reader
+	wr *EofWriter
+	// We read from wr and write on this, which is the "write" half of a pipe.
+	pw *os.File
 
-	typeahead *readResult
+	// Caller reads from this, which is the "read" half of a pipe.
+	R *os.File
 
-	// The reader we're wrapping
-	R io.Reader
-
-	// Only start run() once.
-	once sync.Once
-
-	// Counters that help keep track of stuff during debugging.
-	readId int
-	runId  int
-}
-
-// If R has an Fd method, we should too.
-type CancelableReaderTTY struct {
-	*CancelableReader
-}
-
-type Canceler interface {
-	Cancel()
-}
-
-type readReq struct {
-	p []byte
-}
-
-type readResult struct {
-	p   []byte
+	eof bool
 	err error
 }
 
-var (
-	mux sync.RWMutex
-)
+func NewEofWriter() (*EofWriter, error) {
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		return nil, err
+	}
+	eofWriter := &EofWriter{
+		// wr: r,
+		pw: pw,
+		pr: pr,
+	}
 
-func NewCancelableReader(ctx context.Context, r io.Reader) io.Reader {
-	log.Printf("Starting new CancelableReader for %p", r)
+	return eofWriter, nil
+}
+
+func (e *EofWriter) Write(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+
+	buf := make([]byte, 3+len(p))
+	buf[0] = Data
+	binary.LittleEndian.PutUint16(buf[1:], uint16(len(p)))
+	copy(buf[3:], p)
+	n, err := e.pw.Write(buf[:])
+	if err != nil {
+		log.Printf("EOFWriter.Write: error writing msg: %v", err)
+		return n, err
+	}
+	if n < len(buf) {
+		log.Printf("EOFWriter.Write: error writing msg: wanted to write %d bytes, only wrote %d",
+			len(buf), n)
+	}
+	log.Printf("EOFWriter.run: Wrote data %q, size %d", buf[3:n], n-3)
+	return n, nil
+}
+
+func (e *EofWriter) EOF() error {
+	_, err := e.pw.Write([]byte{EOF, 0, 0})
+	log.Printf("EOFWriter.EOF: Wrote EOF, err: %v", err)
+	return err
+}
+
+func (e *EofWriter) Read(p []byte) (int, error) {
+	return e.pr.Read(p)
+}
+
+func (e *EofWriter) Close() error {
+	err := e.pw.Close()
+	err2 := e.pr.Close()
+	if err != nil {
+		return err
+	}
+	if err2 != nil {
+		return err2
+	}
+	return nil
+}
+
+func NewEofReader(ctx context.Context, r *EofWriter) (*EofReader, error) {
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		return nil, err
+	}
 
 	// rdCtx, rdCancel := context.WithCancel(ctx)
 	ctx, cancel := context.WithCancel(ctx)
-	c := io.Reader(&CancelableReader{
-		R:      r,
+	c := &EofReader{
+		wr:     r,
+		pw:     pw,
+		R:      pr,
 		ctx:    ctx,
 		cancel: cancel,
-		// rdCtx:    rdCtx,
-		// rdCancel: rdCancel,
-		in:  make(chan *readReq),
-		out: make(chan *readResult),
-	})
-
-	// Make sure [[ -t 0 ]] still works
-	if _, ok := r.(fder); ok {
-		c = &CancelableReaderTTY{
-			CancelableReader: c.(*CancelableReader),
-		}
 	}
 
-	return c
+	log.Printf("Starting new EofReader: %p", c)
+
+	go func() {
+		<-ctx.Done()
+		log.Printf("EofReader %p: context cancelled: closing pw & pr", c)
+		c.Close()
+	}()
+
+	go c.run()
+
+	return c, nil
 }
 
-// Read implements the io.Reader interface
-func (c *CancelableReader) Read(p []byte) (int, error) {
-	if atomic.LoadInt32(&c.closed) == 1 {
-		return 0, errors.New("Read on closed CancelableReader")
-	}
-
-	if err := c.ctx.Err(); err != nil {
-		return 0, err
-	}
-
-	c.readMux.Lock()
-	defer c.readMux.Unlock()
-
-	// if c.typeahead != nil {
-	// 	n := copy(p, c.typeahead.p)
-	// 	err := c.typeahead.err
-	// 	if n < len(c.typeahead.p) {
-	// 		c.typeahead.p = c.typeahead.p[n:]
-	// 		err = nil
-	// 	} else {
-	// 		c.typeahead = nil
-	// 	}
-	// 	return n, err
-	// }
-
-	// defer func() {
-	// 	if c.rdCtx.Err() != nil {
-	// 		c.rdCtx, c.rdCancel = context.WithCancel(c.ctx)
-	// 	}
-	// }()
-
-	id := c.readId
-	c.readId++
-
-	log.Printf("CancelableReader.Read: id %v with p %p of cap %d", id, p, cap(p))
-
-	c.once.Do(func() { go c.run(id) })
-
-	// Allocate a private buffer: if we start a read and then they cancel
-	// it, we don't want to be writing on a buffer we don't own any more if the
-	// Read does eventually read something.
-	buf := make([]byte, len(p))
-	req := &readReq{p: buf}
-	// c.rdCtx, c.rdCancel = context.WithCancel(c.ctx)
-
-	// Send the request over to the reader goroutine.
-	select {
-	case c.in <- req:
-		log.Printf("CancelableReader.Read: (from %v) sent buffer p %p of len %d", id, p, len(buf))
-	case <-c.ctx.Done():
-		log.Printf("CancelableReader.Read: (from %v) ctx done 1 with p %p of len %d", id, p, len(buf))
-		return 0, io.EOF
-		// default:
-		// 	// If run is stuck in a read, it won't be listening on c.in, and we'll
-		// 	// fall through to here.
-		// 	log.Printf("CancelableReader.Read: (from %v) c.in is busy; waiting on previous read", id)
-	}
-
-	// Get the output from the reader goroutine.
-	select {
-	case res := <-c.out:
-		log.Printf("CancelableReader.Read: (from %v) got results %q, %v, p %p",
-			id, res.p, res.err, p)
-		copy(p, res.p)
-		return len(res.p), res.err
-
-		// n := len(res.p)
-		// err := res.err
-		// if n > 0 {
-		// 	// Might be copying res.p from a previous read and so it might differ
-		// 	// in length from p
-		// 	n = copy(p, res.p)
-		// 	if n < len(res.p) {
-		// 		c.typeahead = &readResult{
-		// 			p:   res.p[n:],
-		// 			err: res.err,
-		// 		}
-		// 		err = nil
-		// 	}
-		// }
-		// if err != nil {
-		// 	log.Printf("CancelableReader.Read: (from %v) err: %v", id, res.err)
-		// }
-		// return n, err
-
-	case <-c.ctx.Done():
-		log.Printf("CancelableReader.Read: (from %v) ctx done 2, p %p of len %d",
-			id, p, len(p))
-		return 0, io.EOF
-	}
-}
-
-func (c *CancelableReader) run(rn int) {
-	log.Printf("CancelableReader.run starting (from %v)", rn)
-	defer log.Printf("CancelableReader.run exiting (from %v)", rn)
-
-	// var typeahead *readResult
-
-	for c.ctx.Err() == nil {
-		id := c.runId
-		c.runId++
-
-		log.Printf("CancelableReader.run: (from %v) select", id)
-
-		var n int
-		var err error
-		var req *readReq
-
-		select {
-		case req = <-c.in:
-			log.Printf("CancelableReader.run: (from %v) calling Read buf %p", id, req.p)
-
-			// if typeahead != nil {
-			// 	n := copy(req.buf, typeahead.buf)
-			// 	err := typeahead.err
-			// 	if n < len(typeahead.buf) {
-			// 		typeahead.buf = typeahead.buf[n:]
-			// 		err = nil
-			// 	} else {
-			// 		typeahead = nil
-			// 	}
-			// 	c.out <- &readResult{buf: req.buf, err: err}
-			// 	continue
-			// }
-
-			n, err = c.R.Read(req.p)
-			req.p = req.p[:n]
-			log.Printf("CancelableReader.run: (from %v) Read returned on buf %p: %d, %v, active: %t",
-				id, req.p, n, err, c.ctx.Err() == nil)
-		case <-c.ctx.Done():
-			log.Printf("CancelableReader.run: (from %v) ctx done 3", id)
+func (c *EofReader) run() {
+	defer log.Printf("EofReader.run %p: returning", c)
+	var header [3]byte
+	for c.err == nil {
+		// Read the header
+		log.Printf("EofReader.run %p: reading header", c)
+		_, err := io.ReadFull(c.wr, header[:])
+		// n, err := c.wr.Read(header[:])
+		if err != nil {
+			c.err = err
+			c.Close()
+			log.Printf("EofReader.run %p: error reading header: %v", c, err)
 			return
 		}
+		// if n != 3 {
+		// 	c.cancel()
+		// 	log.Printf("EofReader.run %p: read %d bytes, expected 3", c, n)
+		// 	return
+		// }
 
-		select {
-		case c.out <- &readResult{p: req.p, err: err}:
-			log.Printf("CancelableReader.run: (from %v) sent results in buf %p: %d, %v", id, req.p, n, err)
-		case <-c.ctx.Done():
+		switch header[0] {
+		case Data:
+			// Read and forward the data block
+			size := binary.LittleEndian.Uint16(header[1:])
+			log.Printf("EofReader.run %p: read Data header, size: %d", c, size)
+			buf := make([]byte, size)
+			_, err = io.ReadFull(c.wr, buf)
+			if err != nil {
+				c.err = err
+				c.Close()
+				log.Printf("EofReader.run %p: error reading data: %v", c, err)
+				return
+			}
+			log.Printf("EofReader.run %p: Writing %q, %d bytes to pw", c, buf, size)
+			_, err = c.pw.Write(buf)
+			if err != nil {
+				// os.Stderr should probably be runner.stderr
+				log.Printf("EofReader.run %p: Error on c.wp.Write: %v", c, err)
+				c.err = err
+				c.Close()
+				return
+			}
+
+		case EOF:
+			if !c.eof {
+				// "send" an EOF by closing the pipe file handles
+				c.Close()
+				log.Printf("EofReader.run %p: \"sending\" eof by closing output pipe", c)
+			}
+			return
 		}
 	}
 }
 
-func (c *CancelableReader) Cancel() {
-	log.Printf("cancel: ctx is %p, cancel is %p", c.ctx, c.cancel)
+// Read implements io.Reader.
+func (c *EofReader) Read(p []byte) (int, error) {
+	return c.R.Read(p)
+}
+
+func (c *EofReader) Cancel() {
+	log.Printf("EofReader %p: cancel", c)
 	c.cancel()
 }
 
-func (ct *CancelableReaderTTY) Fd() uintptr {
-	return ct.R.(fder).Fd()
-}
-
-// Close implements the io.Closer interface.
-func (c *CancelableReader) Close() error {
-	if err := c.ctx.Err(); err != nil {
-		return err
-	}
-	if atomic.CompareAndSwapInt32(&c.closed, 0, 1) {
-		c.cancel()
-		if closer, ok := c.R.(io.Closer); ok {
-			return closer.Close()
-		}
+// TODO: should protect eof with a lock
+func (c *EofReader) Close() {
+	if c.eof {
+		log.Printf("EofReader %p: Close called after eof", c)
 	} else {
-		return errors.New("Close on already-closed CancelableReader")
+		c.eof = true
+		log.Printf("EofReader %p: Close", c)
+		err := c.pw.Close()
+		if err != nil {
+			log.Printf("EofReader.Close %p: pw.Close error: %v", c, err)
+		}
+		err = c.R.Close()
+		if err != nil {
+			log.Printf("EofReader.Close %p: R.Close error: %v", c, err)
+		}
+		c.cancel()
 	}
-	return nil
 }

--- a/interp/reader.go
+++ b/interp/reader.go
@@ -2,9 +2,11 @@ package interp
 
 import (
 	"context"
+	"errors"
 	"io"
 	"log"
 	"sync"
+	"sync/atomic"
 )
 
 var _ io.Reader = (*CancelableReader)(nil)
@@ -16,12 +18,18 @@ var _ fder = (*CancelableReaderTTY)(nil)
 type CancelableReader struct {
 	// Don't allow overlapping reads
 	readMux sync.Mutex
+	closed  int32
 
 	ctx    context.Context
 	cancel context.CancelFunc
+	// rdCtx    context.Context
+	// rdCancel context.CancelFunc
 
 	// run's input queue
-	in chan *readReq
+	in  chan *readReq
+	out chan *readResult
+
+	typeahead *readResult
 
 	// The reader we're wrapping
 	R io.Reader
@@ -44,38 +52,32 @@ type Canceler interface {
 }
 
 type readReq struct {
-	buf []byte
-	out chan readResult
+	p []byte
 }
 
 type readResult struct {
-	n   int
+	p   []byte
 	err error
 }
 
 var (
-	mux    sync.RWMutex
-	allCRs = map[io.Reader]io.Reader{}
+	mux sync.RWMutex
 )
 
 func NewCancelableReader(ctx context.Context, r io.Reader) io.Reader {
-	// If there's already a CancelableReader for this r, return it.
-	mux.RLock()
-	c, ok := allCRs[r]
-	mux.RUnlock()
-	if ok {
-		log.Printf("Reusing CancelableReader from %p", r)
-		return c
-	}
 	log.Printf("Starting new CancelableReader for %p", r)
 
+	// rdCtx, rdCancel := context.WithCancel(ctx)
 	ctx, cancel := context.WithCancel(ctx)
-	c = &CancelableReader{
+	c := io.Reader(&CancelableReader{
 		R:      r,
 		ctx:    ctx,
 		cancel: cancel,
-		in:     make(chan *readReq),
-	}
+		// rdCtx:    rdCtx,
+		// rdCancel: rdCancel,
+		in:  make(chan *readReq),
+		out: make(chan *readResult),
+	})
 
 	// Make sure [[ -t 0 ]] still works
 	if _, ok := r.(fder); ok {
@@ -84,23 +86,15 @@ func NewCancelableReader(ctx context.Context, r io.Reader) io.Reader {
 		}
 	}
 
-	mux.Lock()
-	allCRs[r] = c
-	mux.Unlock()
-
-	// Clean up allCRs
-	go func() {
-		<-ctx.Done()
-		mux.Lock()
-		delete(allCRs, r)
-		mux.Unlock()
-	}()
-
 	return c
 }
 
 // Read implements the io.Reader interface
 func (c *CancelableReader) Read(p []byte) (int, error) {
+	if atomic.LoadInt32(&c.closed) == 1 {
+		return 0, errors.New("Read on closed CancelableReader")
+	}
+
 	if err := c.ctx.Err(); err != nil {
 		return 0, err
 	}
@@ -108,16 +102,28 @@ func (c *CancelableReader) Read(p []byte) (int, error) {
 	c.readMux.Lock()
 	defer c.readMux.Unlock()
 
+	// if c.typeahead != nil {
+	// 	n := copy(p, c.typeahead.p)
+	// 	err := c.typeahead.err
+	// 	if n < len(c.typeahead.p) {
+	// 		c.typeahead.p = c.typeahead.p[n:]
+	// 		err = nil
+	// 	} else {
+	// 		c.typeahead = nil
+	// 	}
+	// 	return n, err
+	// }
+
+	// defer func() {
+	// 	if c.rdCtx.Err() != nil {
+	// 		c.rdCtx, c.rdCancel = context.WithCancel(c.ctx)
+	// 	}
+	// }()
+
 	id := c.readId
 	c.readId++
 
 	log.Printf("CancelableReader.Read: id %v with p %p of cap %d", id, p, cap(p))
-
-	// Sometimes the user cancels the read before even calling it.
-	if c.ctx.Err() != nil {
-		log.Printf("rdCtx %p err is '%v'", c.ctx, c.ctx.Err())
-		return 0, io.EOF
-	}
 
 	c.once.Do(func() { go c.run(id) })
 
@@ -125,34 +131,48 @@ func (c *CancelableReader) Read(p []byte) (int, error) {
 	// it, we don't want to be writing on a buffer we don't own any more if the
 	// Read does eventually read something.
 	buf := make([]byte, len(p))
+	req := &readReq{p: buf}
+	// c.rdCtx, c.rdCancel = context.WithCancel(c.ctx)
 
-	req := &readReq{buf: buf, out: make(chan readResult)}
-
-	// Send the request over to the reader goroutine
+	// Send the request over to the reader goroutine.
 	select {
 	case c.in <- req:
 		log.Printf("CancelableReader.Read: (from %v) sent buffer p %p of len %d", id, p, len(buf))
 	case <-c.ctx.Done():
 		log.Printf("CancelableReader.Read: (from %v) ctx done 1 with p %p of len %d", id, p, len(buf))
 		return 0, io.EOF
+		// default:
+		// 	// If run is stuck in a read, it won't be listening on c.in, and we'll
+		// 	// fall through to here.
+		// 	log.Printf("CancelableReader.Read: (from %v) c.in is busy; waiting on previous read", id)
 	}
 
 	// Get the output from the reader goroutine.
 	select {
-	case res := <-req.out:
-		// Hope they don't cancel before we return!  Or if they do, hope they
-		// don't do anything with p, 'cause we're about to write on it.
+	case res := <-c.out:
+		log.Printf("CancelableReader.Read: (from %v) got results %q, %v, p %p",
+			id, res.p, res.err, p)
+		copy(p, res.p)
+		return len(res.p), res.err
 
-		log.Printf("CancelableReader.Read: (from %v) got results %q, %d, %v, p %p",
-			id, buf[:res.n], res.n, res.err, p)
-		if res.n > 0 {
-			copy(p, buf[:res.n])
-		}
-		if res.err != nil {
-			log.Printf("CancelableReader.Read: (from %v) c.cancel(), err: %v", id, res.err)
-			c.cancel()
-		}
-		return res.n, res.err
+		// n := len(res.p)
+		// err := res.err
+		// if n > 0 {
+		// 	// Might be copying res.p from a previous read and so it might differ
+		// 	// in length from p
+		// 	n = copy(p, res.p)
+		// 	if n < len(res.p) {
+		// 		c.typeahead = &readResult{
+		// 			p:   res.p[n:],
+		// 			err: res.err,
+		// 		}
+		// 		err = nil
+		// 	}
+		// }
+		// if err != nil {
+		// 	log.Printf("CancelableReader.Read: (from %v) err: %v", id, res.err)
+		// }
+		// return n, err
 
 	case <-c.ctx.Done():
 		log.Printf("CancelableReader.Read: (from %v) ctx done 2, p %p of len %d",
@@ -161,27 +181,11 @@ func (c *CancelableReader) Read(p []byte) (int, error) {
 	}
 }
 
-// Close implements the io.Closer interface.
-func (c *CancelableReader) Close() error {
-	if err := c.ctx.Err(); err != nil {
-		return err
-	}
-	c.cancel()
-	if closer, ok := c.R.(io.Closer); ok {
-		return closer.Close()
-	}
-	return nil
-}
-
 func (c *CancelableReader) run(rn int) {
 	log.Printf("CancelableReader.run starting (from %v)", rn)
 	defer log.Printf("CancelableReader.run exiting (from %v)", rn)
 
-	// type typeahead struct {
-	// 	data []byte // n is implicitly len(data)
-	// 	err  error
-	// }
-	// var ta *typeahead
+	// var typeahead *readResult
 
 	for c.ctx.Err() == nil {
 		id := c.runId
@@ -195,47 +199,34 @@ func (c *CancelableReader) run(rn int) {
 
 		select {
 		case req = <-c.in:
-			// // If we have typeahead info left over from the previous read, return
-			// // it.
-			// if ta != nil {
-			// 	log.Printf("CancelableReader.run: (from %v) using typeahead, len %d",
-			// 		id, len(ta.data))
-			// 	n = copy(req.buf, ta.data)
-			// 	if n < len(ta.data) {
-			// 		// We didn't return all the typeahead that we actually have.  err remains nil
-			// 		ta.data = ta.data[n:]
-			// 		log.Printf("CancelableReader.run: (from %v) %d bytes of typeahead remain",
-			// 			id, len(ta.data))
+			log.Printf("CancelableReader.run: (from %v) calling Read buf %p", id, req.p)
+
+			// if typeahead != nil {
+			// 	n := copy(req.buf, typeahead.buf)
+			// 	err := typeahead.err
+			// 	if n < len(typeahead.buf) {
+			// 		typeahead.buf = typeahead.buf[n:]
+			// 		err = nil
 			// 	} else {
-			// 		log.Printf("CancelableReader.run: (from %v) clearing typeahead", id)
-			// 		err = ta.err
-			// 		ta = nil
+			// 		typeahead = nil
 			// 	}
-			// 	break
+			// 	c.out <- &readResult{buf: req.buf, err: err}
+			// 	continue
 			// }
 
-			log.Printf("CancelableReader.run: (from %v) calling Read buf %p", id, req.buf)
-			n, err = c.R.Read(req.buf)
+			n, err = c.R.Read(req.p)
+			req.p = req.p[:n]
 			log.Printf("CancelableReader.run: (from %v) Read returned on buf %p: %d, %v, active: %t",
-				id, req.buf[:n], n, err, c.ctx.Err() == nil)
+				id, req.p, n, err, c.ctx.Err() == nil)
 		case <-c.ctx.Done():
 			log.Printf("CancelableReader.run: (from %v) ctx done 3", id)
 			return
 		}
 
 		select {
-		case req.out <- readResult{n: n, err: err}:
-			log.Printf("CancelableReader.run: (from %v) sent results in buf %p: %d, %v", id, req.buf[:n], n, err)
+		case c.out <- &readResult{p: req.p, err: err}:
+			log.Printf("CancelableReader.run: (from %v) sent results in buf %p: %d, %v", id, req.p, n, err)
 		case <-c.ctx.Done():
-			// Cancelled before we could send the response.  Save it in the
-			// typeahead buffer.
-			// log.Printf("CancelableReader.run: (from %v) ctx done 4 (buf %p); storing typeahead", id, req.buf[:n])
-			// buf2 := make([]byte, n)
-			// copy(buf2, req.buf[:n])
-			// ta = &typeahead{
-			// 	data: buf2,
-			// 	err:  err,
-			// }
 		}
 	}
 }
@@ -247,4 +238,20 @@ func (c *CancelableReader) Cancel() {
 
 func (ct *CancelableReaderTTY) Fd() uintptr {
 	return ct.R.(fder).Fd()
+}
+
+// Close implements the io.Closer interface.
+func (c *CancelableReader) Close() error {
+	if err := c.ctx.Err(); err != nil {
+		return err
+	}
+	if atomic.CompareAndSwapInt32(&c.closed, 0, 1) {
+		c.cancel()
+		if closer, ok := c.R.(io.Closer); ok {
+			return closer.Close()
+		}
+	} else {
+		return errors.New("Close on already-closed CancelableReader")
+	}
+	return nil
 }

--- a/interp/reader.go
+++ b/interp/reader.go
@@ -1,0 +1,112 @@
+package interp
+
+import (
+	"context"
+	"io"
+	"sync"
+)
+
+var _ io.Reader = (*CancelableReader)(nil)
+var _ io.Reader = (*CancelableReaderTTY)(nil)
+var _ Canceler = (*CancelableReader)(nil)
+var _ Canceler = (*CancelableReaderTTY)(nil)
+var _ fder = (*CancelableReaderTTY)(nil)
+
+type CancelableReader struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+	in     chan []byte
+	out    chan readResult
+	err    error
+	r      io.Reader
+	once   sync.Once
+}
+
+type CancelableReaderTTY struct {
+	CancelableReader
+}
+
+type Canceler interface {
+	Cancel()
+}
+
+type readResult struct {
+	n   int
+	err error
+}
+
+func NewCancelableReader(ctx context.Context, r io.Reader) io.Reader {
+	ctx, cancel := context.WithCancel(ctx)
+	c := CancelableReader{
+		r:      r,
+		ctx:    ctx,
+		cancel: cancel,
+		in:     make(chan []byte),
+		out:    make(chan readResult),
+	}
+	// Make sure [[ -t 0 ]] still works
+	if _, ok := r.(fder); ok {
+		return &CancelableReaderTTY{
+			CancelableReader: c,
+		}
+	}
+	return &c
+}
+
+// Read implements the io.Reader interface
+func (c *CancelableReader) Read(p []byte) (int, error) {
+	c.once.Do(func() { go c.begin() })
+
+	// Send the buffer over to the reader goroutine
+	select {
+	case c.in <- p:
+	case <-c.ctx.Done():
+		return 0, c.ctx.Err()
+	}
+
+	// Get the output from the reader goroutine.
+	select {
+	case res, ok := <-c.out:
+		if !ok {
+			return 0, c.err
+		}
+		return res.n, res.err
+	case <-c.ctx.Done():
+		return 0, c.ctx.Err()
+	}
+}
+
+// Close implements the io.Closer interface.
+func (c *CancelableReader) Close() error {
+	close(c.in)
+	if closer, ok := c.r.(io.Closer); ok {
+		return closer.Close()
+	}
+	return nil
+}
+
+func (c *CancelableReader) begin() {
+	for c.ctx.Err() == nil {
+		select {
+		case buf, ok := <-c.in:
+			if !ok {
+				return
+			}
+			n, err := c.r.Read(buf)
+			select {
+			case c.out <- readResult{n: n, err: err}:
+			case <-c.ctx.Done():
+				return
+			}
+		case <-c.ctx.Done():
+		}
+	}
+}
+
+func (c *CancelableReader) Cancel() {
+	c.cancel()
+}
+
+func (ct *CancelableReaderTTY) Fd() uintptr {
+	return ct.r.(fder).Fd()
+}

--- a/interp/test.go
+++ b/interp/test.go
@@ -16,6 +16,10 @@ import (
 	"mvdan.cc/sh/v3/syntax"
 )
 
+type fder interface {
+	Fd() uintptr
+}
+
 // non-empty string is true, empty string is false
 func (r *Runner) bashTest(ctx context.Context, expr syntax.TestExpr, classic bool) string {
 	switch x := expr.(type) {
@@ -178,7 +182,7 @@ func (r *Runner) unTest(ctx context.Context, op syntax.UnTestOperator, x string)
 		case 2:
 			f = r.stderr
 		}
-		if f, ok := f.(interface{ Fd() uintptr }); ok {
+		if f, ok := f.(fder); ok {
 			// Support Fd methods such as the one on *os.File.
 			return term.IsTerminal(int(f.Fd()))
 		}


### PR DESCRIPTION
- Add a CancelableReader type, and wrap stdin with it at the top of Runner.Run.
- Also include CancelableReaderTTY which preserves stdin looking like a tty, i.e. [[ -t 0 ]] is still true.