### PR TITLE
shfmt: state -ln=auto on posix parse errors

### DIFF
--- a/cmd/shfmt/testdata/scripts/flags.txt
+++ b/cmd/shfmt/testdata/scripts/flags.txt
@@ -98,7 +98,7 @@ stdin input-bash-arrays
 stderr 'parsed as posix via -ln=auto'
 
 stdin input-bash-extglobs
-! shfmt -ln=auto -filename=input.sh
+! shfmt -filename=input.sh
 stderr 'parsed as posix via -ln=auto'
 
 stdin flags-input

--- a/cmd/shfmt/testdata/scripts/flags.txt
+++ b/cmd/shfmt/testdata/scripts/flags.txt
@@ -92,6 +92,15 @@ stdin input-mksh
 shfmt -ln=auto -filename=input.mksh
 stdout 'coprocess'
 
+# Explicitly state language on parse errors
+stdin input-bash-arrays
+! shfmt -ln=auto -filename=input.sh
+stderr 'parsed as posix via -ln=auto'
+
+stdin input-bash-extglobs
+! shfmt -ln=auto -filename=input.sh
+stderr 'parsed as posix via -ln=auto'
+
 stdin flags-input
 shfmt -i 2
 cmp stdout flags-output.indent-golden
@@ -151,6 +160,12 @@ coprocess |&
 -- input-mksh-shebang --
 #!/bin/mksh
 coprocess |&
+-- input-bash-extglobs --
+#!/bin/sh
+echo !(a)
+-- input-bash-arrays --
+#!/bin/sh
+foo=(bar)
 
 -- flags-input --
 foo() {


### PR DESCRIPTION
explicitly state language dialect on `syntax.LangError`s when ln
is set to `auto`

for example, incompatible bash constructs will cause parse errors
due to the parser using posix as language dialect

fixes #803 