### PR TITLE
shfmt: fix typo on FormatPath's

### DIFF
--- a/cmd/shfmt/main.go
+++ b/cmd/shfmt/main.go
@@ -394,7 +394,7 @@ func formatPath(path string, checkShebang bool) error {
 	}
 	readBuf.Reset()
 	if checkShebang || shebangForAuto {
-		n, err := io.ReadAtLeast(f, copyBuf[:32], len("#/bin/sh\n"))
+		n, err := io.ReadAtLeast(f, copyBuf[:32], len("#!/bin/sh\n"))
 		switch {
 		case !checkShebang:
 			// only wanted the shebang for LangAuto


### PR DESCRIPTION
the `io.ReadAtLeast` at a minimum, checks for the shebang
directive but we're missing the `!`