### PR TITLE
syntax: fix whitespace on nested subshells

### DIFF
--- a/syntax/printer.go
+++ b/syntax/printer.go
@@ -1081,6 +1081,13 @@ func (p *Printer) command(cmd Command, redirs []*Redirect) (startRedirs int) {
 		p.WriteByte('(')
 		if len(x.Stmts) > 0 && startsWithLparen(x.Stmts[0]) {
 			p.wantSpace = spaceRequired
+			if nested, ok := x.Stmts[0].Cmd.(*Subshell); ok {
+				// we only want to keep the space between two nested subshells' open brackets
+				// if its in a single line to avoid ambiguity
+				if x.Lparen.Line() != nested.Pos().Line() {
+					p.wantSpace = spaceNotRequired
+				}
+			}
 		} else {
 			p.wantSpace = spaceNotRequired
 		}

--- a/syntax/printer.go
+++ b/syntax/printer.go
@@ -1082,13 +1082,13 @@ func (p *Printer) command(cmd Command, redirs []*Redirect) (startRedirs int) {
 		stmts := x.Stmts
 		if len(stmts) > 0 && startsWithLparen(stmts[0]) {
 			p.wantSpace = spaceRequired
-			// we only want to keep the space between two nested subshells' open brackets
-			// if its in a single line to avoid ambiguity
-			if x.Lparen.Line() != stmts[0].Pos().Line() || len(stmts) > 1 && !p.singleLine {
+			// Add a space between nested parentheses if we're printing them in a single line,
+			// to avoid the ambiguity between `((` and `( (`.
+			if (x.Lparen.Line() != stmts[0].Pos().Line() || len(stmts) > 1) && !p.singleLine {
 				p.wantSpace = spaceNotRequired
 
 				if p.minify {
-					p.newline(stmts[0].Pos())
+					p.mustNewline = true
 				}
 			}
 		} else {
@@ -1349,7 +1349,7 @@ func (p *Printer) stmtList(stmts []*Stmt, last []Comment) {
 			// statement.
 			p.comments(c)
 		}
-		if !p.minify || p.wantSpace == spaceRequired {
+		if p.mustNewline || !p.minify || p.wantSpace == spaceRequired {
 			p.newlines(pos)
 		}
 		p.line = pos.Line()

--- a/syntax/printer.go
+++ b/syntax/printer.go
@@ -1079,14 +1079,13 @@ func (p *Printer) command(cmd Command, redirs []*Redirect) (startRedirs int) {
 		p.ifClause(x, false)
 	case *Subshell:
 		p.WriteByte('(')
-		if len(x.Stmts) > 0 && startsWithLparen(x.Stmts[0]) {
+		stmts := x.Stmts
+		if len(stmts) > 0 && startsWithLparen(stmts[0]) {
 			p.wantSpace = spaceRequired
-			if nested, ok := x.Stmts[0].Cmd.(*Subshell); ok {
-				// we only want to keep the space between two nested subshells' open brackets
-				// if its in a single line to avoid ambiguity
-				if x.Lparen.Line() != nested.Pos().Line() {
-					p.wantSpace = spaceNotRequired
-				}
+			// we only want to keep the space between two nested subshells' open brackets
+			// if its in a single line to avoid ambiguity
+			if x.Lparen.Line() != stmts[0].Pos().Line() || len(stmts) > 1 {
+				p.wantSpace = spaceNotRequired
 			}
 		} else {
 			p.wantSpace = spaceNotRequired

--- a/syntax/printer.go
+++ b/syntax/printer.go
@@ -1084,12 +1084,17 @@ func (p *Printer) command(cmd Command, redirs []*Redirect) (startRedirs int) {
 			p.wantSpace = spaceRequired
 			// we only want to keep the space between two nested subshells' open brackets
 			// if its in a single line to avoid ambiguity
-			if x.Lparen.Line() != stmts[0].Pos().Line() || len(stmts) > 1 {
+			if x.Lparen.Line() != stmts[0].Pos().Line() || len(stmts) > 1 && !p.singleLine {
 				p.wantSpace = spaceNotRequired
+
+				if p.minify {
+					p.newline(stmts[0].Pos())
+				}
 			}
 		} else {
 			p.wantSpace = spaceNotRequired
 		}
+
 		p.spacePad(stmtsPos(x.Stmts, x.Last))
 		p.nestedStmts(x.Stmts, x.Last, x.Rparen)
 		p.wantSpace = spaceNotRequired

--- a/syntax/printer_test.go
+++ b/syntax/printer_test.go
@@ -616,6 +616,28 @@ var printTests = []printCase{
 		"`declare`",
 		"$(declare)",
 	},
+	{
+		"(\n(foo >redir))",
+		"(\n\t(foo >redir)\n)",
+	},
+	{
+		"( (foo) )",
+		"( (foo))",
+	},
+	{
+		"( (foo); bar )",
+		"(\n\t(foo)\n\tbar\n)",
+	},
+	{
+		"( ((foo++)) )",
+		"( ((foo++)))",
+	},
+	{
+		"( ((foo++)); bar )",
+		"(\n\t((foo++))\n\tbar\n)",
+	},
+	samePrint("(\n\t((foo++))\n)"),
+	samePrint("(foo && bar)"),
 }
 
 func TestPrintWeirdFormat(t *testing.T) {
@@ -1303,28 +1325,6 @@ func TestPrintManyStmts(t *testing.T) {
 		{"foo\nbar <<EOF\nbody\nEOF\n", "foo\nbar <<EOF\nbody\nEOF\n"},
 		{"foo\nbar # inline", "foo\nbar # inline\n"},
 		{"# comment before\nfoo bar", "# comment before\nfoo bar\n"},
-		{
-			"(\n(foo >redir)\n)",
-			"(\n\t(foo >redir)\n)\n",
-		},
-		{
-			"( (foo) )",
-			"( (foo))\n",
-		},
-		{
-			"( (foo); bar )",
-			"(\n\t(foo)\n\tbar\n)\n",
-		},
-		{
-			"( ((foo++)) )",
-			"( ((foo++)))\n",
-		},
-		{
-			"( ((foo++)); bar )",
-			"(\n\t((foo++))\n\tbar\n)\n",
-		},
-		samePrint("(\n\t((foo++))\n)\n"),
-		samePrint("(foo && bar)\n"),
 	}
 	parser := NewParser(KeepComments(true))
 	printer := NewPrinter()

--- a/syntax/printer_test.go
+++ b/syntax/printer_test.go
@@ -616,6 +616,14 @@ var printTests = []printCase{
 		"`declare`",
 		"$(declare)",
 	},
+	{
+		"(\n(foo >redir)\n)",
+		"(\n\t(foo >redir)\n)",
+	},
+	{
+		"( (foo >redir) )",
+		"( (foo >redir))",
+	},
 }
 
 func TestPrintWeirdFormat(t *testing.T) {

--- a/syntax/printer_test.go
+++ b/syntax/printer_test.go
@@ -621,9 +621,19 @@ var printTests = []printCase{
 		"(\n\t(foo >redir)\n)",
 	},
 	{
-		"( (foo >redir) )",
-		"( (foo >redir))",
+		"( (foo) )",
+		"( (foo))",
 	},
+	{
+		"( {foo}; bar; )",
+		"(\n\t{foo}\n\tbar\n)",
+	},
+	{
+		"( ((foo++)) )",
+		"( ((foo++)))",
+	},
+	samePrint("(\n\t((foo++))\n)"),
+	samePrint("(foo && bar)"),
 }
 
 func TestPrintWeirdFormat(t *testing.T) {

--- a/syntax/printer_test.go
+++ b/syntax/printer_test.go
@@ -616,24 +616,6 @@ var printTests = []printCase{
 		"`declare`",
 		"$(declare)",
 	},
-	{
-		"(\n(foo >redir)\n)",
-		"(\n\t(foo >redir)\n)",
-	},
-	{
-		"( (foo) )",
-		"( (foo))",
-	},
-	{
-		"( {foo}; bar; )",
-		"(\n\t{foo}\n\tbar\n)",
-	},
-	{
-		"( ((foo++)) )",
-		"( ((foo++)))",
-	},
-	samePrint("(\n\t((foo++))\n)"),
-	samePrint("(foo && bar)"),
 }
 
 func TestPrintWeirdFormat(t *testing.T) {
@@ -1321,6 +1303,28 @@ func TestPrintManyStmts(t *testing.T) {
 		{"foo\nbar <<EOF\nbody\nEOF\n", "foo\nbar <<EOF\nbody\nEOF\n"},
 		{"foo\nbar # inline", "foo\nbar # inline\n"},
 		{"# comment before\nfoo bar", "# comment before\nfoo bar\n"},
+		{
+			"(\n(foo >redir)\n)",
+			"(\n\t(foo >redir)\n)\n",
+		},
+		{
+			"( (foo) )",
+			"( (foo))\n",
+		},
+		{
+			"( (foo); bar )",
+			"(\n\t(foo)\n\tbar\n)\n",
+		},
+		{
+			"( ((foo++)) )",
+			"( ((foo++)))\n",
+		},
+		{
+			"( ((foo++)); bar )",
+			"(\n\t((foo++))\n\tbar\n)\n",
+		},
+		samePrint("(\n\t((foo++))\n)\n"),
+		samePrint("(foo && bar)\n"),
 	}
 	parser := NewParser(KeepComments(true))
 	printer := NewPrinter()


### PR DESCRIPTION
we want white space on nested subshells if its in a single line since
its ambiguous, eg we want `( (` over `((`

this shouldn't be the case for multiple lines- fix the logic that adds
white space to only do so if the two subshells are in the same line

fixes #814