### PR TITLE
interp: allow to register go functions

### DIFF
--- a/interp/gocmd.go
+++ b/interp/gocmd.go
@@ -1,0 +1,48 @@
+package interp
+
+import (
+	"context"
+	"io"
+
+	"mvdan.cc/sh/v3/expand"
+	"mvdan.cc/sh/v3/syntax"
+)
+
+// DeclareGoCommand registers a Go function as if it was a bash command.
+func (r *Runner) DeclareGoCommand(name string, cmd GoCmd) {
+	// FIXME: looks like r.Funcs isn't always allocated
+	if r.Funcs == nil {
+		r.Funcs = make(map[string]*syntax.Stmt)
+	}
+	r.Funcs[name] = &syntax.Stmt{Cmd: goCmdExpr{cmd}}
+}
+
+// GoCmd represents a go function that can be called by the interpreter
+//
+// FIXME: do we really want to expose local variables in the env?
+// FIXME: what about other file descriptors, wouldn't it be best to pass a
+//        list of fds?
+type GoCmd func(ctx context.Context, args []string, env expand.Environ, cwd string, stdin io.Reader, stdout, stderr io.Writer) (exit uint8)
+
+// goCmdExpr extends the syntax.Command with a custom node
+//
+// FIXME: should this struct be moved to the syntax package? Technically it's
+// not a parsed expression so I didn't want to pollute the other package.
+type goCmdExpr struct {
+	fn GoCmd
+}
+
+// FIXME: move to the syntax package?
+var noPos = syntax.Pos{}
+
+func (goCmdExpr) Pos() syntax.Pos {
+	return noPos
+}
+
+func (goCmdExpr) End() syntax.Pos {
+	return noPos
+}
+
+func (goCmdExpr) CommandNode() {}
+
+var _ syntax.Command = goCmdExpr{}

--- a/interp/runner.go
+++ b/interp/runner.go
@@ -641,6 +641,11 @@ func (r *Runner) cmd(ctx context.Context, cm syntax.Command) {
 		// TODO: can we do these?
 		r.outf(format, "user", elapsedString(0, x.PosixFormat))
 		r.outf(format, "sys", elapsedString(0, x.PosixFormat))
+	case goCmdExpr:
+		exit := x.fn(ctx, r.Params, r.writeEnv, r.Dir, r.stdin, r.stdout, r.stderr)
+		if exit > 0 {
+			r.err = returnStatus(exit)
+		}
 	default:
 		panic(fmt.Sprintf("unhandled command node: %T", x))
 	}

--- a/syntax/nodes.go
+++ b/syntax/nodes.go
@@ -214,25 +214,25 @@ func (s *Stmt) End() Pos {
 // *DeclClause, *LetClause, *TimeClause, and *CoprocClause.
 type Command interface {
 	Node
-	commandNode()
+	CommandNode()
 }
 
-func (*CallExpr) commandNode()     {}
-func (*IfClause) commandNode()     {}
-func (*WhileClause) commandNode()  {}
-func (*ForClause) commandNode()    {}
-func (*CaseClause) commandNode()   {}
-func (*Block) commandNode()        {}
-func (*Subshell) commandNode()     {}
-func (*BinaryCmd) commandNode()    {}
-func (*FuncDecl) commandNode()     {}
-func (*ArithmCmd) commandNode()    {}
-func (*TestClause) commandNode()   {}
-func (*DeclClause) commandNode()   {}
-func (*LetClause) commandNode()    {}
-func (*TimeClause) commandNode()   {}
-func (*CoprocClause) commandNode() {}
-func (*TestDecl) commandNode()     {}
+func (*CallExpr) CommandNode()     {}
+func (*IfClause) CommandNode()     {}
+func (*WhileClause) CommandNode()  {}
+func (*ForClause) CommandNode()    {}
+func (*CaseClause) CommandNode()   {}
+func (*Block) CommandNode()        {}
+func (*Subshell) CommandNode()     {}
+func (*BinaryCmd) CommandNode()    {}
+func (*FuncDecl) CommandNode()     {}
+func (*ArithmCmd) CommandNode()    {}
+func (*TestClause) CommandNode()   {}
+func (*DeclClause) CommandNode()   {}
+func (*LetClause) CommandNode()    {}
+func (*TimeClause) CommandNode()   {}
+func (*CoprocClause) CommandNode() {}
+func (*TestDecl) CommandNode()     {}
 
 // Assign represents an assignment to a variable.
 //


### PR DESCRIPTION
As part of the long-running branch in https://github.com/direnv/direnv/tree/gosh, there are a number of bash functions that could be sped up by implementing them in Go instead.

This PR is a bit of a brute-force attempt to see if I could add the capability to this project. It seems to work but I don't know if a solution like that would be acceptable. I'm looking for an initial review to validate the overall approach before continuing on the PR.