### PR TITLE
expand: do not panic on extglob nodes

### DIFF
--- a/expand/expand.go
+++ b/expand/expand.go
@@ -636,6 +636,8 @@ func (cfg *Config) wordFields(wps []syntax.WordPart) ([][]fieldPart, error) {
 				return nil, err
 			}
 			splitAdd(path)
+		case *syntax.ExtGlob:
+			return nil, fmt.Errorf("extended globbing is not supported")
 		default:
 			panic(fmt.Sprintf("unhandled word part: %T", x))
 		}

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -2598,6 +2598,9 @@ set +o pipefail
 		"shopt -s nullglob; touch existing-1; echo missing-* existing-*",
 		"existing-1\n",
 	},
+	// Extended globbing is not supported
+	{"ls ab+(2|3).txt", "extended globbing is not supported\nexit status 1 #JUSTERR"},
+	{"echo *(/)", "extended globbing is not supported\nexit status 1 #JUSTERR"},
 	// Ensure that setting nullglob does not return invalid globs as null
 	// strings.
 	{


### PR DESCRIPTION
we currently don't support bash's `extglob` option and when attempted,
interp panics

fix expand so that we return the error properly and exit with status `1`

fixes #841