### PR TITLE
syntax: parse a redirect edge case without spaces

### DIFF
--- a/syntax/parser.go
+++ b/syntax/parser.go
@@ -1009,7 +1009,7 @@ func (p *Parser) ensureNoNested() {
 
 func (p *Parser) wordPart() WordPart {
 	switch p.tok {
-	case _Lit, _LitWord:
+	case _Lit, _LitWord, _LitRedir:
 		l := p.lit(p.pos, p.val)
 		p.next()
 		return l

--- a/syntax/printer_test.go
+++ b/syntax/printer_test.go
@@ -91,7 +91,7 @@ var printTests = []printCase{
 	{"if a; then b\nelse c\nfi", "if a; then\n\tb\nelse\n\tc\nfi"},
 	samePrint("foo >&2 <f bar"),
 	samePrint("foo >&2 bar <f"),
-	{"foo >&2 bar <f bar2", "foo >&2 bar bar2 <f"},
+	{"foo >&2>/dev/null", "foo >&2 >/dev/null"},
 	{"foo <<EOF bar\nl1\nEOF", "foo bar <<EOF\nl1\nEOF"},
 	samePrint("foo <<\\\\\\\\EOF\nbar\n\\\\EOF"),
 	samePrint("foo <<\"\\EOF\"\nbar\n\\EOF"),


### PR DESCRIPTION
(see commit message)

