### PR TITLE
interp: display all Bash's `shopt` option

### DIFF
--- a/interp/api.go
+++ b/interp/api.go
@@ -185,6 +185,12 @@ func New(opts ...RunnerOption) (*Runner, error) {
 			return nil, err
 		}
 	}
+
+	// turn "on" the default Bash options
+	for i, opt := range bashOptsTable {
+		r.opts[len(shellOptsTable)+i] = opt.defaultState
+	}
+
 	// Set the default fallbacks, if necessary.
 	if r.Env == nil {
 		Env(nil)(r)
@@ -274,7 +280,7 @@ func Params(args ...string) RunnerOption {
 			value := fp.value()
 			if value == "" && enable {
 				for i, opt := range &shellOptsTable {
-					r.printOptLine(opt.name, r.opts[i])
+					r.printOptLine(opt.name, r.opts[i], true)
 				}
 				continue
 			}
@@ -288,7 +294,7 @@ func Params(args ...string) RunnerOption {
 				}
 				continue
 			}
-			opt := r.optByName(value, false)
+			_, opt := r.optByName(value, false)
 			if opt == nil {
 				return fmt.Errorf("invalid option: %q", value)
 			}
@@ -366,28 +372,38 @@ func StdIO(in io.Reader, out, err io.Writer) RunnerOption {
 	}
 }
 
-func (r *Runner) optByName(name string, bash bool) *bool {
+// optByName returns the matching runner's option index and status
+func (r *Runner) optByName(name string, bash bool) (index int, status *bool) {
 	if bash {
-		for i, optName := range bashOptsTable {
-			if optName == name {
-				return &r.opts[len(shellOptsTable)+i]
+		for i, opt := range bashOptsTable {
+			if opt.name == name {
+				index = len(shellOptsTable) + i
+				return index, &r.opts[index]
 			}
 		}
 	}
 	for i, opt := range &shellOptsTable {
 		if opt.name == name {
-			return &r.opts[i]
+			return i, &r.opts[i]
 		}
 	}
-	return nil
+	return 0, nil
 }
 
 type runnerOpts [len(shellOptsTable) + len(bashOptsTable)]bool
 
-var shellOptsTable = [...]struct {
+type shellOpt struct {
 	flag byte
 	name string
-}{
+}
+
+type bashOpt struct {
+	name         string
+	defaultState bool // Bash's default value for this option
+	supported    bool // whether we support the option's non-default state
+}
+
+var shellOptsTable = [...]shellOpt{
 	// sorted alphabetically by name; use a space for the options
 	// that have no flag form
 	{'a', "allexport"},
@@ -399,11 +415,108 @@ var shellOptsTable = [...]struct {
 	{' ', "pipefail"},
 }
 
-var bashOptsTable = [...]string{
-	// sorted alphabetically by name
-	"expand_aliases",
-	"globstar",
-	"nullglob",
+var bashOptsTable = [...]bashOpt{
+	// supported options, sorted alphabetically by name
+	{
+		name:         "expand_aliases",
+		defaultState: false,
+		supported:    true,
+	},
+	{
+		name:         "globstar",
+		defaultState: false,
+		supported:    true,
+	},
+	{
+		name:         "nullglob",
+		defaultState: false,
+		supported:    true,
+	},
+	// unsupported options, sorted alphabetically by name
+	{name: "assoc_expand_once"},
+	{name: "autocd"},
+	{name: "cdable_vars"},
+	{name: "cdspell"},
+	{name: "checkhash"},
+	{name: "checkjobs"},
+	{
+		name:         "checkwinsize",
+		defaultState: true,
+	},
+	{
+		name:         "cmdhist",
+		defaultState: true,
+	},
+	{name: "compat31"},
+	{name: "compat32"},
+	{name: "compat40"},
+	{name: "compat41"},
+	{name: "compat42"},
+	{name: "compat44"},
+	{name: "compat43"},
+	{name: "compat44"},
+	{
+		name:         "complete_fullquote",
+		defaultState: true,
+	},
+	{name: "direxpand"},
+	{name: "dirspell"},
+	{name: "dotglob"},
+	{name: "execfail"},
+	{name: "extdebug"},
+	{name: "extglob"},
+	{
+		name:         "extquote",
+		defaultState: true,
+	},
+	{name: "failglob"},
+	{
+		name:         "force_fignore",
+		defaultState: true,
+	},
+	{name: "globasciiranges"},
+	{name: "gnu_errfmt"},
+	{name: "histappend"},
+	{name: "histreedit"},
+	{name: "histverify"},
+	{
+		name:         "hostcomplete",
+		defaultState: true,
+	},
+	{name: "huponexit"},
+	{
+		name:         "inherit_errexit",
+		defaultState: true,
+	},
+	{
+		name:         "interactive_comments",
+		defaultState: true,
+	},
+	{name: "lastpipe"},
+	{name: "lithist"},
+	{name: "localvar_inherit"},
+	{name: "localvar_unset"},
+	{name: "login_shell"},
+	{name: "mailwarn"},
+	{name: "no_empty_cmd_completion"},
+	{name: "nocaseglob"},
+	{name: "nocasematch"},
+	{
+		name:         "progcomp",
+		defaultState: true,
+	},
+	{name: "progcomp_alias"},
+	{
+		name:         "promptvars",
+		defaultState: true,
+	},
+	{name: "restricted_shell"},
+	{name: "shift_verbose"},
+	{
+		name:         "sourcepath",
+		defaultState: true,
+	},
+	{name: "xpg_echo"},
 }
 
 // To access the shell options arrays without a linear search when we

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -2072,6 +2072,23 @@ set +o pipefail
 	{"shopt -u -o noexec; echo foo_interp_missing", "foo_interp_missing\n"},
 	{"shopt -u globstar; shopt globstar | grep 'off$' | wc -l | tr -d ' '", "1\n"},
 	{"shopt -s globstar; shopt globstar | grep 'off$' | wc -l | tr -d ' '", "0\n"},
+	{"shopt extglob | grep 'off' | wc -l | tr -d ' '", "1\n"},
+	{
+		"shopt inherit_errexit",
+		"inherit_errexit\ton\t(\"off\" not supported)\n #JUSTERR",
+	},
+	{
+		"shopt -s extglob",
+		"shopt: invalid option name \"extglob\" \"off\" (\"on\" not supported)\nexit status 1 #IGNORE",
+	},
+	{
+		"shopt -s interactive_comments",
+		"shopt: invalid option name \"interactive_comments\" \"on\" (\"off\" not supported)\nexit status 1 #IGNORE",
+	},
+	{
+		"shopt -s foo",
+		"shopt: invalid option name \"foo\"\nexit status 1 #JUSTERR",
+	},
 
 	// IFS
 	{`echo -n "$IFS"`, " \t\n"},

--- a/interp/test.go
+++ b/interp/test.go
@@ -190,7 +190,7 @@ func (r *Runner) unTest(ctx context.Context, op syntax.UnTestOperator, x string)
 	case syntax.TsNempStr:
 		return x != ""
 	case syntax.TsOptSet:
-		if opt := r.optByName(x, false); opt != nil {
+		if _, opt := r.optByName(x, false); opt != nil {
 			return *opt
 		}
 		return false


### PR DESCRIPTION
Trying to set an unsupported but valid Bash option leads to a
potentially confusing error message:
```
$ gosh -c "shopt -s extglob"
shopt: invalid option name "extglob"
```

Fix that by handling the unsupported options differently from the
invalid ones:
```
$ gosh -c "shopt -s extglob"
bash: line 1: shopt: extglob off ("on" not supported)
exit status 1
```

Additionally, this commit lists all of the Bash options when `shopt`
without arguments is called and explicitly identify the unsupported
options, for example:
```
$ gosh -c "shopt"
expand_aliases  off
globstar        off
nullglob        off
// .. cut for brevity
hostcomplete    on      ("off" not supported)
inherit_errexit on      ("off" not supported)
interactive_comments    on      ("off" not supported)
```

While at it, rewrite the `bashOptsTable` so that it can keep two option
states: 1) Bash's default options and 2) whether we support it

Fixes #877