### PR TITLE
expand: fix parameters with leading/trailing spaces

### DIFF
--- a/expand/expand.go
+++ b/expand/expand.go
@@ -546,11 +546,22 @@ func (cfg *Config) wordFields(wps []syntax.WordPart) ([][]fieldPart, error) {
 		curField = nil
 	}
 	splitAdd := func(val string) {
-		for i, field := range strings.FieldsFunc(val, cfg.ifsRune) {
-			if i > 0 {
+		fieldStart := -1
+		for i, r := range val {
+			if cfg.ifsRune(r) {
+				if fieldStart >= 0 { // ending a field
+					curField = append(curField, fieldPart{val: val[fieldStart:i]})
+					fieldStart = -1
+				}
 				flush()
+			} else {
+				if fieldStart < 0 { // starting a new field
+					fieldStart = i
+				}
 			}
-			curField = append(curField, fieldPart{val: field})
+		}
+		if fieldStart >= 0 { // ending a field without IFS
+			curField = append(curField, fieldPart{val: val[fieldStart:]})
 		}
 	}
 	for i, wp := range wps {

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -313,6 +313,8 @@ var runTests = []runTest{
 	{`echo a'b'c"d"e`, "abcde\n"},
 	{`a=" b c "; echo $a`, "b c\n"},
 	{`a=" b c "; echo "$a"`, " b c \n"},
+	{`a=" b c "; echo foo${a}bar`, "foo b c bar\n"},
+	{`a="b    c"; echo foo${a}bar`, "foob cbar\n"},
 	{`echo "$(echo ' b c ')"`, " b c \n"},
 	{"echo ''", "\n"},
 	{`$(echo)`, ""},


### PR DESCRIPTION
(see commit message)

Fixes #886.