### PR TITLE
interp_test: fix sleep syntax compatibility

### DIFF
--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -1340,7 +1340,7 @@ var runTests = []runTest{
 	},
 	{`mkdir d; old=$PWD; cd d & wait; [[ $old == "$PWD" ]]`, ""},
 	{
-		"f() { echo 1; }; { sleep 0.01s; f; } & f() { echo 2; }; wait",
+		"f() { echo 1; }; { sleep 0.01; f; } & f() { echo 2; }; wait",
 		"1\n",
 	},
 
@@ -3616,10 +3616,9 @@ var testBuiltinsMap = map[string]func(HandlerContext, []string) error{
 		return nil
 	},
 	"sleep": func(hc HandlerContext, args []string) error {
-		// Note that, unlike GNU sleep, we don't assume a default unit
-		// of seconds.
 		for _, arg := range args {
-			d, err := time.ParseDuration(arg)
+			// assume and default unit to be in seconds
+			d, err := time.ParseDuration(fmt.Sprintf("%ss", arg))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Running the tests on master gives me the following error:
```
--- FAIL: TestRunnerRunConfirm (0.03s)
    --- FAIL: TestRunnerRunConfirm/#420 (0.02s)
        interp_test.go:3690: wrong bash output in "f() { echo 1; }; { sleep 0.01s; f; } & f() { echo 2; }; wait":
            want: "1\n"
            got:  "usage: sleep seconds\n1\n"
```

I am running on `bash version 5.1.16(1)-release`:
```
$ bash --version
GNU bash, version 5.1.16(1)-release (aarch64-apple-darwin21.5.0)
Copyright (C) 2020 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>

This is free software; you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
```

The error I suppose, is because of the difference of the sleep
syntax on BSD/Unix/MacOS vs on GNU/Linux - the former requires
no unit and defaults to seconds, while the latter requires either
`smdh` as unit

To fix, fix the `sleep` test builtin to accept either of the syntax
and default to seconds when none is found

Finally, modify the tests to run without units so it would pass when
ran against real bash