### PR TITLE
syntax: allow escaped newlines to precede unquoted words again

### DIFF
--- a/syntax/printer_test.go
+++ b/syntax/printer_test.go
@@ -144,14 +144,16 @@ var printTests = []printCase{
 		"a bb\\\ncc d",
 		"a bbcc d",
 	},
-	samePrint("a \\\n\tb \\\n\tc \\\n\t;"),
-	samePrint("a=1 \\\n\tb=2 \\\n\tc=3 \\\n\t;"),
+	samePrint("a \\\n\tb \\\n\t\"c\" \\\n\t;"),
+	samePrint("a=1 \\\n\tb=2 \\\n\tc=\"3\" \\\n\t;"),
 	{
 		"a=\\\nfoo\nb=\\\n\"bar\"\nc=\\\n'baz'",
 		"a=foo\nb=\"bar\"\nc='baz'",
 	},
 
 	samePrint("if a \\\n\t; then b; fi"),
+	samePrint("a > \\\n\tfoo"),
+	samePrint("a <<< \\\n\t\"foo\""),
 	samePrint("a 'b\nb' c"),
 	samePrint("a $'b\nb' c"),
 	{


### PR DESCRIPTION
(see commit message)

Fixes #873.