### PR TITLE
syntax: add a TODO reminder about C.UTF-8

### DIFF
--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -129,8 +129,7 @@ func TestMain(m *testing.M) {
 	}
 	os.Setenv("GOSH_PROG", prog)
 
-	// Set the locale to computer-friendly English and UTF-8.
-	// Some systems like Arch miss C.UTF8, so fall back to the US English locale.
+	// Mimic syntax/parser_test.go's TestMain.
 	if out, _ := exec.Command("locale", "-a").Output(); strings.Contains(
 		strings.ToLower(string(out)), "c.utf",
 	) {

--- a/syntax/parser_test.go
+++ b/syntax/parser_test.go
@@ -157,6 +157,9 @@ func TestParseBats(t *testing.T) {
 func TestMain(m *testing.M) {
 	// Set the locale to computer-friendly English and UTF-8.
 	// Some systems like Arch miss C.UTF8, so fall back to the US English locale.
+	//
+	// TODO: glibc 2.35 was released with C.UTF-8 in February 2022.
+	// This locale is now becoming a standard, so remove the workaround in 2023.
 	if out, _ := exec.Command("locale", "-a").Output(); strings.Contains(
 		strings.ToLower(string(out)), "c.utf",
 	) {


### PR DESCRIPTION
(see commit message)

