### PR TITLE
cmd/shfmt: incorrect flag name for --case-indent

### DIFF
--- a/cmd/shfmt/shfmt.1.scd
+++ b/cmd/shfmt/shfmt.1.scd
@@ -74,7 +74,7 @@ predictable. Some aspects of the format can be configured via printer flags.
 *-bn*, *--binary-next-line*
 	Binary ops like *&&* and *|* may start a line.
 
-*-ci*, *--switch-case-indent*
+*-ci*, *--case-indent*
 	Switch cases will be indented.
 
 *-sr*, *--space-redirects*


### PR DESCRIPTION
The shfmt manpage had a typo for the long-option `--case-indent`. It has
been corrected from `--switch-case-indent`, which was not a valid option.

Fixes #898.