### PR TITLE
syntax: forbid ${!foo*} and ${!foo@} in mksh mode

### DIFF
--- a/syntax/filetests_test.go
+++ b/syntax/filetests_test.go
@@ -2608,7 +2608,7 @@ var fileTests = []testCase{
 	},
 	{
 		Strs: []string{`${!foo*} ${!bar@}`},
-		bsmk: call(
+		bash: call(
 			word(&ParamExp{
 				Excl:  true,
 				Param: lit("foo"),

--- a/syntax/parser_test.go
+++ b/syntax/parser_test.go
@@ -1928,7 +1928,21 @@ var shellTests = []errorCase{
 	},
 	{
 		in:    "echo ${!foo}",
-		posix: `1:8: ${!foo} is a bash/mksh feature`,
+		posix: `1:6: "${!foo}" is a bash/mksh feature`,
+	},
+	{
+		in:    "echo ${!foo*}",
+		posix: `1:6: "${!foo*}" is a bash feature`,
+		mksh:  `1:6: "${!foo*}" is a bash feature`,
+	},
+	{
+		in:    "echo ${!foo@}",
+		posix: `1:12: this expansion operator is a bash/mksh feature`,
+		mksh:  `1:6: "${!foo@}" is a bash feature`,
+	},
+	{
+		in:    "echo ${!foo[@]}",
+		posix: `1:12: arrays are a bash/mksh feature`,
 	},
 	{
 		in:    "echo ${foo[1]}",


### PR DESCRIPTION
(see commit message)

