### PR TITLE
interp: make trap consistent with errexit logic

### DIFF
--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -2156,6 +2156,7 @@ set +o pipefail
 	// trap
 	{"trap 'echo at_exit' EXIT; true", "at_exit\n"},
 	{"trap 'echo on_err' ERR; false; echo FAIL", "on_err\nFAIL\n"},
+	{"trap 'echo on_err' ERR; false || true; echo OK", "OK\n"},
 	{"trap 'echo at_exit' EXIT; trap - EXIT; echo OK", "OK\n"},
 	{"set -e; trap 'echo A' ERR EXIT; false; echo FAIL", "A\nA\nexit status 1"},
 	{"trap 'foo_interp_missingbar_interp_missing' UNKNOWN", "trap: UNKNOWN: invalid signal specification\nexit status 2 #JUSTERR"},

--- a/interp/runner.go
+++ b/interp/runner.go
@@ -311,7 +311,7 @@ func (r *Runner) stmtSync(ctx context.Context, st *syntax.Stmt) {
 		//   part of && or || lists
 		//   preceded by !
 		r.exitShell(ctx, r.exit)
-	} else if r.exit != 0 {
+	} else if r.exit != 0 && !r.noErrExit {
 		r.trapCallback(ctx, r.callbackErr, "error")
 	}
 	if !r.keepRedirs {


### PR DESCRIPTION
interp already excludes conditional contexts for exiting on error when `errexit` is set (see case above); this makes the logic consistently apply the same filtering for reporting errors to a trap routine.

To test this behavior, I ran the below script under `bash`, under `gosh` (without this change), and under `gosh` (with this change). `bash` reports that the handler was invoked once. Without this change `gosh` reports that it was invoked twice, and with this change, only once.

```bash
#!/bin/bash

count=0

my_handler()
{
  echo "Handler invoked"
  count=$((count + 1))
}

trap my_handler ERR

echo "Trying unconditional"
non_existent_cmd

echo "Trying conditional"
non_existent_cmd || true

echo "Handler called: $count time(s)"
```