### PR TITLE
interp: implement %b for printf builtin

### DIFF
--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -304,6 +304,9 @@ var runTests = []runTest{
 	{"printf 'nofmt' 1 2 3", "nofmt"},
 	{"printf '%d_' 1 2 3", "1_2_3_"},
 	{"printf '%02d %02d\n' 1 2 3", "01 02\n03 00\n"},
+	{`printf '0%s1' 'a\bc'`, `0a\bc1`},
+	{`printf '0%b1' 'a\bc'`, "0a\bc1"},
+	{"printf 'a%bc'", "ac"},
 
 	// words and quotes
 	{"echo  foo_interp_missing ", "foo_interp_missing\n"},


### PR DESCRIPTION
Update `printf` implementation to do the same as `echo -e` for the `%b` format specifier: expand backslash escape sequences in the provided argument but not `%` format specifiers.

Extracts inner logic from `Format` into `formatIntoBuffer` to avoid issues with non-reentrancy of `Format` (due to use of a special cached buffer in `Config`.

---

_Request for feedback_

This was the simplest change that I could see, but I wasn't thrilled about having `formatIntoBuffer` recursively call itself for the `%b` case; this shouldn't generally be problematic, since the recursive call won't process `%` format specifiers and shouldn't further recur.