### PR TITLE
Add `pre-commit.com` support

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,16 @@
+- id: shfmt
+  name: shfmt
+  description: A shell formatter.
+  minimum_pre_commit_version: 3.0.0
+  entry: shfmt
+  language: golang
+  types: [shell]
+  args: [-s, -w]
+
+- id: shfmt-system
+  name: shfmt system
+  description: A shell formatter.
+  entry: shfmt
+  language: system
+  types: [shell]
+  args: [-s, -w]

--- a/README.md
+++ b/README.md
@@ -28,6 +28,19 @@ viewed directly as Markdown or rendered with [scdoc].
 Packages are available on [Alpine], [Arch], [Debian], [Docker], [Fedora], [FreeBSD],
 [Homebrew], [MacPorts], [NixOS], [Scoop], [Snapcraft], [Void] and [webi].
 
+### As a pre-commit hook
+
+See [pre-commit](https://github.com/pre-commit/pre-commit) for instructions
+
+Sample `.pre-commit-config.yaml`:
+
+```yaml
+-   repo: https://github.com/mvdan/sh
+    rev: ''  # Use the sha / tag you want to point at > 3.6.0
+    hooks:
+    -   id: shfmt
+```
+
 ### gosh
 
 	go install mvdan.cc/sh/v3/cmd/gosh@latest


### PR DESCRIPTION
Now that `language_version` is supported for `golang` starting from [pre-commit v3.0.0](https://github.com/pre-commit/pre-commit/releases/tag/v3.0.0) and as this was the main [concern](https://github.com/mvdan/sh/pull/762#pullrequestreview-811904344), I think we can now fully support to `pre-commit`.