### PR TITLE
interp: handle select clause

### DIFF
--- a/interp/builtin.go
+++ b/interp/builtin.go
@@ -594,7 +594,7 @@ func (r *Runner) builtinCode(ctx context.Context, pos syntax.Pos, name string, a
 			return 1
 		}
 		if len(args) == 0 {
-			args = append(args, "REPLY")
+			args = append(args, shellReplyVar)
 		}
 
 		values := expand.ReadFields(r.ecfg, string(line), len(args), raw)

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -2087,6 +2087,23 @@ set +o pipefail
 		`x=orig; f() { local x=local; unset x; [[ -v x ]] && echo set || echo unset; }; f`,
 		"unset\n",
 	},
+	{
+		`PS3="pick one: "; select opt in foo bar baz; do echo "Selected $opt"; break; done <<< 3`,
+		"1) foo\n2) bar\n3) baz\npick one: Selected baz\n",
+	},
+	{
+		`opts=(foo bar baz); select opt in ${opts[@]}; do echo "Selected $opt"; break; done <<< 99`,
+		"1) foo\n2) bar\n3) baz\n#? Selected \n",
+	},
+	{
+		`select opt in foo; do
+	case $opt in
+	foo) echo "option 1"; break;;
+	*) echo "invalid option $REPLY"; break;;
+	esac
+done <<< 2`,
+		"1) foo\n#? invalid option 2\n",
+	},
 
 	// shopt
 	{"set -e; shopt -o | grep -E 'errexit|noexec' | wc -l | tr -d ' '", "2\n"},


### PR DESCRIPTION
the parser already supports the `select` command but the interpreter
treats it just like any other `for` command

given the syntax:
```
select name [in words ...]; do commands; done
```

fix support by:
* expanding and printing the words following `in`, to generate a list
  of items, each preceeded by a number and a close parenthesis
* display the prompt and read the line from stdin
* assigning the selected option to a special variable in Bash called
  `REPLY`
* support `PS3`, another special variable in Bash, which can be
  set to the prompt while the shell awaits for input. if not provided,
  defaults to `#?`:

additionally, `select` should loop until an input is provided. in case
of an invalid input, the name will be empty
```
$ bash -c 'PS3="pick one: "; select SEL in foo; do echo $REPLY; break; done'
1) foo
pick one:
1) foo
pick one:
1) foo
pick one: 1
```

fixes https://github.com/mvdan/sh/issues/969