### PR TITLE
Add a pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,28 @@
+---
+- id: shfmt
+  name: shfmt
+  description: "A shell parser, formatter, and interpreter with bash support"
+  minimum_pre_commit_version: 3.0.0
+  language: golang
+  entry: shfmt
+  args:
+    - -s
+    - -w
+  types:
+    - shell
+  exclude_types:
+    - zsh
+
+- id: shfmt-system
+  name: shfmt system
+  description: "A shell parser, formatter, and interpreter with bash support"
+  minimum_pre_commit_version: 3.0.0
+  language: system
+  entry: shfmt
+  args:
+    - -s
+    - -w
+  types:
+    - shell
+  exclude_types:
+    - zsh


### PR DESCRIPTION
Refer <https://pre-commit.com/#golang>

Usage:

Shell developers can create a file named `.pre-commit-config.yaml` in their repos:

```yaml
repos:
  - repo: https://github.com/Freed-Wu/sh
    rev: v3.6.0
    hooks:
      - id: shfmt
```

Then enable `pre-commit` by `pre-commit install`.

Then if they write a code like this:

```bash
if [[ $OSTYPE == msys2 || $OSTYPE == cygwin ]]; then
shopt -s completion_strip_exe
fi
```

When they `git commit`, `pre-commit` will auto run `shftm -w` for all shell files except zsh files:

```
[INFO] Initializing environment for https://github.com/Freed-Wu/sh.
[INFO] Installing environment for https://github.com/Freed-Wu/sh.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
shfmt.........................................................................Failed
- hook id: shfmt
- files were modified by this hook
```

Now your bash file has be changed to

```bash
if [[ $OSTYPE == msys2 || $OSTYPE == cygwin ]]; then
	shopt -s completion_strip_exe
fi
```

You must `git add the_changed_bash_file`, then `git commit`:

```
shfmt.........................................................................Passed
```

Now it is OK.

I think it will be useful for shell developers.

And if you merge this change, remember Publish a new version, because

```yaml
repos:
  - repo: https://github.com/Freed-Wu/sh
    rev: v3.6.0
    hooks:
      - id: shfmt
```

Only download the shfmt of v3.6.0, which don't contain a pre-commit-hook.