### PR TITLE
Fix interp build tags to allow WebAssembly builds

### DIFF
--- a/interp/os_notunix.go
+++ b/interp/os_notunix.go
@@ -1,6 +1,9 @@
 // Copyright (c) 2017, Andrey Nering <andrey.nering@gmail.com>
 // See LICENSE for licensing information
 
+//go:build !unix
+// +build !unix
+
 package interp
 
 import (

--- a/interp/os_unix.go
+++ b/interp/os_unix.go
@@ -1,8 +1,8 @@
 // Copyright (c) 2017, Andrey Nering <andrey.nering@gmail.com>
 // See LICENSE for licensing information
 
-//go:build !windows
-// +build !windows
+//go:build unix
+// +build unix
 
 package interp
 

--- a/interp/unix_test.go
+++ b/interp/unix_test.go
@@ -1,8 +1,8 @@
 // Copyright (c) 2019, Daniel Martí <mvdan@mvdan.cc>
 // See LICENSE for licensing information
 
-//go:build !windows
-// +build !windows
+//go:build unix
+// +build unix
 
 package interp_test
 


### PR DESCRIPTION
This PR changes package interp's build tags and filenames around to allow building on WebAssembly (and potentially Plan 9).