### PR TITLE
interp: umask/fg/bg shouldn't panic

### DIFF
--- a/interp/builtin.go
+++ b/interp/builtin.go
@@ -878,7 +878,8 @@ func (r *Runner) builtinCode(ctx context.Context, pos syntax.Pos, name string, a
 
 	default:
 		// "umask", "fg", "bg",
-		panic(fmt.Sprintf("unhandled builtin: %s", name))
+		r.errf("%s: unimplemented builtin\n", name)
+		return 2
 	}
 	return 0
 }


### PR DESCRIPTION
This fixes an issue where running `umask`, `fg` or `bg` causes a panic.

Related issue: https://github.com/diamondburned/libdb.so/issues/3