### PR TITLE
interp: Fix (*Runner).errf missing new lines

### DIFF
--- a/interp/builtin.go
+++ b/interp/builtin.go
@@ -166,7 +166,7 @@ func (r *Runner) builtinCode(ctx context.Context, pos syntax.Pos, name string, a
 		}
 	case "break", "continue":
 		if !r.inLoop {
-			r.errf("%s is only useful in a loop", name)
+			r.errf("%s is only useful in a loop\n", name)
 			break
 		}
 		enclosing := &r.breakEnclosing
@@ -752,7 +752,7 @@ func (r *Runner) builtinCode(ctx context.Context, pos syntax.Pos, name string, a
 				words = append(words, w)
 				return true
 			}); err != nil {
-				r.errf("alias: could not parse %q: %v", src, err)
+				r.errf("alias: could not parse %q: %v\n", src, err)
 				continue
 			}
 
@@ -869,7 +869,7 @@ func (r *Runner) builtinCode(ctx context.Context, pos syntax.Pos, name string, a
 			vr.List = append(vr.List, scanner.Text())
 		}
 		if err := scanner.Err(); err != nil {
-			r.errf("%s: unable to read, %v", name, err)
+			r.errf("%s: unable to read, %v\n", name, err)
 			return 2
 		}
 		r.setVarInternal(arrayName, vr)

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -247,8 +247,8 @@ var runTests = []runTest{
 	{"exit; echo foo_interp_missing", ""},
 	{"exit 0; echo foo_interp_missing", ""},
 	{"printf", "usage: printf format [arguments]\nexit status 2 #JUSTERR"},
-	{"break", "break is only useful in a loop #JUSTERR"},
-	{"continue", "continue is only useful in a loop #JUSTERR"},
+	{"break", "break is only useful in a loop\n #JUSTERR"},
+	{"continue", "continue is only useful in a loop\n #JUSTERR"},
 	{"cd a b", "usage: cd [dir]\nexit status 2 #JUSTERR"},
 	{"shift a", "usage: shift [n]\nexit status 2 #JUSTERR"},
 	{

--- a/interp/runner.go
+++ b/interp/runner.go
@@ -105,20 +105,20 @@ func (r *Runner) fillExpandConfig(ctx context.Context) {
 				case syntax.CmdIn:
 					f, err := os.OpenFile(path, os.O_WRONLY, 0)
 					if err != nil {
-						r.errf("cannot open fifo for stdout: %v", err)
+						r.errf("cannot open fifo for stdout: %v\n", err)
 						return
 					}
 					r2.stdout = f
 					defer func() {
 						if err := f.Close(); err != nil {
-							r.errf("closing stdout fifo: %v", err)
+							r.errf("closing stdout fifo: %v\n", err)
 						}
 						os.Remove(path)
 					}()
 				default: // syntax.CmdOut
 					f, err := os.OpenFile(path, os.O_RDONLY, 0)
 					if err != nil {
-						r.errf("cannot open fifo for stdin: %v", err)
+						r.errf("cannot open fifo for stdin: %v\n", err)
 						return
 					}
 					r2.stdin = f


### PR DESCRIPTION
Some of the `errf` calls were missing new lines, so I added them. One call is left where new lines are not wanted.