### PR TITLE
interp: fix `cd` builtin: call a system function to determine access instead of reverse-engineering it ourselves

### DIFF
--- a/interp/builtin.go
+++ b/interp/builtin.go
@@ -963,7 +963,7 @@ func (r *Runner) changeDir(ctx context.Context, path string) int {
 	if err != nil || !info.IsDir() {
 		return 1
 	}
-	if !hasPermissionToDir(info) {
+	if !hasPermissionToDir(path) {
 		return 1
 	}
 	r.Dir = path

--- a/interp/os_notunix.go
+++ b/interp/os_notunix.go
@@ -7,7 +7,6 @@ package interp
 
 import (
 	"fmt"
-	"os"
 )
 
 func mkfifo(path string, mode uint32) error {

--- a/interp/os_notunix.go
+++ b/interp/os_notunix.go
@@ -15,6 +15,6 @@ func mkfifo(path string, mode uint32) error {
 }
 
 // hasPermissionToDir is a no-op on Windows.
-func hasPermissionToDir(info os.FileInfo) bool {
+func hasPermissionToDir(string) bool {
 	return true
 }

--- a/interp/os_unix.go
+++ b/interp/os_unix.go
@@ -6,11 +6,6 @@
 package interp
 
 import (
-	"os"
-	"os/user"
-	"strconv"
-	"syscall"
-
 	"golang.org/x/sys/unix"
 )
 
@@ -20,55 +15,6 @@ func mkfifo(path string, mode uint32) error {
 
 // hasPermissionToDir returns true if the OS current user has execute
 // permission to the given directory
-func hasPermissionToDir(info os.FileInfo) bool {
-	user, err := user.Current()
-	if err != nil {
-		return false // unknown user; assume no permissions
-	}
-	uid, err := strconv.Atoi(user.Uid)
-	if err != nil {
-		return false // on POSIX systems, Uid should always be a decimal number
-	}
-	if uid == 0 {
-		return true // super-user
-	}
-
-	st, _ := info.Sys().(*syscall.Stat_t)
-	if st == nil {
-		panic("unexpected info.Sys type")
-	}
-	perm := info.Mode().Perm()
-
-	// user (u)
-	if st.Uid == uint32(uid) {
-		return perm&0o100 != 0
-	}
-
-	// group (g) -- check the users's actual group, and then all the other
-	// groups they're in.
-	gid, err := strconv.Atoi(user.Gid)
-	if err != nil {
-		return false // on POSIX systems, Gid should always be a decimal number
-	}
-	if st.Gid == uint32(gid) {
-		return perm&0o010 != 0
-	}
-	gids, err := user.GroupIds()
-	if err != nil {
-		// If we can't get the list of group IDs, we can't know if the group
-		// permissions, so default to false/no access.
-		return false
-	}
-	for _, gid := range gids {
-		gid, err := strconv.Atoi(gid)
-		if err != nil {
-			return false
-		}
-		if st.Gid == uint32(gid) {
-			return perm&0o010 != 0
-		}
-	}
-
-	// remaining users (o)
-	return perm&0o001 != 0
+func hasPermissionToDir(path string) bool {
+	return unix.Access(path, unix.X_OK) == nil
 }


### PR DESCRIPTION
Fixes #1033.