### PR TITLE
Resolve symlink when formatting single file

### DIFF
--- a/cmd/shfmt/main.go
+++ b/cmd/shfmt/main.go
@@ -253,6 +253,14 @@ For more information, see 'man shfmt' and https://github.com/mvdan/sh.
 	status := 0
 	for _, path := range flag.Args() {
 		if info, err := os.Stat(path); err == nil && !info.IsDir() && !find.val {
+			// Resolve symlink to avoid breaking symlink and creating a regular file
+			if info.Mode()&os.ModeSymlink == 0 {
+				if path, err = filepath.EvalSymlinks(path); err != nil {
+					_, _ = fmt.Fprintln(os.Stderr, err)
+					return 1
+				}
+			}
+
 			// When given paths to files directly, always format
 			// them, no matter their extension or shebang.
 			//


### PR DESCRIPTION
Fix for: https://github.com/mvdan/sh/issues/1053

Using regular `os.Open` on symlink, formatting and writing back the output breaks the link and creates a new file instead.

Following a symlink automatically is something to decide. Do we trust the use to have done due diligence when passing a symlink OR avoid surprise and return an error for symlinks?

This change resolves the symlink and operates on resolved path, updates the source path and retains the symlink.