### PR TITLE
cmd/shfmt: fix typo in shfmt.1.scd

### DIFF
--- a/cmd/shfmt/shfmt.1.scd
+++ b/cmd/shfmt/shfmt.1.scd
@@ -65,7 +65,7 @@ predictable. Some aspects of the format can be configured via printer flags.
 	If neither come up with a result, *bash* is used as a fallback.
 
 	The filename extension *.sh* is a special case: it implies *posix*,
-	but may be overriden by a valid shell shebang.
+	but may be overridden by a valid shell shebang.
 
 *-p*, *--posix*
 	Shorthand for *-ln=posix*.


### PR DESCRIPTION
overriden -> overridden