### PR TITLE
cmd/shfmt: Add support for minify and simplify via EditorConfig

### DIFF
--- a/cmd/shfmt/shfmt.1.scd
+++ b/cmd/shfmt/shfmt.1.scd
@@ -1,5 +1,7 @@
 shfmt(1)
 
+; To render and view: scdoc <shfmt.1.scd | man -l -
+
 # NAME
 
 shfmt - Format shell programs
@@ -42,12 +44,6 @@ predictable. Some aspects of the format can be configured via printer flags.
 	To never use color, set a non-empty *NO_COLOR* or *TERM=dumb*.
 	To always use color, set a non-empty *FORCE_COLOR*.
 
-*-s*, *--simplify*
-	Simplify the code.
-
-*-mn*, *--minify*
-	Minify the code to reduce its size (implies *-s*).
-
 *--apply-ignore*
 	Always apply EditorConfig ignore rules.
 
@@ -77,6 +73,9 @@ predictable. Some aspects of the format can be configured via printer flags.
 *-p*, *--posix*
 	Shorthand for *-ln=posix*.
 
+*-s*, *--simplify*
+	Simplify the code.
+
 ## Printer flags
 
 *-i*, *--indent* <uint>
@@ -99,6 +98,9 @@ predictable. Some aspects of the format can be configured via printer flags.
 
 *-fn*, *--func-next-line*
 	Function opening braces are placed on a separate line.
+
+*-mn*, *--minify*
+	Minify the code to reduce its size (implies *-s*).
 
 ## Utility flags
 

--- a/cmd/shfmt/testdata/script/editorconfig.txtar
+++ b/cmd/shfmt/testdata/script/editorconfig.txtar
@@ -172,6 +172,12 @@ keep_padding = true
 [function_next_line.sh]
 function_next_line = true
 
+[simplify.sh]
+simplify = true
+
+[minify.sh]
+minify = true
+
 -- otherknobs/shell_variant_bash.sh --
 array=(elem)
 -- otherknobs/shell_variant_mksh.sh --
@@ -195,6 +201,14 @@ echo  foo    bar
 foo()
 {
 	echo foo
+}
+-- otherknobs/simplify.sh --
+foo() {
+	((bar))
+}
+-- otherknobs/minify.sh --
+foo(){
+((bar))
 }
 -- ignored/.editorconfig --
 root = true


### PR DESCRIPTION
I've never used `go` before, so I this is a naive, but working approach to support `simplify` and `minify` in editorconfig files. I have not looked at adding tests yet, but will add tests if this code change approach is agreeable.

Manual testing below.

```bash
$ for opt in "" "simplify=true" "minify=true"; do echo $'[[shell]]\nindent=4\n'"$opt" > .editorconfig; echo "### $opt"; shfmt --diff f.sh; done
###
--- f.sh.orig
+++ f.sh
@@ -1,11 +1,11 @@
 #!/bin/bash

 ff() {
-local h=asdffdfd
+       local h=asdffdfd
 }
 g=a

-echo $(( 1 + 2 ));
+echo $((1 + 2))
 ff
 echo $h
 [[ "$HOME" == "$HELLO" ]]
### simplify=true
--- f.sh.orig
+++ f.sh
@@ -1,11 +1,11 @@
 #!/bin/bash

 ff() {
-local h=asdffdfd
+       local h=asdffdfd
 }
 g=a

-echo $(( 1 + 2 ));
+echo $((1 + 2))
 ff
 echo $h
-[[ "$HOME" == "$HELLO" ]]
+[[ $HOME == "$HELLO" ]]
### minify=true
--- f.sh.orig
+++ f.sh
@@ -1,11 +1,9 @@
 #!/bin/bash
-
-ff() {
+ff(){
 local h=asdffdfd
 }
 g=a
-
-echo $(( 1 + 2 ));
+echo $((1+2))
 ff
 echo $h
-[[ "$HOME" == "$HELLO" ]]
+[[ $HOME == "$HELLO" ]]
```

Adding, for e.g. `-s` or `-mn` to the `shfmt` call leads to consistent results (i.e. if `-s` is on, then for the `opts=`, `opts="simplify=true"`, we get the second result above, but the `opts="minify=true"` option stays consistent with `minify` respected).

Closes #819.
