### PR TITLE
Allow case-insensitive filename globbing; add nocaseglob

### DIFF
--- a/expand/expand.go
+++ b/expand/expand.go
@@ -68,6 +68,10 @@ type Config struct {
 	// "**".
 	GlobStar bool
 
+	// NoCaseGlob corresponds to the shell option that causes case-insensitive
+	// pattern matching in pathname expansion.
+	NoCaseGlob bool
+
 	// NullGlob corresponds to the shell option that allows globbing
 	// patterns which match nothing to result in zero fields.
 	NullGlob bool
@@ -946,7 +950,11 @@ func (cfg *Config) glob(base, pat string) ([]string, error) {
 			}
 			continue
 		}
-		expr, err := pattern.Regexp(part, pattern.Filenames|pattern.EntireString)
+		mode := pattern.Filenames | pattern.EntireString
+		if cfg.NoCaseGlob {
+			mode |= pattern.NoGlobCase
+		}
+		expr, err := pattern.Regexp(part, mode)
 		if err != nil {
 			return nil, err
 		}

--- a/interp/api.go
+++ b/interp/api.go
@@ -494,6 +494,11 @@ var bashOptsTable = [...]bashOpt{
 		supported:    true,
 	},
 	{
+		name:         "nocaseglob",
+		defaultState: false,
+		supported:    true,
+	},
+	{
 		name:         "nullglob",
 		defaultState: false,
 		supported:    true,
@@ -565,7 +570,6 @@ var bashOptsTable = [...]bashOpt{
 	{name: "login_shell"},
 	{name: "mailwarn"},
 	{name: "no_empty_cmd_completion"},
-	{name: "nocaseglob"},
 	{name: "nocasematch"},
 	{
 		name:         "progcomp",
@@ -589,6 +593,7 @@ var bashOptsTable = [...]bashOpt{
 // know which option we're after at compile time. First come the shell options,
 // then the bash options.
 const (
+	// These correspond to indexes in shellOptsTable
 	optAllExport = iota
 	optErrExit
 	optNoExec
@@ -597,8 +602,11 @@ const (
 	optXTrace
 	optPipeFail
 
+	// These correspond to indexes (offset by the above seven items) of
+	// supported options in bashOptsTable
 	optExpandAliases
 	optGlobStar
+	optNoCaseGlob
 	optNullGlob
 )
 

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -2139,6 +2139,24 @@ done <<< 2`,
 		"shopt -s foo",
 		"shopt: invalid option name \"foo\"\nexit status 1 #JUSTERR",
 	},
+	{
+		// Beware that macOS file systems are by default case-preserving but
+		// case-insensitive, so e.g. "touch x X" creates only one file.
+		"touch a ab Ac Ad; shopt -u nocaseglob; echo a*",
+		"a ab\n",
+	},
+	{
+		"touch a ab Ac Ad; shopt -s nocaseglob; echo a*",
+		"Ac Ad a ab\n",
+	},
+	{
+		"touch a ab abB Ac Ad; shopt -u nocaseglob; echo *b",
+		"ab\n",
+	},
+	{
+		"touch a ab abB Ac Ad; shopt -s nocaseglob; echo *b",
+		"ab abB\n",
+	},
 
 	// IFS
 	{`echo -n "$IFS"`, " \t\n"},

--- a/interp/runner.go
+++ b/interp/runner.go
@@ -163,6 +163,7 @@ func (r *Runner) updateExpandOpts() {
 		}
 	}
 	r.ecfg.GlobStar = r.opts[optGlobStar]
+	r.ecfg.NoCaseGlob = r.opts[optNoCaseGlob]
 	r.ecfg.NullGlob = r.opts[optNullGlob]
 	r.ecfg.NoUnset = r.opts[optNoUnset]
 }

--- a/pattern/pattern.go
+++ b/pattern/pattern.go
@@ -34,6 +34,7 @@ const (
 	Filenames                     // "*" and "?" don't match slashes; only "**" does
 	Braces                        // support "{a,b}" and "{1..4}"
 	EntireString                  // match the entire string using ^$ delimiters
+	NoGlobCase                    // Do case-insensitive match (that is, use (?i) in the regexp)
 )
 
 var numRange = regexp.MustCompile(`^([+-]?\d+)\.\.([+-]?\d+)}`)
@@ -68,6 +69,9 @@ noopLoop:
 	// Enable matching `\n` with the `.` metacharacter as globs match `\n`
 	buf.WriteString("(?s)")
 	dotMeta := false
+	if mode&NoGlobCase != 0 {
+		buf.WriteString("(?i)")
+	}
 	if mode&EntireString != 0 {
 		buf.WriteString("^")
 	}
@@ -242,7 +246,7 @@ writeLoop:
 	if mode&EntireString != 0 {
 		buf.WriteString("$")
 	}
-	// No `.` metacharacters were used, so don't return the flag.
+	// No `.` metacharacters were used, so don't return the (?s) flag.
 	if !dotMeta {
 		return string(buf.Bytes()[4:]), nil
 	}


### PR DESCRIPTION
- Add a FoldCase flag to the expand.Config struct, which is used to configure how expand.Fields behaves.
- Similarly, add a FoldCase Mode to pattern.Regexp. Setting the flag adds (?i) to the front of the generated regular expression.
- Use the former to set the latter when calling expand.Fields.
- Use all of the above to implement the "nocaseglob" shopt.

Rationale: I use expand.Fields to do filename expansion, for which I'd like to do case-insensitive matching. E.g. I'd like "c*" to match both "cmd" and "CHANGELOG.md"