### PR TITLE
DebugPrint: Print the string value of tokens

### DIFF
--- a/syntax/walk.go
+++ b/syntax/walk.go
@@ -308,6 +308,10 @@ func (p *debugPrinter) print(x reflect.Value) {
 		}
 		p.printf("}")
 	default:
-		p.printf("%#v", x.Interface())
+		if s, ok := x.Interface().(fmt.Stringer); ok && !x.IsZero() {
+			p.printf("%#v (%s)", x.Interface(), s)
+		} else {
+			p.printf("%#v", x.Interface())
+		}
 	}
 }


### PR DESCRIPTION
In DebugPrint, if a value implements fmt.Stringer, and isn't a zero value, display its string value in addition to the default %#v format.

For the most part, this prints the string value of "tokens", e.g. for a syntax.Redirect.Op, instead of "Op: 0x3b", you get "Op: 0x3b (>&)".