### PR TITLE
Implement -O and -G tests

### DIFF
--- a/interp/os_notunix.go
+++ b/interp/os_notunix.go
@@ -6,7 +6,10 @@
 package interp
 
 import (
+	"context"
 	"fmt"
+
+	"mvdan.cc/sh/v3/syntax"
 )
 
 func mkfifo(path string, mode uint32) error {
@@ -16,4 +19,12 @@ func mkfifo(path string, mode uint32) error {
 // hasPermissionToDir is a no-op on Windows.
 func hasPermissionToDir(string) bool {
 	return true
+}
+
+// unTestOwnOrGrp panics. Under Unix, it implements the -O and -G unary tests,
+// but under Windows, it's unclear how to implement those tests, since Windows
+// doesn't have the concept of a file owner, just ACLs, and it's unclear how
+// to map the one to the other.
+func (r *Runner) unTestOwnOrGrp(ctx context.Context, op syntax.UnTestOperator, x string) bool {
+	panic(fmt.Sprintf("unhandled unary test op: %v", op))
 }

--- a/interp/os_unix.go
+++ b/interp/os_unix.go
@@ -6,7 +6,13 @@
 package interp
 
 import (
+	"context"
+	"os/user"
+	"strconv"
+	"syscall"
+
 	"golang.org/x/sys/unix"
+	"mvdan.cc/sh/v3/syntax"
 )
 
 func mkfifo(path string, mode uint32) error {
@@ -17,4 +23,23 @@ func mkfifo(path string, mode uint32) error {
 // permission to the given directory
 func hasPermissionToDir(path string) bool {
 	return unix.Access(path, unix.X_OK) == nil
+}
+
+// unTestOwnOrGrp implements the -O and -G unary tests. If the file does not
+// exist, or the current user cannot be retrieved, returns false.
+func (r *Runner) unTestOwnOrGrp(ctx context.Context, op syntax.UnTestOperator, x string) bool {
+	info, err := r.stat(ctx, x)
+	if err != nil {
+		return false
+	}
+	u, err := user.Current()
+	if err != nil {
+		return false
+	}
+	if op == syntax.TsUsrOwn {
+		uid, _ := strconv.Atoi(u.Uid)
+		return uint32(uid) == info.Sys().(*syscall.Stat_t).Uid
+	}
+	gid, _ := strconv.Atoi(u.Gid)
+	return uint32(gid) == info.Sys().(*syscall.Stat_t).Gid
 }

--- a/interp/test.go
+++ b/interp/test.go
@@ -8,11 +8,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"os/user"
 	"regexp"
-	"runtime"
-	"strconv"
-	"syscall"
 
 	"golang.org/x/term"
 
@@ -205,23 +201,7 @@ func (r *Runner) unTest(ctx context.Context, op syntax.UnTestOperator, x string)
 	case syntax.TsNot:
 		return x == ""
 	case syntax.TsUsrOwn, syntax.TsGrpOwn:
-		if runtime.GOOS == "windows" {
-			panic(fmt.Sprintf("unhandled unary test op: %v", op))
-		}
-		fi, err := os.Stat(x)
-		if err != nil {
-			return false
-		}
-		u, err := user.Current()
-		if err != nil {
-			return false
-		}
-		if op == syntax.TsUsrOwn {
-			uid, _ := strconv.Atoi(u.Uid)
-			return uint32(uid) == fi.Sys().(*syscall.Stat_t).Uid
-		}
-		gid, _ := strconv.Atoi(u.Gid)
-		return uint32(gid) == fi.Sys().(*syscall.Stat_t).Gid
+		return r.unTestOwnOrGrp(ctx, op, x)
 	default:
 		panic(fmt.Sprintf("unhandled unary test op: %v", op))
 	}

--- a/interp/test.go
+++ b/interp/test.go
@@ -8,7 +8,11 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"os/user"
 	"regexp"
+	"runtime"
+	"strconv"
+	"syscall"
 
 	"golang.org/x/term"
 
@@ -200,6 +204,24 @@ func (r *Runner) unTest(ctx context.Context, op syntax.UnTestOperator, x string)
 		return r.lookupVar(x).Kind == expand.NameRef
 	case syntax.TsNot:
 		return x == ""
+	case syntax.TsUsrOwn, syntax.TsGrpOwn:
+		if runtime.GOOS == "windows" {
+			panic(fmt.Sprintf("unhandled unary test op: %v", op))
+		}
+		fi, err := os.Stat(x)
+		if err != nil {
+			return false
+		}
+		u, err := user.Current()
+		if err != nil {
+			return false
+		}
+		if op == syntax.TsUsrOwn {
+			uid, _ := strconv.Atoi(u.Uid)
+			return uint32(uid) == fi.Sys().(*syscall.Stat_t).Uid
+		}
+		gid, _ := strconv.Atoi(u.Gid)
+		return uint32(gid) == fi.Sys().(*syscall.Stat_t).Gid
 	default:
 		panic(fmt.Sprintf("unhandled unary test op: %v", op))
 	}


### PR DESCRIPTION
Implement -O (syntax.TsUsrOwn, "file exists and is owned by the effective user id") and -G (syntax.TsGrpOwn, "file exists and is owned by the effective group id") tests, for non-Windows only.

Under Windows, still panics, as before.

-O and -G are hard/not applicable for Windows, since it doesn't really have the concept of "file owners", only ACLs, and it's not clear how to translate one to the other.