### PR TITLE
shfmt: skip non-regular files

### DIFF
--- a/cmd/shfmt/main.go
+++ b/cmd/shfmt/main.go
@@ -323,6 +323,9 @@ func walkPath(path string, entry fs.DirEntry) error {
 	if entry.IsDir() && vcsDir.MatchString(entry.Name()) {
 		return filepath.SkipDir
 	}
+	if !entry.IsDir() && !entry.Type().IsRegular() {
+		return nil
+	}
 	// We don't know the language variant at this point yet, as we are walking directories
 	// and we first want to tell if we should skip a path entirely.
 	//


### PR DESCRIPTION
I had a named pipe in my source directory, and `shfmt .` suddenly stopped working.

It probably doesn't make sense to try reading non-regular files.