### PR TITLE
fileutil: Omit zsh extensions and shebangs

### DIFF
--- a/cmd/shfmt/testdata/script/walk.txtar
+++ b/cmd/shfmt/testdata/script/walk.txtar
@@ -183,9 +183,9 @@ foo
 #!/bin/envsh
  foo
 
--- skip/ext.zsh
+-- skip/ext.zsh --
 foo
--- skip/shebang-zsh
+-- skip/shebang-zsh --
 #!/bin/zsh
 foo
 -- skip/.git/ext.sh --

--- a/fileutil/file.go
+++ b/fileutil/file.go
@@ -13,8 +13,8 @@ import (
 )
 
 var (
-	shebangRe = regexp.MustCompile(`^#!\s?/(usr/)?bin/(env\s+)?(sh|bash|mksh|bats|zsh)(\s|$)`)
-	extRe     = regexp.MustCompile(`\.(sh|bash|mksh|bats|zsh)$`)
+	shebangRe = regexp.MustCompile(`^#!\s?/(usr/)?bin/(env\s+)?(sh|bash|mksh|bats)(\s|$)`)
+	extRe     = regexp.MustCompile(`\.(sh|bash|mksh|bats)$`)
 )
 
 // TODO: consider removing HasShebang in favor of Shebang in v4


### PR DESCRIPTION
**testdata: Fix missing zsh files**

These lines were being rendered into the contents of `shebang-nospace`
rather than separate files because they were missing the trailing `--`
delimiters.

It seems that there's no way to guard against this based `txtar` docs:

> There are no possible syntax errors in a txtar archive.

This change will cause the tests to fail and will be fixed in a
subsequent commit:

    > cmpenv stdout find.golden
     diff stdout find.golden
     --- stdout
     +++ find.golden
     @@ -16,6 +16,4 @@
      modify/shebang-space
      modify/shebang-tabs
      modify/shebang-usr-sh
     -skip/ext.zsh
     -skip/shebang-zsh
      symlink/subdir/ext-shebang.sh

     FAIL: testdata/script/walk.txtar:10: stdout and find.golden differ

**fileutil: Omit zsh extensions and shebangs**

To prevent `shfmt` from discovering `zsh` files which aren't currently
supported for formatting.

This fixes #535 and the following test:

    > cmpenv stdout find.golden
     diff stdout find.golden
     --- stdout
     +++ find.golden
     @@ -16,6 +16,4 @@
      modify/shebang-space
      modify/shebang-tabs
      modify/shebang-usr-sh
     -skip/ext.zsh
     -skip/shebang-zsh
      symlink/subdir/ext-shebang.sh

     FAIL: testdata/script/walk.txtar:10: stdout and find.golden differ

It could be considered a breaking change to `shfmt` and `fileutil`.

There's some discussion in that issue about whether it's beneficial to
match `zsh` files because they can _sometimes_ be formatted if they
don't contain any zsh-specific syntax, but without any way to explicitly
exclude them from discovery it's more of a hindrance than help until #120 is done.