### PR TITLE
interp: improve method signature

### DIFF
--- a/interp/builtin.go
+++ b/interp/builtin.go
@@ -902,7 +902,7 @@ func (r *Runner) builtinCode(ctx context.Context, pos syntax.Pos, name string, a
 
 // mapfileSplit returns a suitable Split function for a [bufio.Scanner];
 // the code is mostly stolen from [bufio.ScanLines].
-func mapfileSplit(delim byte, dropDelim bool) func(data []byte, atEOF bool) (advance int, token []byte, err error) {
+func mapfileSplit(delim byte, dropDelim bool) bufio.SplitFunc {
 	return func(data []byte, atEOF bool) (advance int, token []byte, err error) {
 		if atEOF && len(data) == 0 {
 			return 0, nil, nil


### PR DESCRIPTION
this is a zero code changes. The signature was already the right one.
We are just using an alias, that will make things clearer.
