### PR TITLE
shfmt: add -vb, --variable-braces printer option to put braces around variables

### DIFF
--- a/cmd/shfmt/main.go
+++ b/cmd/shfmt/main.go
@@ -50,7 +50,6 @@ var (
 	diff        = &multiFlag[bool]{"d", "diff", false}
 	simplify    = &multiFlag[bool]{"s", "simplify", false}
 	minify      = &multiFlag[bool]{"mn", "minify", false}
-	varBraces   = &multiFlag[bool]{"vb", "variable-braces", false}
 	applyIgnore = &multiFlag[bool]{"", "apply-ignore", false}
 	filename    = &multiFlag[string]{"", "filename", ""}
 
@@ -64,6 +63,7 @@ var (
 	spaceRedirs = &multiFlag[bool]{"sr", "space-redirects", false}
 	keepPadding = &multiFlag[bool]{"kp", "keep-padding", false}
 	funcNext    = &multiFlag[bool]{"fn", "func-next-line", false}
+	varBraces   = &multiFlag[bool]{"vb", "variable-braces", false}
 
 	find     = &multiFlag[boolString]{"f", "find", "false"}
 	toJSON   = &multiFlag[bool]{"tojson", "to-json", false} // TODO(v4): remove "tojson" for consistency
@@ -83,9 +83,9 @@ var (
 
 	allFlags = []any{
 		versionFlag, list,
-		write, diff, simplify, minify, varBraces, applyIgnore, filename,
+		write, diff, simplify, minify, applyIgnore, filename,
 		lang, posix, expRecover,
-		indent, binNext, caseIndent, spaceRedirs, keepPadding, funcNext,
+		indent, binNext, caseIndent, spaceRedirs, keepPadding, funcNext, varBraces,
 		find, toJSON, fromJSON,
 	}
 )
@@ -170,7 +170,7 @@ Parser options:
 
 Printer options:
 
-  -i,     --indent uint       0 for tabs (default), >0 for number of spaces
+  -i,     --indent <uint>     0 for tabs (default), >0 for number of spaces
   -bn,    --binary-next-line  binary ops like && and | may start a line
   -ci,    --case-indent       switch cases will be indented
   -sr,    --space-redirects   redirect operators will be followed by a space

--- a/cmd/shfmt/main.go
+++ b/cmd/shfmt/main.go
@@ -47,15 +47,15 @@ var (
 	list        = &multiFlag[boolString]{"l", "list", "false"}
 
 	write       = &multiFlag[bool]{"w", "write", false}
+	diff        = &multiFlag[bool]{"d", "diff", false}
 	simplify    = &multiFlag[bool]{"s", "simplify", false}
 	minify      = &multiFlag[bool]{"mn", "minify", false}
-	find        = &multiFlag[boolString]{"f", "find", "false"}
-	diff        = &multiFlag[bool]{"d", "diff", false}
+	varBraces   = &multiFlag[bool]{"vb", "variable-braces", false}
 	applyIgnore = &multiFlag[bool]{"", "apply-ignore", false}
+	filename    = &multiFlag[string]{"", "filename", ""}
 
 	lang       = &multiFlag[syntax.LangVariant]{"ln", "language-dialect", syntax.LangAuto}
 	posix      = &multiFlag[bool]{"p", "posix", false}
-	filename   = &multiFlag[string]{"", "filename", ""}
 	expRecover = &multiFlag[int]{"", "exp.recover", 0}
 
 	indent      = &multiFlag[uint]{"i", "indent", 0}
@@ -65,6 +65,7 @@ var (
 	keepPadding = &multiFlag[bool]{"kp", "keep-padding", false}
 	funcNext    = &multiFlag[bool]{"fn", "func-next-line", false}
 
+	find     = &multiFlag[boolString]{"f", "find", "false"}
 	toJSON   = &multiFlag[bool]{"tojson", "to-json", false} // TODO(v4): remove "tojson" for consistency
 	fromJSON = &multiFlag[bool]{"", "from-json", false}
 
@@ -149,16 +150,18 @@ shfmt formats shell programs. If the only argument is a dash ('-') or no
 arguments are given, standard input will be used. If a given path is a
 directory, all shell scripts found under that directory will be used.
 
-  --version  show version and exit
+  -v,     --version     show version and exit
+  -l[=0], --list[=0]    list files whose formatting differs from shfmt;
+                        paths are separated by a newline or a null character if -l=0
 
-  -l[=0], --list[=0]  list files whose formatting differs from shfmt;
-                      paths are separated by a newline or a null character if -l=0
-  -w,     --write     write result to file instead of stdout
-  -d,     --diff      error with a diff when the formatting differs
-  -s,     --simplify  simplify the code
-  -mn,    --minify    minify the code to reduce its size (implies -s)
-  --apply-ignore      always apply EditorConfig ignore rules
-  --filename str      provide a name for the standard input file
+  -w,     --write              write result to file instead of stdout
+  -d,     --diff               error with a diff when the formatting differs
+  -s,     --simplify           simplify the code
+  -mn,    --minify             minify the code to reduce its size (implies -s)
+  -vb,    --variable-braces    prefer putting braces around variable references;
+                               this option is ignored if -mn is used
+          --apply-ignore       always apply EditorConfig ignore rules
+          --filename str       provide a name for the standard input file
 
 Parser options:
 
@@ -167,19 +170,19 @@ Parser options:
 
 Printer options:
 
-  -i,  --indent uint       0 for tabs (default), >0 for number of spaces
-  -bn, --binary-next-line  binary ops like && and | may start a line
-  -ci, --case-indent       switch cases will be indented
-  -sr, --space-redirects   redirect operators will be followed by a space
-  -kp, --keep-padding      keep column alignment paddings
-  -fn, --func-next-line    function opening braces are placed on a separate line
+  -i,     --indent uint        0 for tabs (default), >0 for number of spaces
+  -bn,    --binary-next-line   binary ops like && and | may start a line
+  -ci,    --case-indent        switch cases will be indented
+  -sr,    --space-redirects    redirect operators will be followed by a space
+  -kp,    --keep-padding       keep column alignment paddings
+  -fn,    --func-next-line     function opening braces are placed on a separate line
 
 Utilities:
 
-  -f[=0], --find[=0]  recursively find all shell files and print the paths;
-                      paths are separated by a newline or a null character if -f=0
-  --to-json           print syntax tree to stdout as a typed JSON
-  --from-json         read syntax tree from stdin as a typed JSON
+  -f[=0], --find[=0]    recursively find all shell files and print the paths;
+                        paths are separated by a newline or a null character if -f=0
+          --to-json     print syntax tree to stdout as a typed JSON
+          --from-json   read syntax tree from stdin as a typed JSON
 
 Formatting options can also be read from EditorConfig files; see 'man shfmt'
 for a detailed description of the tool's behavior.

--- a/cmd/shfmt/main.go
+++ b/cmd/shfmt/main.go
@@ -43,7 +43,7 @@ type multiFlag[T any] struct {
 }
 
 var (
-	versionFlag = &multiFlag[bool]{"", "version", false}
+	versionFlag = &multiFlag[bool]{"v", "version", false}
 	list        = &multiFlag[boolString]{"l", "list", "false"}
 
 	write       = &multiFlag[bool]{"w", "write", false}
@@ -82,9 +82,11 @@ var (
 	version = "(devel)" // to match the default from runtime/debug
 
 	allFlags = []any{
-		versionFlag, list, write, simplify, minify, find, diff, applyIgnore,
-		lang, posix, filename, expRecover,
-		indent, binNext, caseIndent, spaceRedirs, keepPadding, funcNext, toJSON, fromJSON,
+		versionFlag, list,
+		write, diff, simplify, minify, varBraces, applyIgnore, filename,
+		lang, posix, expRecover,
+		indent, binNext, caseIndent, spaceRedirs, keepPadding, funcNext,
+		find, toJSON, fromJSON,
 	}
 )
 

--- a/cmd/shfmt/main.go
+++ b/cmd/shfmt/main.go
@@ -152,39 +152,38 @@ shfmt formats shell programs. If the only argument is a dash ('-') or no
 arguments are given, standard input will be used. If a given path is a
 directory, all shell scripts found under that directory will be used.
 
-  -v,     --version     show version and exit
-  -l[=0], --list[=0]    list files whose formatting differs from shfmt;
-                        paths are separated by a newline or a null character if -l=0
+  -v,     --version           show version and exit
+  -l[=0], --list[=0]          list files whose formatting differs from shfmt;
+                              paths are separated by a newline or a null character if -l=0
 
-  -w,     --write              write result to file instead of stdout
-  -d,     --diff               error with a diff when the formatting differs
-  -s,     --simplify           simplify the code
-  -mn,    --minify             minify the code to reduce its size (implies -s)
-  -vb,    --variable-braces    prefer putting braces around variable references;
-                               this option is ignored if -mn is used
-          --apply-ignore       always apply EditorConfig ignore rules
-          --filename str       provide a name for the standard input file
+  -w,     --write             write result to file instead of stdout
+  -d,     --diff              error with a diff when the formatting differs
+  -s,     --simplify          simplify the code
+  -mn,    --minify            minify the code to reduce its size (implies -s)
+          --apply-ignore      always apply EditorConfig ignore rules
+          --filename <str>    provide a name for the standard input file
 
 Parser options:
 
-  -ln, --language-dialect str  bash/posix/mksh/bats, default "auto"
-  -p,  --posix                 shorthand for -ln=posix
+  -ln,    --language <str>    bash/posix/mksh/bats, default "auto"
+  -p,     --posix             shorthand for -ln=posix
 
 Printer options:
 
-  -i,     --indent uint        0 for tabs (default), >0 for number of spaces
-  -bn,    --binary-next-line   binary ops like && and | may start a line
-  -ci,    --case-indent        switch cases will be indented
-  -sr,    --space-redirects    redirect operators will be followed by a space
-  -kp,    --keep-padding       keep column alignment paddings
-  -fn,    --func-next-line     function opening braces are placed on a separate line
+  -i,     --indent uint       0 for tabs (default), >0 for number of spaces
+  -bn,    --binary-next-line  binary ops like && and | may start a line
+  -ci,    --case-indent       switch cases will be indented
+  -sr,    --space-redirects   redirect operators will be followed by a space
+  -kp,    --keep-padding      keep column alignment paddings
+  -fn,    --func-next-line    function opening braces are placed on a separate line
+  -vb,    --variable-braces   put braces around all variable references (overriden by -mn)
 
 Utilities:
 
-  -f[=0], --find[=0]    recursively find all shell files and print the paths;
-                        paths are separated by a newline or a null character if -f=0
-          --to-json     print syntax tree to stdout as a typed JSON
-          --from-json   read syntax tree from stdin as a typed JSON
+  -f[=0], --find[=0]          recursively find all shell files and print the paths;
+                              paths are separated by a newline or a null character if -f=0
+          --to-json           print syntax tree to stdout as a typed JSON
+          --from-json         read syntax tree from stdin as a typed JSON
 
 Formatting options can also be read from EditorConfig files; see 'man shfmt'
 for a detailed description of the tool's behavior.
@@ -229,7 +228,8 @@ For more information and to report bugs, see https://github.com/mvdan/sh.
 			caseIndent.short, caseIndent.long,
 			spaceRedirs.short, spaceRedirs.long,
 			keepPadding.short, keepPadding.long,
-			funcNext.short, funcNext.long:
+			funcNext.short, funcNext.long,
+			varBraces.short, varBraces.long:
 			useEditorConfig = false
 		}
 	})
@@ -250,6 +250,7 @@ For more information and to report bugs, see https://github.com/mvdan/sh.
 		syntax.SpaceRedirects(spaceRedirs.val)(printer)
 		syntax.KeepPadding(keepPadding.val)(printer)
 		syntax.FunctionNextLine(funcNext.val)(printer)
+		syntax.VariableBraces(varBraces.val)(printer)
 	}
 
 	// Decide whether or not to use color for the diff output,
@@ -277,7 +278,7 @@ For more information and to report bugs, see https://github.com/mvdan/sh.
 		return
 	}
 	if filename.val != "" {
-		fmt.Fprintln(os.Stderr, "-filename can only be used with stdin")
+		fmt.Fprintln(os.Stderr, "--filename can only be used with stdin")
 		os.Exit(1)
 	}
 	if toJSON.val {

--- a/cmd/shfmt/shfmt.1.scd
+++ b/cmd/shfmt/shfmt.1.scd
@@ -30,7 +30,7 @@ predictable. Some aspects of the format can be configured via printer flags.
 
 *-l[=0]*, *--list[=0]*
 	List files whose formatting differs from shfmt's;
-	paths are separated by a newline or a null character if -l=0
+	paths are separated by a newline or a null character if *-l=0*.
 
 *-w*, *--write*
 	Write result to file instead of stdout.
@@ -48,10 +48,6 @@ predictable. Some aspects of the format can be configured via printer flags.
 *-mn*, *--minify*
 	Minify the code to reduce its size (implies *-s*).
 
-*-vb*, *--variable-braces*
-	Prefer putting braces around variable references ;
-	this option is ignored if -mn is used
-
 *--apply-ignore*
 	Always apply EditorConfig ignore rules.
 
@@ -67,7 +63,7 @@ predictable. Some aspects of the format can be configured via printer flags.
 
 ## Parser flags
 
-*-ln*, *--language-dialect* <str>
+*-ln*, *--language* <str>
 	Language dialect (*bash*/*posix*/*mksh*/*bats*, default *auto*).
 
 	When set to *auto*, the language is detected from the input filename,
@@ -104,11 +100,14 @@ predictable. Some aspects of the format can be configured via printer flags.
 *-fn*, *--func-next-line*
 	Function opening braces are placed on a separate line.
 
+*-vb*, *--variable-braces*
+	Put braces around all variable references (overriden by *-mn*).
+
 ## Utility flags
 
 *-f[=0]*, *--find[=0]*
 	Recursively find all shell files and print the paths;
-	paths are separated by a newline or a null character if -f=0.
+	paths are separated by a newline or a null character if *-f=0*.
 
 *--to-json*
 	Print syntax tree to stdout as a typed JSON.

--- a/cmd/shfmt/shfmt.1.scd
+++ b/cmd/shfmt/shfmt.1.scd
@@ -48,6 +48,10 @@ predictable. Some aspects of the format can be configured via printer flags.
 *-mn*, *--minify*
 	Minify the code to reduce its size (implies *-s*).
 
+*-vb*, *--variable-braces*
+	Prefer putting braces around variable references ;
+	this option is ignored if -mn is used
+
 *--apply-ignore*
 	Always apply EditorConfig ignore rules.
 
@@ -133,8 +137,8 @@ showing how to set any option:
 ```
 [*.sh]
 # like -i=4
-indent_style = space
-indent_size = 4
+indent_style       = space
+indent_size        = 4
 
 # --language-variant
 shell_variant      = posix

--- a/syntax/printer.go
+++ b/syntax/printer.go
@@ -231,12 +231,13 @@ type Printer struct {
 	spaceRedirects bool
 	keepPadding    bool
 	minify         bool
+	varBraces      bool
 	singleLine     bool
 	funcNextLine   bool
 
 	wantSpace wantSpaceState // whether space is required or has been written
 
-	wantNewline bool // newline is wanted for pretty-printing; ignored by singleLine; ignored by singleLine
+	wantNewline bool // newline is wanted for pretty-printing; ignored by singleLine
 	mustNewline bool // newline is required to keep shell syntax valid
 	wroteSemi   bool // wrote ';' for the current statement
 
@@ -615,7 +616,7 @@ func (p *Printer) wordParts(wps []WordPart, quoted bool) {
 	// However, we want to allow a leading escaped newline for cases such as:
 	//
 	//   foo <<< \
-	//     "bar baz"
+	//   "bar baz"
 	if !quoted && !p.singleLine && wps[0].Pos().Line() > p.line {
 		p.bslashNewl()
 	}
@@ -691,6 +692,9 @@ func (p *Printer) wordPart(wp, next WordPart) {
 		name := wp.Param.Value
 		switch {
 		case !p.minify:
+			if p.varBraces {
+				wp.Short = false
+			}
 		case wp.Excl, wp.Length, wp.Width:
 		case wp.Index != nil, wp.Slice != nil:
 		case wp.Repl != nil, wp.Exp != nil:

--- a/syntax/printer.go
+++ b/syntax/printer.go
@@ -125,7 +125,6 @@ func NewPrinter(opts ...PrinterOption) *Printer {
 // when a [*File] is used.
 func (p *Printer) Print(w io.Writer, node Node) error {
 	p.reset()
-	fmt.Println(p.varBraces)
 
 	if p.minify && p.singleLine {
 		return fmt.Errorf("Minify and SingleLine together are not supported yet; please file an issue describing your use case: https://github.com/mvdan/sh/issues")
@@ -699,12 +698,13 @@ func (p *Printer) wordPart(wp, next WordPart) {
 		name := wp.Param.Value
 		switch {
 		case !p.minify:
-			if p.varBraces && strings.ContainsAny(name, regexp.MustCompile("[a-zA-Z]").String()) {
+			if p.varBraces && regexp.MustCompile("[a-zA-Z]").MatchString(name) {
 				x2 := *wp
 				x2.Short = false
 				p.paramExp(&x2)
 				return
 			}
+
 		case wp.Excl, wp.Length, wp.Width:
 		case wp.Index != nil, wp.Slice != nil:
 		case wp.Repl != nil, wp.Exp != nil:
@@ -771,7 +771,6 @@ func (p *Printer) paramExp(pe *ParamExp) {
 		p.wroteIndex(pe.Index)
 		return
 	}
-	// fmt.Println(pe.Short, pe.Param.Value)
 	if pe.Short { // $var
 		p.WriteByte('$')
 		p.writeLit(pe.Param.Value)


### PR DESCRIPTION
As the name says, I've added the option to put braces around variables. The -vb option has no effect if -mn is used which overrides it.

Also updated the .1.scd file and the --help command to reflect the change.

I also took the liberty to align the --help command (OCD overwhelmed me xD) which forced me to modify --language-dialect to just --language. Feel free to remove this if it's overstepping.