### PR TITLE
fileutil: shebang detection improvements

### DIFF
--- a/fileutil/file.go
+++ b/fileutil/file.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	shebangRe = regexp.MustCompile(`^#!\s?/(usr/)?bin/(env\s+)?(sh|bash|mksh|bats|zsh)(\s|$)`)
+	shebangRe = regexp.MustCompile(`^#![ \t]*/(usr/)?bin/(env[ \t]+)?(sh|bash|mksh|bats|zsh)(\s|$)`)
 	extRe     = regexp.MustCompile(`\.(sh|bash|mksh|bats|zsh)$`)
 )
 

--- a/fileutil/file_test.go
+++ b/fileutil/file_test.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2025, Ville Skyttä <ville.skytta@iki.fi>
+// See LICENSE for licensing information
+
+package fileutil
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestShebang(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		in   []byte
+		want string
+	}{
+		{
+			in:   []byte("#!/usr/bin/env bash"),
+			want: "bash",
+		},
+		{
+			in:   []byte("#!/bin/bash"),
+			want: "bash",
+		},
+		{
+			in:   []byte("#!foo bar"),
+			want: "",
+		},
+		{
+			in:   []byte("#!/bin/zsh"),
+			want: "zsh",
+		},
+		{
+			in:   []byte("#! /bin/zsh true"),
+			want: "zsh",
+		},
+		{
+			in:   []byte("#!  /bin/zsh"),
+			want: "zsh",
+		},
+		{
+			in:   []byte("#!\t/bin/zsh"),
+			want: "zsh",
+		},
+		{
+			in:   []byte("#!\f/bin/zsh"),
+			want: "",
+		},
+	}
+
+	for _, test := range tests {
+		name := strings.ReplaceAll(strings.ReplaceAll(string(test.in), "\f", "\\f"), "\t", "\\t")
+		t.Run(name, func(t *testing.T) {
+			if got := Shebang(test.in); got != test.want {
+				t.Fatalf("want %q, got %q", test.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Allow any number of spaces or tabs around the first argument, and only spaces or tabs (for example, not form feeds).

I don't have a "standard" ref on this at hand, but this matches the behavior I see on Ubuntu 24.04 and as documented currently in https://en.wikipedia.org/wiki/Shebang_(Unix)#Syntax -- difference to previous behavior being more than zero or one space or tab is acceptable after `#!`, form feed is not.