### PR TITLE
expand: always use pattern.NoGlobStar option

### DIFF
--- a/expand/expand.go
+++ b/expand/expand.go
@@ -963,7 +963,7 @@ func (cfg *Config) glob(base, pat string) ([]string, error) {
 			}
 			continue
 		}
-		mode := pattern.Filenames | pattern.EntireString
+		mode := pattern.Filenames | pattern.EntireString | pattern.NoGlobStar
 		if cfg.NoCaseGlob {
 			mode |= pattern.NoGlobCase
 		}


### PR DESCRIPTION
This is a followup to #1147 and #1149 to slightly simplify the logic and add some tests.

After adding `pattern.NoGlobStar` in #1147 I had a nagging doubt that I should have addded some code to use this new mode in the expand package, depending on whether `cfg.GlobStar` was enabled or not. I spent some time this afternoon checking that assumption, and I can't find a way to get the expand package to use the GlobStar support in the pattern package, even before the fixes you added for #1149 where the behavior was different.

But it's possible I missed something, and I think it's a good idea to disable the unused functionality just in case. Hence this PR.