### PR TITLE
Revert `C.UTF-8` on tests to fix tests on macOS

### DIFF
--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -144,8 +144,15 @@ func TestMain(m *testing.M) {
 	os.Setenv("GOSH_PROG", prog)
 
 	// Mimic syntax/parser_test.go's TestMain.
-	os.Setenv("LANGUAGE", "C.UTF-8")
-	os.Setenv("LC_ALL", "C.UTF-8")
+	if out, _ := exec.Command("locale", "-a").Output(); strings.Contains(
+		strings.ToLower(string(out)), "c.utf",
+	) {
+		os.Setenv("LANGUAGE", "C.UTF-8")
+		os.Setenv("LC_ALL", "C.UTF-8")
+	} else {
+		os.Setenv("LANGUAGE", "en_US.UTF-8")
+		os.Setenv("LC_ALL", "en_US.UTF-8")
+	}
 
 	os.Unsetenv("CDPATH")
 	hasBash52 = checkBash()

--- a/syntax/parser_test.go
+++ b/syntax/parser_test.go
@@ -157,10 +157,8 @@ func TestParseBats(t *testing.T) {
 
 func TestMain(m *testing.M) {
 	// Set the locale to computer-friendly English and UTF-8.
-	// Some systems like Arch miss C.UTF8, so fall back to the US English locale.
-	//
-	// TODO: glibc 2.35 was released with C.UTF-8 in February 2022.
-	// This locale is now becoming a standard, so remove the workaround in 2023.
+	// Some systems like macOS miss C.UTF8, so fall back to the US English
+	// locale.
 	if out, _ := exec.Command("locale", "-a").Output(); strings.Contains(
 		strings.ToLower(string(out)), "c.utf",
 	) {

--- a/syntax/parser_test.go
+++ b/syntax/parser_test.go
@@ -156,10 +156,20 @@ func TestParseBats(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	// Set the locale to computer-friendly English and UTF-8, C.UTF-8,
-	// which started shipping with glibc 2.35 in February 2022.
-	os.Setenv("LANGUAGE", "C.UTF-8")
-	os.Setenv("LC_ALL", "C.UTF-8")
+	// Set the locale to computer-friendly English and UTF-8.
+	// Some systems like Arch miss C.UTF8, so fall back to the US English locale.
+	//
+	// TODO: glibc 2.35 was released with C.UTF-8 in February 2022.
+	// This locale is now becoming a standard, so remove the workaround in 2023.
+	if out, _ := exec.Command("locale", "-a").Output(); strings.Contains(
+		strings.ToLower(string(out)), "c.utf",
+	) {
+		os.Setenv("LANGUAGE", "C.UTF-8")
+		os.Setenv("LC_ALL", "C.UTF-8")
+	} else {
+		os.Setenv("LANGUAGE", "en_US.UTF-8")
+		os.Setenv("LC_ALL", "en_US.UTF-8")
+	}
 	os.Exit(m.Run())
 }
 


### PR DESCRIPTION
Revert "all: assume C.UTF-8 is available in the tests"

This reverts commit dfc1441b9cd87d9430893024743aa2197a8e3e8f.

---

That commits assumes `C.UTF-8` is available everywhere, but it is not really available on macOS, making several tests fail because this is prefixed on the expected outputs:

```
bash: warning: setlocale: LC_ALL: cannot change locale (C.UTF-8): Bad file descriptor
```

Also, FYI `TestRunnerRunConfirm` is still failing on macOS after this change. I may take a look soon.

```
ok  	mvdan.cc/sh/v3/cmd/gosh	(cached)
ok  	mvdan.cc/sh/v3/cmd/shfmt	(cached)
ok  	mvdan.cc/sh/v3/expand	(cached)
ok  	mvdan.cc/sh/v3/fileutil	(cached)
--- FAIL: TestRunnerRunConfirm (0.02s)
    --- FAIL: TestRunnerRunConfirm/#433 (0.01s)
        interp_test.go:4012: wrong bash output in "echo foo >&- 2>&-; :":
            want: ""
            got:  "bash: line 1: echo: write error: Bad file descriptor\n"
    --- FAIL: TestRunnerRunConfirm/#289 (0.01s)
        interp_test.go:4012: wrong bash output in "HOME='/*'; echo ~; echo \"$HOME\"":
            want: "/*\n/*\n"
            got:  "/Users/andrey\n/*\n"
    --- FAIL: TestRunnerRunConfirm/#948 (0.03s)
        interp_test.go:4012: wrong bash output in "HOME=/foo; echo ~ ~/ ~/'' ~'' ~\"\"":
            want: "/foo /foo/ /foo/ ~ ~\n"
            got:  "/Users/andrey /Users/andrey/ /Users/andrey/ ~ ~\n"
    --- FAIL: TestRunnerRunConfirm/#946 (0.02s)
        interp_test.go:4012: wrong bash output in "HOME=/foo; rel=/bar; echo ~/bar ~/'bar' ~/\"bar\" ~/$rel ~/\"$rel\"":
            want: "/foo/bar /foo/bar /foo/bar /foo//bar /foo//bar\n"
            got:  "/Users/andrey/bar /Users/andrey/bar /Users/andrey/bar /Users/andrey//bar /Users/andrey//bar\n"
FAIL
FAIL	mvdan.cc/sh/v3/interp	2.405s
ok  	mvdan.cc/sh/v3/pattern	(cached)
ok  	mvdan.cc/sh/v3/shell	(cached)
ok  	mvdan.cc/sh/v3/syntax	2.628s
ok  	mvdan.cc/sh/v3/syntax/typedjson	(cached)
FAIL
```