### PR TITLE
fix(interp): allow multiple options on `declare` (`-Ag`)

### DIFF
--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -2551,6 +2551,10 @@ done <<< 2`,
 		"\n\nb\n\n",
 	},
 	{
+		`declare -Ag a=([x]=y); echo ${a["x"]}`,
+		"y\n",
+	},
+	{
 		`declare -A a=([x]=b [y]=c); for e in ${a[@]}; do echo $e; done | sort`,
 		"b\nc\n",
 	},

--- a/interp/runner.go
+++ b/interp/runner.go
@@ -676,17 +676,19 @@ func (r *Runner) cmd(ctx context.Context, cm syntax.Command) {
 			for _, as := range r.flattenAssign(as) {
 				name := as.Name.Value
 				if strings.HasPrefix(name, "-") {
-					switch name {
-					case "-x", "-r":
-						modes = append(modes, name)
-					case "-a", "-A", "-n":
-						valType = name
-					case "-g":
-						global = true
-					default:
-						r.errf("declare: invalid option %q\n", name)
-						r.exit = 2
-						return
+					for _, rune := range name[1:] {
+						switch rune {
+						case 'x', 'r':
+							modes = append(modes, name)
+						case 'a', 'A', 'n':
+							valType = name
+						case 'g':
+							global = true
+						default:
+							r.errf("declare: invalid option %q\n", name)
+							r.exit = 2
+							return
+						}
 					}
 					continue
 				}


### PR DESCRIPTION
We were getting the following error on a given script:

    declare: invalid option "-Ag"