### PR TITLE
README.md: add another example to caveats

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ We use Go's native fuzzing support. For instance:
 
 ```sh
 $ echo '${array[spaced string]}' | shfmt
-1:16: not a valid arithmetic operator: string
+<standard input>:1:16: not a valid arithmetic operator: string
+$ echo '${array[weird!key]}' | shfmt
+<standard input>:1:8: reached ! without matching [ with ]
 $ echo '${array[dash-string]}' | shfmt
 ${array[dash - string]}
 ```


### PR DESCRIPTION
```sh
$ echo '${array[weird!key]}' | shfmt
<standard input>:1:8: reached ! without matching [ with ]
```

I was not aware of this limitation but saw it in README just before filing a bug. Let's add another example, mostly for the sake of discoverability.

While at it, add <standard input> to an existing example, as this is how the output looks like now (using v3.11).