### PR TITLE
syntax: support alternate command substitution of Bash 5.3

### DIFF
--- a/syntax/filetests_test.go
+++ b/syntax/filetests_test.go
@@ -1951,29 +1951,29 @@ var fileTests = []testCase{
 		)))),
 	},
 	{
-		Strs: []string{"${ foo;}", "${\n\tfoo; }", "${\tfoo;}"},
-		mksh: &CmdSubst{
+		Strs: []string{"${ foo;}", "${\nfoo; }", "${\n\tfoo; }", "${\tfoo;}"},
+		bsmk: &CmdSubst{
 			Stmts:    litStmts("foo"),
 			TempFile: true,
 		},
 	},
 	{
 		Strs: []string{"${\n\tfoo\n\tbar\n}", "${ foo; bar;}"},
-		mksh: &CmdSubst{
+		bsmk: &CmdSubst{
 			Stmts:    litStmts("foo", "bar"),
 			TempFile: true,
 		},
 	},
 	{
 		Strs: []string{"${|foo;}", "${| foo; }"},
-		mksh: &CmdSubst{
+		bsmk: &CmdSubst{
 			Stmts:    litStmts("foo"),
 			ReplyVar: true,
 		},
 	},
 	{
 		Strs: []string{"${|\n\tfoo\n\tbar\n}", "${|foo; bar;}"},
-		mksh: &CmdSubst{
+		bsmk: &CmdSubst{
 			Stmts:    litStmts("foo", "bar"),
 			ReplyVar: true,
 		},

--- a/syntax/parser.go
+++ b/syntax/parser.go
@@ -1058,13 +1058,13 @@ func (p *Parser) wordPart() WordPart {
 		p.ensureNoNested()
 		switch p.r {
 		case '|':
-			if p.lang != LangMirBSDKorn {
-				p.langErr(p.pos, `"${|stmts;}"`, LangMirBSDKorn)
+			if p.lang != LangBash && p.lang != LangMirBSDKorn {
+				p.langErr(p.pos, `"${|stmts;}"`, LangBash, LangMirBSDKorn)
 			}
 			fallthrough
 		case ' ', '\t', '\n':
-			if p.lang != LangMirBSDKorn {
-				p.langErr(p.pos, `"${ stmts;}"`, LangMirBSDKorn)
+			if p.lang != LangBash && p.lang != LangMirBSDKorn {
+				p.langErr(p.pos, `"${ stmts;}"`, LangBash, LangMirBSDKorn)
 			}
 			cs := &CmdSubst{
 				Left:     p.pos,

--- a/syntax/parser_test.go
+++ b/syntax/parser_test.go
@@ -446,8 +446,7 @@ var shellTests = []errorCase{
 	},
 	{
 		in:    `${ foo;}`,
-		posix: `1:1: "${ stmts;}" is a mksh feature; tried parsing as posix`,
-		bash:  `1:1: "${ stmts;}" is a mksh feature; tried parsing as bash`,
+		posix: `1:1: "${ stmts;}" is a bash/mksh feature; tried parsing as posix`,
 	},
 	{
 		in:   `${ `,
@@ -463,8 +462,7 @@ var shellTests = []errorCase{
 	},
 	{
 		in:    `${|foo;}`,
-		posix: `1:1: "${|stmts;}" is a mksh feature; tried parsing as posix`,
-		bash:  `1:1: "${|stmts;}" is a mksh feature; tried parsing as bash`,
+		posix: `1:1: "${|stmts;}" is a bash/mksh feature; tried parsing as posix`,
 	},
 	{
 		in:   `${|`,


### PR DESCRIPTION
Closes https://github.com/mvdan/sh/issues/1176

Bash 5.3 introduced support for ${ command; } , ${| command; } , ${\n command; } and ${\t command; }

ToDo:
- [ ]  Bash 5.3 supports parsing of `prefix${ echo hello world; }suffix`, but shfmt does not currently support parsing the closing `}` without a terminating characters after it.
  Bash website says:
  > Bash allows the close brace to be joined to the remaining characters in the word without being followed by a shell metacharacter as a reserved word would usually require.

  In my tests, `mksh` works like Bash 5.3, too. It's correctly handling, but shfmt currently does not support the `prefix${ echo hello world; }suffix` syntax. 