### PR TITLE
syntax: fix "esac" as first pattern match literal

### DIFF
--- a/syntax/printer.go
+++ b/syntax/printer.go
@@ -960,6 +960,10 @@ func (p *Printer) wordJoin(ws []*Word) {
 func (p *Printer) casePatternJoin(pats []*Word) {
 	anyNewline := false
 	for i, w := range pats {
+		// Only valid situation for a literal 'esac' here is with a preceding left paran.
+		if i == 0 && w.Lit() == "esac" {
+			p.WriteString("(")
+		}
 		if i > 0 {
 			p.spacedToken("|", Pos{})
 		}

--- a/syntax/printer_test.go
+++ b/syntax/printer_test.go
@@ -875,6 +875,20 @@ func TestPrintSwitchCaseIndent(t *testing.T) {
 	}
 }
 
+func TestPrintSwitchCaseEsacLiteral(t *testing.T) {
+	t.Parallel()
+	tests := [...]printCase{
+		samePrint("case $i in\n1)\n\ta\n\t;;\n(esac)\n\tb\n\t;;\nesac"),
+		samePrint("case $i in\n1)\n\ta\n\t;;\n(esac | 2)\n\tb\n\t;;\nesac"),
+		samePrint("case $i in\n1)\n\ta\n\t;;\n2 | esac)\n\tb\n\t;;\nesac"),
+	}
+	for _, tc := range tests {
+		t.Run("", func(t *testing.T) {
+			printTest(t, NewParser(), NewPrinter(), tc.in, tc.want)
+		})
+	}
+}
+
 func TestPrintFunctionNextLine(t *testing.T) {
 	t.Parallel()
 	tests := [...]printCase{


### PR DESCRIPTION
when a case statement has literal "esac" as its first pattern, it should be preceded by a left
parenthesis. the parser already permits this, but not the syntax printer.

this change adds the conclusion that the only way for "esac" to pass the parser as a first
pattern matching literal is if it was indeed preceded by a left parenthesis.