### PR TITLE
fix: output error when changing into a dir that doesn't exist

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
     steps:
     - uses: actions/checkout@v5
     - name: Test as root, without cgo, and with busybox
-      run: docker run -v="$PWD:/pwd" -w=/pwd -e=CGO_ENABLED=0 golang:1.25.0-alpine go test ./...
+      run: docker run -v="$PWD:/pwd" -w=/pwd --user=1000 -e=GOCACHE=/tmp -e=CGO_ENABLED=0 golang:1.25.0-alpine go test ./...
 
   docker:
     name: Build and test Docker images

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -3376,23 +3376,23 @@ var runTestsUnix = []runTest{
 	},
 	// Note that these will succeed if we're root.
 	{
-		`mkdir a; chmod 0000 a; cd a && test $UID -ne 0`,
+		`mkdir a; chmod 0000 a; cd a`,
 		"exit status 1 #JUSTERR",
 	},
 	{
-		`mkdir a; chmod 0222 a; cd a && test $UID -ne 0`,
+		`mkdir a; chmod 0222 a; cd a`,
 		"exit status 1 #JUSTERR",
 	},
 	{
-		`mkdir a; chmod 0444 a; cd a && test $UID -ne 0`,
+		`mkdir a; chmod 0444 a; cd a`,
 		"exit status 1 #JUSTERR",
 	},
 	{
-		`mkdir a; chmod 0010 a; cd a && test $UID -ne 0`,
+		`mkdir a; chmod 0010 a; cd a`,
 		"exit status 1 #JUSTERR",
 	},
 	{
-		`mkdir a; chmod 0001 a; cd a && test $UID -ne 0`,
+		`mkdir a; chmod 0001 a; cd a`,
 		"exit status 1 #JUSTERR",
 	},
 	{


### PR DESCRIPTION
Right now it merely exits 1, which IMHO lacks context.