### PR TITLE
interp: print output error if `cd` fails

### DIFF
--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -988,7 +988,7 @@ var runTests = []runTest{
 	},
 	{
 		"cd noexist",
-		"exit status 1 #JUSTERR",
+		"cd: no such file or directory: noexist\nexit status 1",
 	},
 	{
 		"mkdir -p a/b && cd a && cd b && cd ../..",
@@ -996,7 +996,7 @@ var runTests = []runTest{
 	},
 	{
 		">a && cd a",
-		"exit status 1 #JUSTERR",
+		"cd: no such file or directory: a\nexit status 1",
 	},
 	{
 		`[[ $PWD == "$(pwd)" ]]`,
@@ -3377,23 +3377,23 @@ var runTestsUnix = []runTest{
 	// Note that these will succeed if we're root.
 	{
 		`mkdir a; chmod 0000 a; cd a && test $UID -ne 0`,
-		"exit status 1 #JUSTERR",
+		"cd: permission denied: a\nexit status 1",
 	},
 	{
 		`mkdir a; chmod 0222 a; cd a && test $UID -ne 0`,
-		"exit status 1 #JUSTERR",
+		"cd: permission denied: a\nexit status 1",
 	},
 	{
 		`mkdir a; chmod 0444 a; cd a && test $UID -ne 0`,
-		"exit status 1 #JUSTERR",
+		"cd: permission denied: a\nexit status 1",
 	},
 	{
 		`mkdir a; chmod 0010 a; cd a && test $UID -ne 0`,
-		"exit status 1 #JUSTERR",
+		"cd: permission denied: a\nexit status 1",
 	},
 	{
 		`mkdir a; chmod 0001 a; cd a && test $UID -ne 0`,
-		"exit status 1 #JUSTERR",
+		"cd: permission denied: a\nexit status 1",
 	},
 	{
 		`unset UID`,


### PR DESCRIPTION
`cd` currently just exits with status 1 without printing any output. This can be confusing when using inside `gosh` for example, because it's not clear that an error happened as there is no feedback for non-zero statuses, and not other error was print.

This patch replicates the behavior of Bash, outputing "no such file or directory" or "permission denied".

---

@mvdan I don't know if there is any specific reason on why there was no output at all for failed `cd` calls. Let me know if I'm missing anything.