### PR TITLE
interp: fix `local -a` without assignment to create indexed array

### DIFF
--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -2630,6 +2630,16 @@ done <<< 2`,
 		`declare -a a=(x y); echo ${a[1]}`,
 		"y\n",
 	},
+	// Test that "local -a" without assignment creates an indexed array
+	{
+		`f() { local -a arr; arr+=("a" "b"); echo "${arr[@]}"; }; f`,
+		"a b\n",
+	},
+	// Test that "declare -a" without assignment creates an indexed array
+	{
+		`f() { declare -a arr; arr[0]="x"; arr[1]="y"; echo "${arr[@]}"; }; f`,
+		"x y\n",
+	},
 	{
 		`a=b; echo "${a[@]}"`,
 		"b\n",

--- a/interp/runner.go
+++ b/interp/runner.go
@@ -711,9 +711,12 @@ func (r *Runner) cmd(ctx context.Context, cm syntax.Command) {
 			}
 			vr := r.lookupVar(as.Name.Value)
 			if as.Naked {
-				if valType == "-A" {
+				switch valType {
+				case "-A":
 					vr.Kind = expand.Associative
-				} else {
+				case "-a":
+					vr.Kind = expand.Indexed
+				default:
 					vr.Kind = expand.KeepValue
 				}
 			} else {


### PR DESCRIPTION
## Summary

When using `local -a varname` or `declare -a varname` without an assignment, the variable should be initialized as an indexed array. Previously, the `-a` flag was not handled, causing the variable to keep its previous kind (or default to scalar), which broke subsequent array operations like `+=` or index assignment.

## Changes

- Add explicit handling for `-a` flag in `runner.go` when processing naked declarations
- Add two test cases to verify the fix

## Before

```go
if as.Naked {
    if valType == "-A" {
        vr.Kind = expand.Associative
    } else {
        vr.Kind = expand.KeepValue  // -a falls through here incorrectly
    }
}
```

## After

```go
if as.Naked {
    switch valType {
    case "-A":
        vr.Kind = expand.Associative
    case "-a":
        vr.Kind = expand.Indexed  // Now handled correctly
    default:
        vr.Kind = expand.KeepValue
    }
}
```

## Test Cases Added

```bash
# Test 1: local -a with +=
f() { local -a arr; arr+=("a" "b"); echo "${arr[@]}"; }; f
# Expected: "a b"

# Test 2: declare -a with index assignment
f() { declare -a arr; arr[0]="x"; arr[1]="y"; echo "${arr[@]}"; }; f
# Expected: "x y"
```

## Real-World Impact

This bug affects Gentoo's `ver_cut` function from `/usr/lib/portage/bin/version-functions.sh`, which uses `local -a comp` to parse version strings. We discovered this while implementing [GRPM](https://github.com/grpmsoft/grpm), a Go-based package manager that uses mvdan.cc/sh for ebuild evaluation.

Fixes #1239