### PR TITLE
coreutils: add specific error type

### DIFF
--- a/moreinterp/coreutils/coreutils.go
+++ b/moreinterp/coreutils/coreutils.go
@@ -76,6 +76,9 @@ func ExecHandler(next interp.ExecHandlerFunc) interp.ExecHandlerFunc {
 			v := c.Env.Get(key)
 			return v.Str, v.Set
 		})
-		return cmd.RunContext(ctx, programArgs...)
+		if err := cmd.RunContext(ctx, programArgs...); err != nil {
+			return &Error{err: err}
+		}
+		return nil
 	}
 }

--- a/moreinterp/coreutils/error.go
+++ b/moreinterp/coreutils/error.go
@@ -1,0 +1,21 @@
+package coreutils
+
+import "fmt"
+
+// Error wraps any error returned from the core utilities.
+type Error struct {
+	err error
+}
+
+var (
+	_ error                       = &Error{}
+	_ interface{ Unwrap() error } = &Error{}
+)
+
+func (err *Error) Error() string {
+	return fmt.Sprintf("coreutils: %v", err.err)
+}
+
+func (err *Error) Unwrap() error {
+	return err.err
+}


### PR DESCRIPTION
We have the need to know if an error was returned by the core utilities. Since the u-root project doesn't have specific error types, that looks like a good fit for the middleware.

Related:

* https://github.com/go-task/task/issues/2466
* https://github.com/go-task/task/pull/2619