### PR TITLE
Revert "fix(interp): send interrupt/kill signals to the whole process group"

### DIFF
--- a/cmd/gosh/main_test.go
+++ b/cmd/gosh/main_test.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"os"
@@ -203,7 +202,7 @@ func TestInteractive(t *testing.T) {
 			runner, _ := interp.New(interp.Interactive(true), interp.StdIO(inReader, outWriter, outWriter))
 			errc := make(chan error, 1)
 			go func() {
-				errc <- runInteractive(context.Background(), runner, inReader, outWriter, outWriter)
+				errc <- runInteractive(runner, inReader, outWriter, outWriter)
 				// Discard the rest of the input.
 				io.Copy(io.Discard, inReader)
 				inReader.Close()
@@ -256,7 +255,7 @@ func TestInteractiveExit(t *testing.T) {
 	}()
 	w := io.Discard
 	runner, _ := interp.New(interp.Interactive(true), interp.StdIO(inReader, w, w))
-	if err := runInteractive(context.Background(), runner, inReader, w, w); err != nil {
+	if err := runInteractive(runner, inReader, w, w); err != nil {
 		t.Fatal("expected a nil error")
 	}
 }

--- a/interp/handler.go
+++ b/interp/handler.go
@@ -138,20 +138,19 @@ func DefaultExecHandler(killTimeout time.Duration) ExecHandlerFunc {
 			Stdout: hc.Stdout,
 			Stderr: hc.Stderr,
 		}
-		prepareCommand(&cmd)
 
 		err = cmd.Start()
 		if err == nil {
 			stopf := context.AfterFunc(ctx, func() {
 				if killTimeout <= 0 || runtime.GOOS == "windows" {
-					_ = killCommand(&cmd)
+					_ = cmd.Process.Signal(os.Kill)
 					return
 				}
-				_ = interruptCommand(&cmd)
+				_ = cmd.Process.Signal(os.Interrupt)
 				// TODO: don't sleep in this goroutine if the program
 				// stops itself with the interrupt above.
 				time.Sleep(killTimeout)
-				_ = killCommand(&cmd)
+				_ = cmd.Process.Signal(os.Kill)
 			})
 			defer stopf()
 

--- a/interp/os_notunix.go
+++ b/interp/os_notunix.go
@@ -8,7 +8,6 @@ package interp
 import (
 	"context"
 	"fmt"
-	"os/exec"
 
 	"mvdan.cc/sh/v3/syntax"
 )
@@ -56,16 +55,3 @@ type waitStatus struct{}
 
 func (waitStatus) Signaled() bool { return false }
 func (waitStatus) Signal() int    { return 0 }
-
-// prepareCommand is a no-op.
-func prepareCommand(cmd *exec.Cmd) {}
-
-// interruptCommand interrupts the process killing it.
-func interruptCommand(cmd *exec.Cmd) error {
-	return cmd.Process.Kill()
-}
-
-// killCommand kills the process by killing it.
-func killCommand(cmd *exec.Cmd) error {
-	return cmd.Process.Kill()
-}

--- a/interp/os_unix.go
+++ b/interp/os_unix.go
@@ -7,7 +7,6 @@ package interp
 
 import (
 	"context"
-	"os/exec"
 	"os/user"
 	"strconv"
 	"syscall"
@@ -47,18 +46,3 @@ func (r *Runner) unTestOwnOrGrp(ctx context.Context, op syntax.UnTestOperator, x
 }
 
 type waitStatus = syscall.WaitStatus
-
-// prepareCommand sets the SysProcAttr for the command to create a new process group.
-func prepareCommand(cmd *exec.Cmd) {
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-}
-
-// interruptCommand interrupts the whole process group.
-func interruptCommand(cmd *exec.Cmd) error {
-	return unix.Kill(-cmd.Process.Pid, unix.SIGINT)
-}
-
-// killCommand kills the whole process group.
-func killCommand(cmd *exec.Cmd) error {
-	return unix.Kill(-cmd.Process.Pid, unix.SIGKILL)
-}


### PR DESCRIPTION
* Reverts mvdan/sh#1172
* Closes https://github.com/mvdan/sh/issues/1242
* Ref https://github.com/go-task/task/issues/2650

That fix adds a critical trade-off: interactive commands do not work anymore. Think of `ssh`, `vim`, `hx`, etc. _Anything_ interactive, basically.

Since this is a pretty important use case for users (Task including), it's not worth keeping a fix that was actually just an edge case.