### PR TITLE
expand: fix formatInto panic and unset var field count

### DIFF
--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -368,6 +368,7 @@ var runTests = []runTest{
 	{`count() { echo $#; }; set -- ""; count "$@"`, "1\n"},
 	{`count() { echo $#; }; set -- ""; shift; count "$@"`, "0\n"},
 	{`count() { echo $#; }; a=(); count "${a[@]}"`, "0\n"},
+	{`count() { echo $#; }; count "${unset_var[@]}"`, "0\n"},
 	{`count() { echo $#; }; a=(""); count "${a[@]}"`, "1\n"},
 	{`echo $1 $3; set -- a b c; echo $1 $3`, "\na c\n"},
 	{`[[ $0 == "bash" || $0 == "gosh" ]]`, ""},


### PR DESCRIPTION
Fix two bugs in `expand/expand.go`, both found while running the interp against Gentoo ebuilds (ref #1252).

### 1. formatInto panic on truncated escape sequences

`readDigits` in `formatInto` reads past the end of the format string when an escape like `\x`, `\u`, or `\U` appears at the end with no hex digits following. A trailing backslash also causes an out-of-bounds access.

```
$ printf '\0'   # OK
$ printf '\x'   # panic: index out of range
$ printf 'a\0'  # panic: index out of range
```

Fix: add `i+j < len(format)` bound in `readDigits` loop, and guard the trailing backslash case.

### 2. Unset var `[@]` produces wrong field count

`"${unset_var[@]}"` produces one empty field instead of zero fields:

```bash
count() { echo $#; }
count "${unset_var[@]}"
# expected: 0
# got: 1
```

Fix: handle the `Unknown` + unset case in `quotedElemFields` to return an empty slice.

Both fixes include tests.
