### PR TITLE
interp,pattern: implement !(pattern) extglob negation

### DIFF
--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -3151,6 +3151,64 @@ done <<< 2`,
 		// Bash would print "a123z a12z az\n"
 		"extglob operator !(: Go's regexp package does not support negative lookahead\n #IGNORE",
 	},
+	// !(pattern) extglob negation in case and [[ ]] matching
+	{
+		"shopt -s extglob\ncase \"bar\" in !(foo)) echo match;; esac",
+		"match\n",
+	},
+	{
+		"shopt -s extglob\ncase \"foo\" in !(foo)) echo match;; esac",
+		"",
+	},
+	{
+		"shopt -s extglob\ncase \"\" in !(foo)) echo match;; esac",
+		"match\n",
+	},
+	{
+		"shopt -s extglob\ncase \"baz\" in !(foo|bar)) echo match;; esac",
+		"match\n",
+	},
+	{
+		"shopt -s extglob\ncase \"file.tar.gz\" in !(*.sig)) echo match;; esac",
+		"match\n",
+	},
+	{
+		"shopt -s extglob\ncase \"file.sig\" in !(*.sig)) echo match;; esac",
+		"",
+	},
+	{
+		"shopt -s extglob\ncase \"foo_xxx_baz\" in foo_!(bar)_baz) echo match;; esac",
+		"match\n",
+	},
+	{
+		"shopt -s extglob\ncase \"foo_bar_baz\" in foo_!(bar)_baz) echo match;; esac",
+		"",
+	},
+	{
+		"shopt -s extglob\n[[ \"bar\" == !(foo) ]] && echo match",
+		"match\n",
+	},
+	// Unsupported: multiple groups, glob prefix, or glob suffix.
+	{
+		"shopt -s extglob\ncase \"xabab\" in *a!(b)) echo match;; esac",
+		" #IGNORE glob prefix not supported",
+	},
+	{
+		"shopt -s extglob\ncase \"baz\" in !(foo)!(bar)) echo match;; esac",
+		" #IGNORE multiple extglob negation groups not supported",
+	},
+	{
+		"shopt -s extglob\ncase \".bar\" in .*!(foo)) echo match;; esac",
+		" #IGNORE glob prefix not supported",
+	},
+	{
+		"shopt -s extglob\ncase \".foo\" in .*!(foo)) echo match;; esac",
+		" #IGNORE glob prefix not supported",
+	},
+	{
+		"shopt -s extglob\ncase \"bar\" in .*!(foo)) echo match;; esac",
+		" #IGNORE glob prefix not supported",
+	},
 	{
 		// Extended pattern matching is always available outside of pathname expansions (globbing).
 		"[[ a123z == a@([0-9])z ]]; echo $?; [[ a123z == a+([0-9])z ]]; echo $?",


### PR DESCRIPTION
Implement `!(pattern-list)` extglob negation for `case` and `[[ ]]` pattern matching, as suggested in #1252 (item 7).

Go's `regexp` package does not support negative lookahead, so `!(pattern)` cannot be compiled into a single regex. Instead, `pattern.Regexp` now returns a `NegExtglobError` sentinel, and the interpreter handles negation at the caller level:

- Simple case (`!(inner)` is the entire pattern): compile the inner pattern and negate `MatchString`
- Mixed case (`prefix!(inner)suffix`): try all split points of the name string where prefix and suffix match, and check that the middle does NOT match the inner pattern

Standalone `!` without `(` is now correctly treated as a literal character, fixing a minor regression where `!` in non-extglob context would error.

Pathname expansion (globbing) still returns the existing error for `!(...)` patterns, as glob matching requires different handling with `Filenames` mode and directory scanning.

Only a single `!(...)` group per pattern is supported; concatenated groups like `!(a)!(b)` are not. The empty pattern `!()` is not supported either, as the parser treats `)` as the end of the case pattern rather than the extglob closing paren.
