### PR TITLE
expand: apply array slicing in quoted parameter expansions

### DIFF
--- a/expand/param.go
+++ b/expand/param.go
@@ -115,24 +115,7 @@ func (cfg *Config) paramExp(pe *syntax.ParamExp) (string, error) {
 		case Indexed:
 			indexAllElements = true
 			callVarInd = false
-			elems = vr.List
-			slicePos := func(n int) int {
-				if n < 0 {
-					n = len(elems) + n
-					if n < 0 {
-						n = len(elems)
-					}
-				} else if n > len(elems) {
-					n = len(elems)
-				}
-				return n
-			}
-			if pe.Slice != nil && pe.Slice.Offset != nil {
-				elems = elems[slicePos(sliceOffset):]
-			}
-			if pe.Slice != nil && pe.Slice.Length != nil {
-				elems = elems[:slicePos(sliceLen)]
-			}
+			elems = cfg.sliceElems(pe, vr.List)
 			str = strings.Join(elems, " ")
 		}
 	}

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -462,6 +462,14 @@ var runTests = []runTest{
 	{`arr=("foo"); echo ${arr[@]:99}`, "\n"},
 	{`echo ${arr[@]:1:99}; echo ${arr[*]:1:99}`, "\n\n"},
 	{`arr=(0 1 2 3 4 5 6 7 8 9 0 a b c d e f g h); echo ${arr[@]:3:4}`, "3 4 5 6\n"},
+
+	// quoted array slicing
+	{`a=(1 2 3 4 5); echo "${a[@]:2:2}"`, "3 4\n"},
+	{`a=(1 2 3 4 5); echo "${a[*]:2:2}"`, "3 4\n"},
+	{`a=(1 2 3 4 5); b=("${a[@]:2:2}"); echo ${#b[@]}`, "2\n"},
+	{`a=(1 2 3 4 5); echo "${a[@]:3}"`, "4 5\n"},
+	{`a=(1 2 3 4 5); echo "${a[@]: -2}"`, "4 5\n"},
+	{`a=(1 2 3 4 5); echo "${a[@]: -99}"`, "\n"},
 	{`echo ${foo[@]}; echo ${foo[*]}`, "\n\n"},
 	// TODO: reenable once we figure out the broken pipe error
 	//{`$ENV_PROG | while read line; do if test -z "$line"; then echo empty; fi; break; done`, ""}, // never begin with an empty element


### PR DESCRIPTION
When `"${a[@]:offset:length}"` was the sole content of a double-quoted word, `quotedElemFields` returned the full array without applying the slice. This happened because the fast path for quoted array expansions did not account for `pe.Slice`.

### Reproduction

```bash
$ bash -c 'a=(1 2 3 4 5); echo "${a[@]:2:2}"'
3 4

$ gosh -c 'a=(1 2 3 4 5); echo "${a[@]:2:2}"'
1 2 3 4 5
```

### Fix

Add a `sliceElems` helper that applies offset and length to the element list, and call it from the `[@]` and `[*]` return points in `quotedElemFields`.

### Tests

6 new test cases covering `[@]`, `[*]`, array assignment, offset-only, negative offset, and negative-beyond-bounds.

Fixes #1239.
