### PR TITLE
expand: fix positional parameter slicing offsets

### DIFF
--- a/expand/param.go
+++ b/expand/param.go
@@ -115,7 +115,7 @@ func (cfg *Config) paramExp(pe *syntax.ParamExp) (string, error) {
 		case Indexed:
 			indexAllElements = true
 			callVarInd = false
-			elems = cfg.sliceElems(pe, vr.List)
+			elems = cfg.sliceElems(pe, vr.List, name == "@" || name == "*")
 			str = strings.Join(elems, " ")
 		}
 	}

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -470,6 +470,21 @@ var runTests = []runTest{
 	{`a=(1 2 3 4 5); echo "${a[@]:3}"`, "4 5\n"},
 	{`a=(1 2 3 4 5); echo "${a[@]: -2}"`, "4 5\n"},
 	{`a=(1 2 3 4 5); echo "${a[@]: -99}"`, "\n"},
+
+	// positional parameter slicing (1-based offset, $0 at offset 0)
+	{`f() { echo "${@:2:2}"; }; f a b c d e`, "b c\n"},
+	{`f() { echo ${@:2:2}; }; f a b c d e`, "b c\n"},
+	{`f() { echo "${@:1}"; }; f a b c`, "a b c\n"},
+	{`f() { echo "${*:2:2}"; }; f a b c d e`, "b c\n"},
+	{`f() { echo "${@: -2}"; }; f a b c d e`, "d e\n"},
+	{`f() { echo "${@: -3:2}"; }; f a b c d e`, "c d\n"},
+	{`f() { echo "${@:1:0}"; }; f a b c`, "\n"},
+	{`f() { echo "${@:99}"; }; f a b c`, "\n"},
+	{`set -- a b c; v=("${@:0:2}"); echo "${#v[@]}"`, "2\n"},
+	{`f() { for x in "${@:2:2}"; do echo "$x"; done; }; f a b c d e`, "b\nc\n"},
+	{`set --; v=("${@:0}"); echo "${#v[@]}"`, "1\n"},
+	{`f() { echo "${@: -10}"; }; f a b c`, "\n"},
+
 	{`echo ${foo[@]}; echo ${foo[*]}`, "\n\n"},
 	// TODO: reenable once we figure out the broken pipe error
 	//{`$ENV_PROG | while read line; do if test -z "$line"; then echo empty; fi; break; done`, ""}, // never begin with an empty element


### PR DESCRIPTION
## Summary

Two bugs in positional parameter slicing (`$@` and `$*`):

1. **Quoted `"${@:N:M}"` as sole double-quoted content** — `quotedElemFields` returned all positional parameters, ignoring the slice entirely.

2. **0-based instead of 1-based offsets** — In bash, `${@:N}` uses 1-based offsets and offset 0 includes `$0`. The interpreter used 0-based offsets because `r.Params` stores `$1+` as a 0-indexed Go slice without `$0`.

## Fix

Prepend `$0` to the element list before calling `sliceElems` (from #1258) at each call site that handles positional parameters. This makes standard 0-based Go slicing produce correct 1-based results. No separate helper function — reuses `sliceElems` directly.

## Changes

- `expand/expand.go` — `quotedElemFields`: handle `"${*:N:M}"` and `"${@:N:M}"` by prepending `$0` and calling `sliceElems`
- `expand/param.go` — `paramExp`: prepend `$0` before `sliceElems` call when `name` is `@` or `*`
- `interp/interp_test.go` — 12 test cases covering both code paths

Updates #1252.