### PR TITLE
syntax, interp: support brace expansion in declaration commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ $ echo '$((foo); (bar))' | shfmt
   This allows statically building their syntax tree,
   as opposed to keeping the arguments as a slice of words.
   It is also required to support `declare foo=(bar)`.
-  Note that this means expansions like `declare {a,b}=c` are not supported.
 
 * The entire library is written in pure Go, which limits how closely the
   interpreter can follow POSIX Shell and Bash semantics.

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -3289,6 +3289,15 @@ done <<< 2`,
 	{"b=c; echo a{1,2}$b", "a1c a2c\n"},
 	{"echo a{1,2}'bc'", "a1bc a2bc\n"},
 
+	// brace expansion in declarations
+	{"declare {A,B}_VAR=1; echo $A_VAR $B_VAR", "1 1\n"},
+	{"declare {x,y}=val; echo $x $y", "val val\n"},
+	{"declare -x RUN_{VERY_,}EXPENSIVE_TESTS=yes; echo $RUN_EXPENSIVE_TESTS", "yes\n"},
+	{"declare {A,B}_VAR; A_VAR=1; B_VAR=2; echo $A_VAR $B_VAR", "1 2\n"},
+	{"declare {foo=x,bar=y}; echo $foo $bar", "x y\n"},
+	{`declare foo{bar=baz`, "declare: invalid name \"foo{bar\"\nexit status 1 #JUSTERR"},
+	{"{a,b}=value", "\"a=value\": executable file not found in $PATH\nexit status 127 #JUSTERR"},
+
 	// tilde expansion
 	{
 		"[[ '~/foo' == ~/foo ]] || [[ ~/foo == '~/foo' ]]",

--- a/syntax/filetests_test.go
+++ b/syntax/filetests_test.go
@@ -4203,6 +4203,14 @@ var fileTests = []fileTestCase{
 		langFile(subshell(litStmt("local", "bar")), LangPOSIX),
 	),
 	fileTest(
+		[]string{"local {a,b}_c=1"},
+		langFile(&DeclClause{
+			Variant: lit("local"),
+			Args:    []*Assign{{Naked: true, Value: litWord("{a,b}_c=1")}},
+		}, LangBash|LangMirBSDKorn|LangZsh),
+		langFile(litStmt("local", "{a,b}_c=1"), LangPOSIX),
+	),
+	fileTest(
 		[]string{"typeset"},
 		langFile(&DeclClause{Variant: lit("typeset")}, LangBash|LangMirBSDKorn|LangZsh),
 		langFile(litStmt("typeset"), LangPOSIX),

--- a/syntax/parser.go
+++ b/syntax/parser.go
@@ -2643,7 +2643,7 @@ func (p *Parser) declClause(s *Stmt) {
 	for !p.stopToken() && !p.peekRedir() {
 		if p.hasValidIdent() {
 			ds.Args = append(ds.Args, p.getAssign(false))
-		} else if p.eqlOffs > 0 {
+		} else if p.eqlOffs > 0 && !strings.Contains(p.val[:p.eqlOffs], "{") {
 			p.curErr("invalid var name")
 		} else if p.tok == _LitWord && ValidName(p.val) {
 			ds.Args = append(ds.Args, &Assign{

--- a/syntax/parser_test.go
+++ b/syntax/parser_test.go
@@ -1666,6 +1666,10 @@ var errorCases = []errorCase{
 		langErr("1:9: invalid var name", LangBash|LangZsh),
 	),
 	errCase(
+		"declare {x,y}=(1 2)",
+		langErr("1:15: `declare` must be followed by names or assignments", LangBash|LangZsh),
+	),
+	errCase(
 		"a=(<)",
 		langErr("1:4: array element values must be words", LangBash|LangMirBSDKorn|LangZsh),
 	),


### PR DESCRIPTION
I took the liberty of submitting this PR because the fix turned out to be minimal (one-line parser change), but I fully understand if you'd prefer a different approach or consider this a deliberate design trade-off.

The parser currently errors on `local {A,B}_VAR=1` because `declClause` validates variable names before brace expansion can occur at runtime. The fix skips the "invalid var name" error when the name part contains `{`, letting it fall through to `getWord()`. At runtime, `flattenAssigns` already handles the rest: `Fields` calls `SplitBraces`/`Braces` to expand `{A,B}_VAR=1` into `A_VAR=1 B_VAR=1`, and the existing `ValidName` check catches invalid names after expansion.

This pattern appears in Gentoo ebuilds:

```bash
local -x RUN_{VERY_,}EXPENSIVE_TESTS=$(usex test-full yes no)
```

Changes:
- `syntax/parser.go`: skip error when name before `=` contains `{`
- `syntax/filetests_test.go`: parser AST test
- `interp/interp_test.go`: 4 runtime tests
- `README.md`: remove caveat

Fixes #1257.
