### PR TITLE
shfmt: insert space after Not

### DIFF
--- a/syntax/filetests_test.go
+++ b/syntax/filetests_test.go
@@ -3088,7 +3088,7 @@ var fileTests = []fileTestCase{
 		langFile(arithmExp(&UnaryArithm{Op: Dec, X: litWord("i")})),
 	),
 	fileTest(
-		[]string{`$((!i))`},
+		[]string{`$((! i))`},
 		langFile(arithmExp(&UnaryArithm{Op: Not, X: litWord("i")})),
 	),
 	fileTest(
@@ -3096,7 +3096,7 @@ var fileTests = []fileTestCase{
 		langFile(arithmExp(&UnaryArithm{Op: BitNegation, X: litWord("i")})),
 	),
 	fileTest(
-		[]string{`$((-!+i))`},
+		[]string{`$((-! +i))`},
 		langFile(arithmExp(&UnaryArithm{
 			Op: Minus,
 			X: &UnaryArithm{
@@ -3106,7 +3106,7 @@ var fileTests = []fileTestCase{
 		})),
 	),
 	fileTest(
-		[]string{`$((!!i))`},
+		[]string{`$((! ! i))`},
 		langFile(arithmExp(&UnaryArithm{
 			Op: Not,
 			X:  &UnaryArithm{Op: Not, X: litWord("i")},

--- a/syntax/printer.go
+++ b/syntax/printer.go
@@ -886,6 +886,9 @@ func (p *Printer) arithmExprRecurse(expr ArithmExpr, compact, spacePlusMinus boo
 				}
 			}
 			p.w.WriteString(expr.Op.String())
+			if expr.Op == Not {
+				p.space()
+			}
 			p.arithmExprRecurse(expr.X, compact, false)
 		}
 	case *ParenArithm:


### PR DESCRIPTION
**Purpose**

Attempts to solve #987 regarding history expansion triggered by missing whitespace after `!`.

**Changes**

I simply added a call to the printer's space function when the unary operator is a Not.

**Questions**

* Should I add a test of some sort?
* Should I add a check for compact, and omit the space if true? It "breaks" if the space is omitted, but I really am not sure if compact is considered "dangerous".

Thanks!

Closes #987