### PR TITLE
fileutil: recognize dash in shebang for -ln=auto

### DIFF
--- a/cmd/shfmt/testdata/script/walk.txtar
+++ b/cmd/shfmt/testdata/script/walk.txtar
@@ -99,6 +99,7 @@ modify${/}ext.zsh
 modify${/}shebang-args
 modify${/}shebang-bash
 modify${/}shebang-bash.sh
+modify${/}shebang-dash
 modify${/}shebang-env-bash
 modify${/}shebang-env-bats
 modify${/}shebang-env-sh
@@ -119,6 +120,7 @@ modify${/}ext.zsh
 modify${/}shebang-args
 modify${/}shebang-bash
 modify${/}shebang-bash.sh
+modify${/}shebang-dash
 modify${/}shebang-env-bash
 modify${/}shebang-env-bats
 modify${/}shebang-env-sh
@@ -137,6 +139,9 @@ modify${/}shebang-zsh
 -- modify/shebang-bash.sh --
 #!/bin/bash
  foo=(bar)
+-- modify/shebang-dash --
+#!/bin/dash
+ foo
 -- modify/shebang-usr-sh --
 #!/usr/bin/sh
  foo

--- a/fileutil/file.go
+++ b/fileutil/file.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	shebangRe = regexp.MustCompile(`^#![ \t]*/(usr/)?bin/(env[ \t]+)?(sh|bash|mksh|bats|zsh)(\s|$)`)
+	shebangRe = regexp.MustCompile(`^#![ \t]*/(usr/)?bin/(env[ \t]+)?(sh|dash|bash|mksh|bats|zsh)(\s|$)`)
 	extRe     = regexp.MustCompile(`\.(sh|bash|mksh|bats|zsh)$`)
 )
 

--- a/fileutil/file_test.go
+++ b/fileutil/file_test.go
@@ -27,6 +27,14 @@ func TestShebang(t *testing.T) {
 			want: "",
 		},
 		{
+			in:   []byte("#!/bin/dash"),
+			want: "dash",
+		},
+		{
+			in:   []byte("#!/usr/bin/env dash"),
+			want: "dash",
+		},
+		{
 			in:   []byte("#!/bin/zsh"),
 			want: "zsh",
 		},

--- a/syntax/parser.go
+++ b/syntax/parser.go
@@ -140,7 +140,7 @@ func (l *LangVariant) Set(s string) error {
 	switch s {
 	case "bash":
 		*l = LangBash
-	case "posix", "sh":
+	case "posix", "sh", "dash":
 		*l = LangPOSIX
 	case "mksh":
 		*l = LangMirBSDKorn


### PR DESCRIPTION
`shfmt --find .` doesn't list shell files with `#!/usr/bin/env dash` now.
I generated this PR using Cursor, but confirmed the changes.

---

## Summary

Extend shebang detection to `#!/bin/dash` and `#!/usr/bin/env dash`, mapping them to POSIX (same as `#!/bin/sh`). `syntax.LangVariant.Set` accepts `"dash"` so `shfmt` can apply the dialect when using `-ln=auto`.

## Context

- Related to #622 (shebang allowlist for auto language detection).
- This change is **detection only**: dash scripts use the existing POSIX dialect; there is no separate parser mode (see discussion in #105).

## Changes

- `fileutil`: add `dash` to `shebangRe`.
- `syntax`: map `dash` → `LangPOSIX` in `LangVariant.Set`.
- Tests: `fileutil` table tests; `walk.txtar` integration expectations for `shebang-dash`.

Made with [Cursor](https://cursor.com)