### PR TITLE
Feat test n option

### DIFF
--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -1977,10 +1977,6 @@ var runTests = []runTest{
 		"r\nw\nx\n",
 	},
 	{
-		"test -N a",
-		"unsupported unary test op: -N\nexit status 1 #IGNORE",
-	},
-	{
 		"test -? a",
 		// TODO: this error message should refer to `-?`
 		"1:1: not a valid test operator: `a`\n1:1: a must be followed by a word\nexit status 2 #JUSTERR",
@@ -3704,6 +3700,20 @@ var runTestsUnix = []runTest{
 	{
 		"mkdir -p 'a-*/d'; test -d $PWD/a-*/*",
 		"",
+	},
+
+	// windows does not reliably track last-access time, so -N is unix-only
+	{
+		">a; cat a; sleep 0.01; echo 'Hello' >> a; test -N a && echo yes",
+		"yes\n",
+	},
+	{
+		"test -N nonexistent",
+		"exit status 1",
+	},
+	{
+		">a; sleep 0.01; cat a; test -N a; echo $?",
+		"1\n",
 	},
 
 	// no fifos on windows

--- a/interp/os_darwin.go
+++ b/interp/os_darwin.go
@@ -1,0 +1,15 @@
+package interp
+
+import (
+	"io/fs"
+	"syscall"
+	"time"
+)
+
+func getAtime(info fs.FileInfo) time.Time {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return info.ModTime()
+	}
+	return time.Unix(stat.Atimespec.Sec, stat.Atimespec.Nsec)
+}

--- a/interp/os_linux.go
+++ b/interp/os_linux.go
@@ -1,0 +1,16 @@
+package interp
+
+import (
+	"io/fs"
+	"syscall"
+	"time"
+)
+
+func getAtime(info fs.FileInfo) time.Time {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return info.ModTime()
+	}
+	// Note that these are int32 on 32-bit platforms.
+	return time.Unix(int64(stat.Atim.Sec), int64(stat.Atim.Nsec))
+}

--- a/interp/os_other.go
+++ b/interp/os_other.go
@@ -1,0 +1,12 @@
+//go:build !linux && !darwin && !windows
+
+package interp
+
+import (
+	"io/fs"
+	"time"
+)
+
+func getAtime(info fs.FileInfo) time.Time {
+	return info.ModTime()
+}

--- a/interp/os_windows.go
+++ b/interp/os_windows.go
@@ -1,0 +1,15 @@
+package interp
+
+import (
+	"io/fs"
+	"syscall"
+	"time"
+)
+
+func getAtime(info fs.FileInfo) time.Time {
+	stat, ok := info.Sys().(*syscall.Win32FileAttributeData)
+	if !ok {
+		return info.ModTime()
+	}
+	return time.Unix(0, stat.LastAccessTime.Nanoseconds())
+}

--- a/interp/test.go
+++ b/interp/test.go
@@ -166,8 +166,11 @@ func (r *Runner) unTest(ctx context.Context, op syntax.UnTestOperator, x string)
 	case syntax.TsGIDSet:
 		return r.statMode(ctx, x, os.ModeSetgid)
 	case syntax.TsModif:
-		r.errf("unsupported unary test op: %v\n", op)
-		return false
+		info, err := r.stat(ctx, x)
+		if err != nil {
+			return false
+		}
+		return info.ModTime().After(getAtime(info))
 	case syntax.TsRead:
 		return r.access(ctx, r.absPath(x), access_R_OK) == nil
 	case syntax.TsWrite:


### PR DESCRIPTION
## Summary

* Implement the -N file test operator (TsModif), which was previously unsupported and returned an error
* Add interp/actime package with platform-specific GetAtime() functions (darwin, linux, windows) to retrieve file access time, as access time retrieval differs across platforms
* Tested GetAtime() across all supported platforms, including Windows

Implemented #1316 