### PR TITLE
syntax: don't join then/do with semicolon when heredocs are pending

### DIFF
--- a/syntax/printer.go
+++ b/syntax/printer.go
@@ -359,7 +359,7 @@ func (p *Printer) spacedToken(s string, pos Pos) {
 }
 
 func (p *Printer) semiOrNewl(s string, pos Pos) {
-	if p.wantsNewline(Pos{}, false) {
+	if p.wantsNewline(Pos{}, false) || len(p.pendingHdocs) > 0 {
 		p.newline(pos)
 		p.indent()
 	} else {

--- a/syntax/printer_test.go
+++ b/syntax/printer_test.go
@@ -113,6 +113,8 @@ var printTests = []printCase{
 	samePrint("<<EOF\nEOF"),
 	samePrint("foo <<EOF\nEOF\n\nbar"),
 	samePrint("foo <<'EOF'\nEOF\n\nbar"),
+	samePrint("if cmd <<EOF\nbody\nEOF\nthen\n\tfoo\nfi"),
+	samePrint("while cmd <<EOF\nbody\nEOF\ndo\n\tfoo\ndone"),
 	{
 		"{ foo; bar; }",
 		"{\n\tfoo\n\tbar\n}",


### PR DESCRIPTION
When a heredoc redirect appears in an if/while condition, semiOrNewl would place "; then" or "; do" on the same line as the redirect, producing hard-to-read output like:

    if cmd <<EOF; then
    body
    EOF
        foo
    fi

Now force a newline when there are pending heredocs, so the heredoc body is flushed before the keyword:

    if cmd <<EOF
    body
    EOF
    then
        foo
    fi