### PR TITLE
syntax: allow bracket globs in array elements

### DIFF
--- a/syntax/filetests_test.go
+++ b/syntax/filetests_test.go
@@ -4915,6 +4915,20 @@ var fileTests = []fileTestCase{
 		}}}, LangBash),
 	),
 	fileTest(
+		[]string{`a=([i])`},
+		langFile(&CallExpr{Assigns: []*Assign{{
+			Name: lit("a"),
+			Array: arrValues(word(lit("[i]"))),
+		}}}, LangBash|LangZsh),
+	),
+	fileTest(
+		[]string{`a=("foo"[0-9])`},
+		langFile(&CallExpr{Assigns: []*Assign{{
+			Name: lit("a"),
+			Array: arrValues(word(dblQuoted(lit("foo")), lit("[0-9]"))),
+		}}}, LangBash|LangZsh),
+	),
+	fileTest(
 		[]string{"a]b"},
 		langFile(litStmt("a]b")),
 	),

--- a/syntax/lexer.go
+++ b/syntax/lexer.go
@@ -325,7 +325,7 @@ skipSpace:
 			}
 			p.next()
 		case '[':
-			if p.quote == arrayElems {
+			if p.quote == arrayElems && p.arrayIndexAssign() {
 				p.rune()
 				p.tok = leftBrack
 			} else {
@@ -1064,6 +1064,54 @@ func (p *Parser) zshNumRange() bool {
 		rest = rest[1:]
 	}
 	return len(rest) > 0 && rest[0] == '>'
+}
+
+// arrayIndexAssign peeks ahead after a '[' in an array literal and reports
+// whether it begins an indexed assignment like [x]=y rather than a word that
+// happens to start with a bracket glob, like [0-9] or [[:space:]].
+func (p *Parser) arrayIndexAssign() bool {
+	rest := p.bs[p.bsp:]
+	depth := 1
+	var quote byte
+	escaped := false
+	for i, b := range rest {
+		if quote != 0 {
+			if escaped {
+				escaped = false
+				continue
+			}
+			if quote == '"' && b == '\\' {
+				escaped = true
+				continue
+			}
+			if b == quote {
+				quote = 0
+			}
+			continue
+		}
+		if escaped {
+			escaped = false
+			continue
+		}
+		switch b {
+		case '\\':
+			escaped = true
+		case '\'', '"':
+			quote = b
+		case '[':
+			depth++
+		case ']':
+			depth--
+			if depth == 0 {
+				return i+1 < len(rest) && rest[i+1] == '='
+			}
+		}
+	}
+	// If we can't find a matching closing bracket in the buffered input, keep the
+	// existing indexed-assignment tokenization and let the parser report any
+	// syntax errors. This keeps the lookahead conservative and avoids changing
+	// unrelated incomplete forms.
+	return true
 }
 
 func (p *Parser) advanceLitNone(r rune) {

--- a/syntax/parser_test.go
+++ b/syntax/parser_test.go
@@ -1694,11 +1694,6 @@ var errorCases = []errorCase{
 		langErr("1:4: reached `)` without matching `[` with `]`", LangBash|LangZsh),
 	),
 	errCase(
-		"a=([i])",
-		langErr("1:4: `[x]` must be followed by `=`", LangBash|LangZsh),
-		flipConfirmAll, // TODO: why is this valid?
-	),
-	errCase(
 		"a[i]=(y)",
 		langErr("1:5: arrays cannot be nested", LangBash),
 	),


### PR DESCRIPTION
Fixes #1322.

Array elements in Bash and Zsh can start with bracket globs, but the array-element lexer currently tokenizes every `[` as the start of an indexed assignment.

That makes inputs like:

```sh
matches=( "${BASE_DIR}/v${YEAR}-"[0-9][0-9]-[0-9][0-9]-[0-9][0-9][0-9][0-9] )
```

fail with `[x] must be followed by '='` even though the shell accepts them.

This change only keeps `[` as indexed-assignment syntax in array literals when the matching `]` is immediately followed by `=`. Otherwise, it stays part of the array element word.

I added regression coverage for both a bare bracket glob array element and the quoted-prefix form from the issue.

Tests:
- `go test ./syntax -run 'TestParseFiles/(bash|zsh)'`
- `go test ./syntax -run 'TestParseErr/(bash|zsh)'`
- `go test ./syntax -run 'TestParseConfirm/(bash|zsh)'`
- `go test ./...`
