### PR TITLE
expand: Support integer bases in arithmetic

### DIFF
--- a/expand/arith.go
+++ b/expand/arith.go
@@ -111,10 +111,35 @@ func oneIf(b bool) int {
 	return 0
 }
 
-// atoi is like [strconv.ParseInt](s, 10, 64), but it ignores errors and trims whitespace.
+// atoi is like [strconv.ParseInt](s, BASE, 64), but it handles integer
+// base prefixes according to bash-shell's rules, ignores errors, and
+// trims whitespace.
+//
+// For more information about bash's integer base handling syntax,
+// refer to the bash manual:
+// https://www.man7.org/linux/man-pages/man1/bash.1.html
 func atoi(s string) int64 {
 	s = strings.TrimSpace(s)
-	n, _ := strconv.ParseInt(s, 10, 64)
+	base := int64(10)
+	switch {
+	case strings.HasPrefix(s, "0x") || strings.HasPrefix(s, "0X"):
+		base = 16
+		s = s[2:]
+	case strings.HasPrefix(s, "0"):
+		base = 8
+		s = s[1:]
+	default:
+		baseStr, intStr, hasSep := strings.Cut(s, "#")
+		if hasSep {
+			var err error
+			base, err = strconv.ParseInt(baseStr, 10, 8)
+			if err != nil || base > 64 {
+				return 0
+			}
+			s = intStr
+		}
+	}
+	n, _ := strconv.ParseInt(s, int(base), 64)
 	return n
 }
 

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -2074,6 +2074,44 @@ var runTests = []runTest{
 		"2 3\n",
 	},
 	{
+		"echo $((255+1))",
+		"256\n",
+	},
+	{
+		"echo $((0xff+1))",
+		"256\n",
+	},
+	{
+		"echo $((0377+1))",
+		"256\n",
+	},
+	{
+		"echo $((10#255+1))",
+		"256\n",
+	},
+	{
+		"echo $((16#ff+1))",
+		"256\n",
+	},
+	{
+		"echo $((2#11111111+1))",
+		"256\n",
+	},
+	// TODO: Enable this test once integer bit widths are
+	// handled in a consistent manner throughout the library.
+	//{
+	//	"echo $((16#badc0ffee+1))",
+	//	"50159747055\n",
+	//},
+	{
+		"echo $((16#cafe+1))",
+		"51967\n",
+	},
+	{
+		"echo $((nope+1))",
+		"1\n", // Yes, this is what bash does.
+	},
+	{
 		"((1))",
 		"",
 	},


### PR DESCRIPTION
The existing arithmetic logic is hard coded to always treat strings as base 10 integers. This commit updates that logic to support what bash supports based on its manual page. [1]

References

1. https://www.man7.org/linux/man-pages/man1/bash.1.html