### PR TITLE
syntax: honor escaped brace metacharacters

### DIFF
--- a/expand/expand_test.go
+++ b/expand/expand_test.go
@@ -92,6 +92,39 @@ func TestFieldsIdempotency(t *testing.T) {
 	}
 }
 
+func TestFieldsBraceEscapes(t *testing.T) {
+	tests := []struct {
+		src  string
+		want []string
+	}{
+		{`\{a,b}`, []string{"{a,b}"}},
+		{`\\{a,b}`, []string{`\a`, `\b`}},
+		{`\\\{a,b}`, []string{`\{a,b}`}},
+		{`{a\,b,c}`, []string{"a,b", "c"}},
+		{`{a\}b,c}`, []string{"a}b", "c"}},
+		{`{1\..3,foo}`, []string{"1..3", "foo"}},
+		{`\{{x},z}`, []string{"{x}", "{z"}},
+		{`\{{x,y},z}`, []string{"{x,z}", "{y,z}"}},
+		{`\{{x}y,z}`, []string{"{x}y", "{z"}},
+		{`\{{1..3},}`, []string{"{1,}", "{2,}", "{3,}"}},
+		{`\{{1\..3},}`, []string{"{1..3}", "{"}},
+		{`{x},z}`, []string{"x}", "z"}},
+		{`{{x},z}`, []string{"{x}", "z"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.src, func(t *testing.T) {
+			word := parseWord(t, tc.src)
+			got, err := Fields(nil, word)
+			if err != nil {
+				t.Fatalf("did not want error, got %v", err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("wanted %q, got %q", tc.want, got)
+			}
+		})
+	}
+}
+
 func Test_glob(t *testing.T) {
 	cfg := &Config{
 		ReadDir2: func(string) ([]fs.DirEntry, error) {

--- a/syntax/braces.go
+++ b/syntax/braces.go
@@ -16,6 +16,22 @@ var (
 	litRightBrace = &Lit{Value: "}"}
 )
 
+// braceEscaped reports whether s[i] is quoted by a backslash.
+//
+// The parser keeps backslashes in literal word parts until quote removal,
+// but brace expansion happens before quote removal. SplitBraces must therefore
+// distinguish unquoted brace metacharacters from escaped literal bytes. An odd
+// number of immediately preceding backslashes quotes s[i]; an even number leaves
+// s[i] unquoted because the backslashes pair up as literal backslashes.
+func braceEscaped(s string, i int) bool {
+	count := 0
+	for i > 0 && s[i-1] == '\\' {
+		count++
+		i--
+	}
+	return count%2 == 1
+}
+
 // SplitBraces parses brace expansions within a word's literal parts.
 // If any valid brace expansions are found, they are replaced with BraceExp nodes,
 // and the function returns true.
@@ -73,19 +89,22 @@ func SplitBraces(word *Word) bool {
 			}
 			switch lit.Value[j] {
 			case '{':
+				if braceEscaped(lit.Value, j) {
+					continue
+				}
 				addlitidx()
 				acc = &Word{}
 				cur = &BraceExp{Elems: []*Word{acc}}
 				open = append(open, cur)
 			case ',':
-				if cur == nil {
+				if cur == nil || braceEscaped(lit.Value, j) {
 					continue
 				}
 				addlitidx()
 				acc = &Word{}
 				cur.Elems = append(cur.Elems, acc)
 			case '.':
-				if cur == nil {
+				if cur == nil || braceEscaped(lit.Value, j) {
 					continue
 				}
 				if j+1 >= len(lit.Value) || lit.Value[j+1] != '.' {
@@ -97,10 +116,19 @@ func SplitBraces(word *Word) bool {
 				cur.Elems = append(cur.Elems, acc)
 				j++
 			case '}':
-				if cur == nil {
+				if cur == nil || braceEscaped(lit.Value, j) {
 					continue
 				}
 				addlitidx()
+				if len(open) == 1 && len(cur.Elems) == 1 && !cur.Sequence {
+					// A single-element top-level brace cannot form an
+					// expansion yet, but a later comma or sequence operator
+					// might; bash treats this '}' as literal in cases like
+					// {x},y}. Nested single-element braces are still closed
+					// below so that {{x},y} expands to {x} and y.
+					addLit(litRightBrace)
+					break
+				}
 				br := pop()
 				if len(br.Elems) == 1 {
 					// return {x} to a non-brace


### PR DESCRIPTION
cc @mvdan 

## Summary

`syntax.SplitBraces` currently scans literal word parts for `{`, `,`, `..`, and `}` without checking whether those bytes were quoted with a backslash. Bash performs brace expansion before quote removal, but brace syntax is still made of **unquoted** metacharacters: an unquoted opening brace, an unquoted comma or sequence expression, and an unquoted closing brace.

As a result, `expand.Fields` can produce fields that differ from bash for words such as:

- `\{a,b}`: the `{` is quoted, so this should stay one field: `{a,b}`
- `{a\,b,c}`: the comma is quoted, so this should expand to `a,b` and `c`
- `{a\}b,c}`: the first `}` is quoted, so this should expand to `a}b` and `c`
- `\{{x},z}`: the first `{` is quoted, but the later brace expression should still be parsed like bash

This PR updates `SplitBraces` to ignore backslash-escaped brace metacharacters. It also keeps a top-level single-element brace open long enough for a later unescaped comma or sequence operator to form an expansion, which is needed for bash-compatible cases like `{x},z}` and `\{{x},z}`.

The actual expansion enumerator, `expand.Braces`, is unchanged; this only changes how `syntax.SplitBraces` identifies `BraceExp` nodes.

## Why this is needed

`expand.Fields` is commonly used as the high-level shell field expansion API. Callers expect it to be close to bash for argument expansion, especially because brace expansion happens before quote removal. Today, callers that need bash-compatible behavior must add their own pre-processing around `expand.Fields` to protect escaped brace metacharacters before `SplitBraces` runs.

Fixing this in `SplitBraces` is the right layer because:

- `SplitBraces` is where literal text is classified as brace syntax or ordinary text.
- `expand.Braces` only enumerates already-parsed `BraceExp` nodes; by then it is too late to know that a metacharacter was escaped.
- The parser preserves backslashes in `*syntax.Lit` values, so `SplitBraces` has enough information to distinguish quoted vs unquoted brace metacharacters.
- Downstream users get bash-compatible behavior without maintaining local workarounds.

## Downstream context

This issue was found while updating DataDog/rshell from `mvdan.cc/sh/v3` v3.13.0 to v3.13.1: https://github.com/DataDog/rshell/pull/197

rshell currently carries a local compatibility shim before calling `expand.Fields` to preserve bash behavior for escaped brace metacharacters. If this fix lands upstream and is released, rshell should be able to remove most or all of that workaround.

## Reproducing and comparing with bash

From a checkout of `mvdan/sh`, run this Go reproducer:

```sh
cat >/tmp/brace-repro.go <<'EOF'
package main

import (
	"fmt"
	"strings"

	"mvdan.cc/sh/v3/expand"
	"mvdan.cc/sh/v3/syntax"
)

func main() {
	cases := []string{
		`\{a,b}`,
		`\\{a,b}`,
		`\\\{a,b}`,
		`{a\,b,c}`,
		`{a\}b,c}`,
		`{1\..3,foo}`,
		`\{{x},z}`,
		`\{{1..3},}`,
		`\{{1\..3},}`,
		`{x},z}`,
		`{{x},z}`,
	}
	for _, src := range cases {
		word, err := syntax.NewParser().Document(strings.NewReader(src))
		if err != nil {
			panic(err)
		}
		fields, err := expand.Fields(nil, word)
		if err != nil {
			panic(err)
		}
		fmt.Printf("case %s\n", src)
		for _, field := range fields {
			fmt.Printf("<%s>\n", field)
		}
	}
}
EOF

go run /tmp/brace-repro.go >/tmp/sh-expand.out
```

Then run the equivalent bash argv-expansion script:

```sh
cat >/tmp/brace-repro.sh <<'EOF'
show() {
	printf 'case %s\n' "$1"
	shift
	printf '<%s>\n' "$@"
}

show '\{a,b}'      \{a,b}
show '\\{a,b}'     \\{a,b}
show '\\\{a,b}'    \\\{a,b}
show '{a\,b,c}'    {a\,b,c}
show '{a\}b,c}'    {a\}b,c}
show '{1\..3,foo}' {1\..3,foo}
show '\{{x},z}'    \{{x},z}
show '\{{1..3},}'  \{{1..3},}
show '\{{1\..3},}' \{{1\..3},}
show '{x},z}'      {x},z}
show '{{x},z}'     {{x},z}
EOF

bash /tmp/brace-repro.sh >/tmp/bash.out
```

Compare them:

```sh
diff -u /tmp/bash.out /tmp/sh-expand.out
```

On `master` before this PR, the diff shows multiple mismatches, for example `\{a,b}` is incorrectly expanded as if the escaped `{` were brace syntax. With this PR, the diff is empty for these cases.

## Tests

```sh
go test ./syntax ./expand
```

