### PR TITLE
interp: add stmt, subshell, builtin, func-call, and var-lookup handlers

### DIFF
--- a/interp/api.go
+++ b/interp/api.go
@@ -85,6 +85,29 @@ type Runner struct {
 	// The slice is needed to preserve the relative order of middlewares.
 	execMiddlewares []func(ExecHandlerFunc) ExecHandlerFunc
 
+	// stmtHandler is built from stmtMiddlewares when Reset is first called.
+	stmtHandler     StmtHandlerFunc
+	stmtMiddlewares []func(StmtHandlerFunc) StmtHandlerFunc
+
+	// subshellHandler is built from subshellMiddlewares when Reset is first called.
+	subshellHandler     SubshellHandlerFunc
+	subshellMiddlewares []func(SubshellHandlerFunc) SubshellHandlerFunc
+
+	// builtinOverrides is the registry populated by [BuiltinHandler]. It may be nil.
+	builtinOverrides map[string]BuiltinHandlerFunc
+
+	// builtinHandler is built from builtinMiddlewares when Reset is first called.
+	builtinHandler     BuiltinHandlerFunc
+	builtinMiddlewares []func(BuiltinHandlerFunc) BuiltinHandlerFunc
+
+	// lookupVarHandler is built from lookupVarMiddlewares when Reset is first called.
+	lookupVarHandler     LookupVarHandlerFunc
+	lookupVarMiddlewares []func(LookupVarHandlerFunc) LookupVarHandlerFunc
+
+	// funcCallHandler is built from funcCallMiddlewares when Reset is first called.
+	funcCallHandler     FuncCallHandlerFunc
+	funcCallMiddlewares []func(FuncCallHandlerFunc) FuncCallHandlerFunc
+
 	// openHandler is a function responsible for opening files. It must not be nil.
 	openHandler OpenHandlerFunc
 
@@ -166,6 +189,48 @@ type Runner struct {
 	// Fake signal callbacks
 	callbackErr  string
 	callbackExit string
+}
+
+// buildHandlerChains constructs the handler middleware chains.
+// Each chain bottom recovers its runner from ctx, so subshells inherit them.
+func (r *Runner) buildHandlerChains() {
+	r.stmtHandler = func(ctx context.Context, stmt *syntax.Stmt) {
+		runnerFromCtx(ctx).dispatchStmt(ctx, stmt)
+	}
+	for _, mw := range slices.Backward(r.stmtMiddlewares) {
+		r.stmtHandler = mw(r.stmtHandler)
+	}
+	r.subshellHandler = func(ctx context.Context, kind SubshellKind, run func(ctx context.Context) int) int {
+		return run(ctx)
+	}
+	for _, mw := range slices.Backward(r.subshellMiddlewares) {
+		r.subshellHandler = mw(r.subshellHandler)
+	}
+	r.builtinHandler = func(ctx context.Context, name string, args []string) ExitStatus {
+		r := HandlerCtx(ctx).runner
+		if fn, ok := r.builtinOverrides[name]; ok {
+			code := fn(ctx, name, args)
+			r.exit.code = uint8(code)
+			return code
+		}
+		r.exit = r.internalBuiltin(ctx, name, args)
+		return ExitStatus(r.exit.code)
+	}
+	for _, mw := range slices.Backward(r.builtinMiddlewares) {
+		r.builtinHandler = mw(r.builtinHandler)
+	}
+	r.funcCallHandler = func(ctx context.Context, name string, args []string) {
+		runnerFromCtx(ctx).dispatchFuncCall(ctx, name, args)
+	}
+	for _, mw := range slices.Backward(r.funcCallMiddlewares) {
+		r.funcCallHandler = mw(r.funcCallHandler)
+	}
+	r.lookupVarHandler = func(ctx context.Context, name string) expand.Variable {
+		return runnerFromCtx(ctx).defaultLookupVar(ctx, name)
+	}
+	for _, mw := range slices.Backward(r.lookupVarMiddlewares) {
+		r.lookupVarHandler = mw(r.lookupVarHandler)
+	}
 }
 
 // exitStatus holds the state of the shell after running one command.
@@ -508,6 +573,83 @@ func StatHandler(f StatHandlerFunc) RunnerOption {
 	}
 }
 
+// StmtHandlers appends middlewares to handle statement dispatch.
+// See [ExecHandlers] for details on the middleware chaining.
+//
+// Unlike [ExecHandlers], this fires for every statement,
+// including builtins, function calls, and nested subshells.
+func StmtHandlers(middlewares ...func(next StmtHandlerFunc) StmtHandlerFunc) RunnerOption {
+	return func(r *Runner) error {
+		r.stmtMiddlewares = append(r.stmtMiddlewares, middlewares...)
+		return nil
+	}
+}
+
+// SubshellHandlers appends middlewares to handle subshell creation.
+// See [ExecHandlers] for details on the middleware chaining.
+func SubshellHandlers(middlewares ...func(next SubshellHandlerFunc) SubshellHandlerFunc) RunnerOption {
+	return func(r *Runner) error {
+		r.subshellMiddlewares = append(r.subshellMiddlewares, middlewares...)
+		return nil
+	}
+}
+
+// BuiltinHandler registers fn as the override for the named builtin.
+// See [BuiltinHandlerFunc] for more info.
+//
+// A nil fn removes any previous registration.
+// The override applies even to names that are not real builtins,
+// so it can also be used to add custom commands.
+//
+// Overriding "set", "unset", "cd", or "read" can disrupt the runner's internal state.
+// For finer-grained control, see [BuiltinHandlers].
+func BuiltinHandler(name string, fn BuiltinHandlerFunc) RunnerOption {
+	return func(r *Runner) error {
+		if fn == nil {
+			delete(r.builtinOverrides, name)
+			return nil
+		}
+		if r.builtinOverrides == nil {
+			r.builtinOverrides = make(map[string]BuiltinHandlerFunc)
+		}
+		r.builtinOverrides[name] = fn
+		return nil
+	}
+}
+
+// BuiltinHandlers appends middlewares around builtin execution.
+// See [ExecHandlers] for details on the middleware chaining.
+//
+// The bottom of the chain dispatches to a [BuiltinHandler] override
+// or to the runner's internal builtin implementation.
+func BuiltinHandlers(middlewares ...func(next BuiltinHandlerFunc) BuiltinHandlerFunc) RunnerOption {
+	return func(r *Runner) error {
+		r.builtinMiddlewares = append(r.builtinMiddlewares, middlewares...)
+		return nil
+	}
+}
+
+// LookupVarHandlers appends middlewares around variable lookup.
+// See [ExecHandlers] for details on the middleware chaining.
+//
+// The bottom of the chain is the runner's own resolution,
+// so middlewares can wrap rather than replace it.
+func LookupVarHandlers(middlewares ...func(next LookupVarHandlerFunc) LookupVarHandlerFunc) RunnerOption {
+	return func(r *Runner) error {
+		r.lookupVarMiddlewares = append(r.lookupVarMiddlewares, middlewares...)
+		return nil
+	}
+}
+
+// FuncCallHandlers appends middlewares around the execution of declared shell functions.
+// See [ExecHandlers] for details on the middleware chaining.
+func FuncCallHandlers(middlewares ...func(next FuncCallHandlerFunc) FuncCallHandlerFunc) RunnerOption {
+	return func(r *Runner) error {
+		r.funcCallMiddlewares = append(r.funcCallMiddlewares, middlewares...)
+		return nil
+	}
+}
+
 func stdinFile(r io.Reader) (*os.File, error) {
 	switch r := r.(type) {
 	case *os.File:
@@ -781,6 +923,7 @@ func (r *Runner) Reset() {
 		for _, mw := range slices.Backward(r.execMiddlewares) {
 			r.execHandler = mw(r.execHandler)
 		}
+		r.buildHandlerChains()
 		// Fill tempDir; only need to do this once given that Env will not change.
 		if dir := r.Env.Get("TMPDIR").String(); filepath.IsAbs(dir) {
 			r.tempDir = dir
@@ -792,13 +935,14 @@ func (r *Runner) Reset() {
 	}
 	// reset the internal state
 	*r = Runner{
-		Env:            r.Env,
-		tempDir:        r.tempDir,
-		callHandler:    r.callHandler,
-		execHandler:    r.execHandler,
-		openHandler:    r.openHandler,
-		readDirHandler: r.readDirHandler,
-		statHandler:    r.statHandler,
+		Env:              r.Env,
+		tempDir:          r.tempDir,
+		callHandler:      r.callHandler,
+		execHandler:      r.execHandler,
+		builtinOverrides: r.builtinOverrides,
+		openHandler:      r.openHandler,
+		readDirHandler:   r.readDirHandler,
+		statHandler:      r.statHandler,
 
 		// These can be set by functions like [Dir] or [Params], but
 		// builtins can overwrite them; reset the fields to whatever the
@@ -822,6 +966,19 @@ func (r *Runner) Reset() {
 
 		dirStack: r.dirStack[:0],
 		usedNew:  r.usedNew,
+
+		stmtMiddlewares:      r.stmtMiddlewares,
+		subshellMiddlewares:  r.subshellMiddlewares,
+		builtinMiddlewares:   r.builtinMiddlewares,
+		funcCallMiddlewares:  r.funcCallMiddlewares,
+		lookupVarMiddlewares: r.lookupVarMiddlewares,
+
+		// Built once in the first-time setup above; see [Runner.buildHandlerChains].
+		stmtHandler:      r.stmtHandler,
+		subshellHandler:  r.subshellHandler,
+		builtinHandler:   r.builtinHandler,
+		funcCallHandler:  r.funcCallHandler,
+		lookupVarHandler: r.lookupVarHandler,
 	}
 	// Ensure we stop referencing any pointers before we reuse bgProcs.
 	clear(r.bgProcs)
@@ -977,22 +1134,37 @@ func (r *Runner) subshell(background bool) *Runner {
 	// Keep in sync with the Runner type. Manually copy fields, to not copy
 	// sensitive ones like [errgroup.Group], and to do deep copies of slices.
 	r2 := &Runner{
-		Dir:            r.Dir,
-		tempDir:        r.tempDir,
-		Params:         r.Params,
-		callHandler:    r.callHandler,
-		execHandler:    r.execHandler,
-		openHandler:    r.openHandler,
-		readDirHandler: r.readDirHandler,
-		statHandler:    r.statHandler,
-		stdin:          r.stdin,
-		stdout:         r.stdout,
-		stderr:         r.stderr,
-		filename:       r.filename,
-		opts:           r.opts,
-		usedNew:        r.usedNew,
-		exit:           r.exit,
-		lastExit:       r.lastExit,
+		Dir:              r.Dir,
+		tempDir:          r.tempDir,
+		Params:           r.Params,
+		callHandler:      r.callHandler,
+		execHandler:      r.execHandler,
+		builtinOverrides: r.builtinOverrides,
+		openHandler:      r.openHandler,
+		readDirHandler:   r.readDirHandler,
+		statHandler:      r.statHandler,
+
+		stmtMiddlewares:      r.stmtMiddlewares,
+		subshellMiddlewares:  r.subshellMiddlewares,
+		builtinMiddlewares:   r.builtinMiddlewares,
+		funcCallMiddlewares:  r.funcCallMiddlewares,
+		lookupVarMiddlewares: r.lookupVarMiddlewares,
+
+		// Inherited from the parent; see [Runner.buildHandlerChains].
+		stmtHandler:      r.stmtHandler,
+		subshellHandler:  r.subshellHandler,
+		builtinHandler:   r.builtinHandler,
+		funcCallHandler:  r.funcCallHandler,
+		lookupVarHandler: r.lookupVarHandler,
+
+		stdin:    r.stdin,
+		stdout:   r.stdout,
+		stderr:   r.stderr,
+		filename: r.filename,
+		opts:     r.opts,
+		usedNew:  r.usedNew,
+		exit:     r.exit,
+		lastExit: r.lastExit,
 
 		origStdout: r.origStdout, // used for process substitutions
 	}

--- a/interp/builtin.go
+++ b/interp/builtin.go
@@ -145,7 +145,20 @@ func (hc HandlerContext) Builtin(ctx context.Context, args []string) error {
 	return nil
 }
 
-func (r *Runner) builtin(ctx context.Context, pos syntax.Pos, name string, args []string) (exit exitStatus) {
+func (r *Runner) builtin(ctx context.Context, pos syntax.Pos, name string, args []string) exitStatus {
+	hctx := r.handlerCtx(ctx, handlerKindBuiltin, pos)
+	r.exit = exitStatus{}
+	code := r.builtinHandler(hctx, name, args)
+	// A middleware may short-circuit without writing r.exit;
+	// fall back to the returned exit code.
+	if r.exit == (exitStatus{}) {
+		r.exit.code = uint8(code)
+	}
+	return r.exit
+}
+
+func (r *Runner) internalBuiltin(ctx context.Context, name string, args []string) (exit exitStatus) {
+	pos := HandlerCtx(ctx).Pos
 	failf := func(code uint8, format string, args ...any) exitStatus {
 		r.errf(format, args...)
 		exit.code = code

--- a/interp/handler.go
+++ b/interp/handler.go
@@ -5,6 +5,7 @@ package interp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -41,6 +42,7 @@ const (
 	handlerKindCall                // [CallHandlerFunc]
 	handlerKindOpen                // [OpenHandlerFunc]
 	handlerKindReadDir             // [ReadDirHandlerFunc2]
+	handlerKindBuiltin             // [BuiltinHandlerFunc]
 )
 
 // HandlerContext is the data passed to all the handler functions via [context.WithValue].
@@ -389,4 +391,92 @@ func DefaultStatHandler() StatHandlerFunc {
 			return os.Stat(path)
 		}
 	}
+}
+
+// StmtHandlerFunc is a handler which runs on every [syntax.Stmt]
+// before it is dispatched by the runner.
+type StmtHandlerFunc func(ctx context.Context, stmt *syntax.Stmt)
+
+// SubshellKind identifies the kind of subshell creation site.
+// It is passed to [SubshellHandlerFunc] so handlers can distinguish them.
+type SubshellKind int
+
+const (
+	_                      SubshellKind = iota
+	SubshellKindBackground              // `cmd &` and `cmd & disown`
+	SubshellKindParen                   // `( ... )`
+	SubshellKindCmdSubst                // `$(...)` and the legacy backtick form
+	SubshellKindProcSubst               // `<(...)` and `>(...)`
+	SubshellKindPipeline                // a non-final pipeline element, e.g. the `a` in `a | b`
+)
+
+func (k SubshellKind) String() string {
+	switch k {
+	case SubshellKindBackground:
+		return "background"
+	case SubshellKindParen:
+		return "paren"
+	case SubshellKindCmdSubst:
+		return "cmd-subst"
+	case SubshellKindProcSubst:
+		return "proc-subst"
+	case SubshellKindPipeline:
+		return "pipeline"
+	}
+	return "unknown"
+}
+
+// SubshellHandlerFunc is a handler which runs around the body of a subshell.
+// It is expected to call run to execute the body, and to return its exit code.
+//
+// The ctx passed into run can differ from the ctx received by the handler,
+// so a middleware can derive a child context with its own cancellation.
+//
+// For [SubshellKindBackground], run returns 0 immediately after launching the
+// goroutine; the body's eventual exit code is not available through this hook.
+type SubshellHandlerFunc func(ctx context.Context, kind SubshellKind, run func(ctx context.Context) int) int
+
+// BuiltinHandlerFunc is a handler which replaces a named builtin.
+// The context includes a [HandlerContext] value.
+//
+// The returned [ExitStatus] is recorded as the runner's exit status.
+type BuiltinHandlerFunc func(ctx context.Context, name string, args []string) ExitStatus
+
+// LookupVarHandlerFunc is a handler which produces a value for a named variable.
+// A returned [expand.Variable] with Set=false signals an unset variable.
+type LookupVarHandlerFunc func(ctx context.Context, name string) expand.Variable
+
+// FuncCallHandlerFunc is a handler which runs around the body of a declared shell function.
+type FuncCallHandlerFunc func(ctx context.Context, name string, args []string)
+
+type runnerCtxKey struct{}
+
+func runnerWithCtx(ctx context.Context, r *Runner) context.Context {
+	return context.WithValue(ctx, runnerCtxKey{}, r)
+}
+
+func runnerFromCtx(ctx context.Context) *Runner {
+	r, _ := ctx.Value(runnerCtxKey{}).(*Runner)
+	return r
+}
+
+// RunStmts dispatches stmts on the runner attached to ctx,
+// reusing its current scope rather than starting a fresh program.
+// To run a fresh program, use [Runner.Run].
+//
+// A non-zero exit status is returned as an [ExitStatus] error.
+// An error is also returned if ctx has no runner attached.
+func RunStmts(ctx context.Context, stmts []*syntax.Stmt) error {
+	r := runnerFromCtx(ctx)
+	if r == nil {
+		return errors.New("interp.RunStmts: no runner in context")
+	}
+	r.stmts(ctx, stmts)
+	if err := r.exit.err; err != nil {
+		return err
+	}
+	if code := r.exit.code; code != 0 {
+		return ExitStatus(code)
+	}
+	return nil
 }

--- a/interp/handler_test.go
+++ b/interp/handler_test.go
@@ -16,10 +16,12 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
 
+	"mvdan.cc/sh/v3/expand"
 	"mvdan.cc/sh/v3/interp"
 	"mvdan.cc/sh/v3/syntax"
 )
@@ -595,4 +597,327 @@ func TestKillSignal(t *testing.T) {
 			}
 		})
 	}
+}
+
+func runWithOptions(t *testing.T, script string, opts ...interp.RunnerOption) string {
+	t.Helper()
+	file := parse(t, nil, script)
+	var stdout bytes.Buffer
+	allOpts := append([]interp.RunnerOption{interp.StdIO(nil, &stdout, os.Stderr)}, opts...)
+	r, err := interp.New(allOpts...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = r.Run(context.Background(), file)
+	return stdout.String()
+}
+
+func TestRunStmts(t *testing.T) {
+	t.Parallel()
+
+	t.Run("FromMiddleware", func(t *testing.T) {
+		injected := parse(t, nil, `echo injected`)
+		mw := func(next interp.StmtHandlerFunc) interp.StmtHandlerFunc {
+			return func(ctx context.Context, stmt *syntax.Stmt) {
+				var buf bytes.Buffer
+				_ = syntax.NewPrinter().Print(&buf, stmt)
+				if strings.Contains(buf.String(), "echo orig") {
+					if err := interp.RunStmts(ctx, injected.Stmts); err != nil {
+						t.Errorf("RunStmts: %v", err)
+					}
+				}
+				next(ctx, stmt)
+			}
+		}
+		out := runWithOptions(t, `echo before; echo orig; echo after`, interp.StmtHandlers(mw))
+		want := "before\ninjected\norig\nafter\n"
+		if out != want {
+			t.Fatalf("output: %q, want %q", out, want)
+		}
+	})
+
+	t.Run("ExitCodeError", func(t *testing.T) {
+		injected := parse(t, nil, `false`)
+		var observedErr error
+		mw := func(next interp.StmtHandlerFunc) interp.StmtHandlerFunc {
+			return func(ctx context.Context, stmt *syntax.Stmt) {
+				var buf bytes.Buffer
+				_ = syntax.NewPrinter().Print(&buf, stmt)
+				if strings.Contains(buf.String(), "marker") && observedErr == nil {
+					observedErr = interp.RunStmts(ctx, injected.Stmts)
+				}
+				next(ctx, stmt)
+			}
+		}
+		runWithOptions(t, `echo marker`, interp.StmtHandlers(mw))
+		var es interp.ExitStatus
+		if !errors.As(observedErr, &es) || int(es) != 1 {
+			t.Fatalf("expected ExitStatus(1), got %v", observedErr)
+		}
+	})
+
+	t.Run("NoRunner", func(t *testing.T) {
+		file := parse(t, nil, `echo hi`)
+		if err := interp.RunStmts(context.Background(), file.Stmts); err == nil {
+			t.Fatal("expected error when ctx has no runner")
+		}
+	})
+}
+
+func TestStmtHandlers(t *testing.T) {
+	t.Parallel()
+
+	t.Run("FireOnEachStatement", func(t *testing.T) {
+		var calls atomic.Int32
+		mw := func(next interp.StmtHandlerFunc) interp.StmtHandlerFunc {
+			return func(ctx context.Context, stmt *syntax.Stmt) {
+				calls.Add(1)
+				next(ctx, stmt)
+			}
+		}
+		out := runWithOptions(t, `echo a; echo b; echo c`, interp.StmtHandlers(mw))
+		if out != "a\nb\nc\n" {
+			t.Fatalf("output: %q", out)
+		}
+		if got := calls.Load(); got < 3 {
+			t.Errorf("expected at least 3 stmt callbacks, got %d", got)
+		}
+	})
+
+	t.Run("ShortCircuit", func(t *testing.T) {
+		mw := func(next interp.StmtHandlerFunc) interp.StmtHandlerFunc {
+			return func(ctx context.Context, stmt *syntax.Stmt) {
+				var buf bytes.Buffer
+				_ = syntax.NewPrinter().Print(&buf, stmt)
+				if strings.Contains(buf.String(), "echo skipped") {
+					return
+				}
+				next(ctx, stmt)
+			}
+		}
+		out := runWithOptions(t, `echo before; echo skipped; echo after`, interp.StmtHandlers(mw))
+		if out != "before\nafter\n" {
+			t.Fatalf("expected short-circuit, got %q", out)
+		}
+	})
+
+	t.Run("ChainedInOrder", func(t *testing.T) {
+		var order []string
+		mwA := func(next interp.StmtHandlerFunc) interp.StmtHandlerFunc {
+			return func(ctx context.Context, stmt *syntax.Stmt) {
+				order = append(order, "A-pre")
+				next(ctx, stmt)
+				order = append(order, "A-post")
+			}
+		}
+		mwB := func(next interp.StmtHandlerFunc) interp.StmtHandlerFunc {
+			return func(ctx context.Context, stmt *syntax.Stmt) {
+				order = append(order, "B-pre")
+				next(ctx, stmt)
+				order = append(order, "B-post")
+			}
+		}
+		runWithOptions(t, `:`, interp.StmtHandlers(mwA, mwB))
+		want := []string{"A-pre", "B-pre", "B-post", "A-post"}
+		if len(order) < len(want) {
+			t.Fatalf("got %v, want %v", order, want)
+		}
+		for i, w := range want {
+			if order[i] != w {
+				t.Fatalf("order[%d] = %q, want %q (full: %v)", i, order[i], w, order)
+			}
+		}
+	})
+}
+
+func TestSubshellHandlers(t *testing.T) {
+	t.Parallel()
+
+	t.Run("FireForEachKind", func(t *testing.T) {
+		kinds := map[interp.SubshellKind]int{}
+		mw := func(next interp.SubshellHandlerFunc) interp.SubshellHandlerFunc {
+			return func(ctx context.Context, kind interp.SubshellKind, run func(ctx context.Context) int) int {
+				kinds[kind]++
+				return next(ctx, kind, run)
+			}
+		}
+		runWithOptions(t, `( true ) &
+wait
+( true )
+x=$(echo hi)
+true | true
+cat <(echo hi) >/dev/null`, interp.SubshellHandlers(mw))
+
+		for _, k := range []interp.SubshellKind{
+			interp.SubshellKindBackground,
+			interp.SubshellKindParen,
+			interp.SubshellKindCmdSubst,
+			interp.SubshellKindPipeline,
+			interp.SubshellKindProcSubst,
+		} {
+			if kinds[k] == 0 {
+				t.Errorf("expected at least one %v, got none", k)
+			}
+		}
+	})
+
+	t.Run("ShortCircuit", func(t *testing.T) {
+		// Skip the body so that the cmd subst returns empty.
+		mw := func(next interp.SubshellHandlerFunc) interp.SubshellHandlerFunc {
+			return func(ctx context.Context, kind interp.SubshellKind, run func(ctx context.Context) int) int {
+				if kind == interp.SubshellKindCmdSubst {
+					return 0
+				}
+				return next(ctx, kind, run)
+			}
+		}
+		out := runWithOptions(t, `x=$(echo body); echo "[$x]"`, interp.SubshellHandlers(mw))
+		if out != "[]\n" {
+			t.Fatalf("expected empty cmd subst, got %q", out)
+		}
+	})
+}
+
+func TestBuiltinHandler(t *testing.T) {
+	t.Parallel()
+
+	t.Run("OverrideByName", func(t *testing.T) {
+		var lastArgs []string
+		override := func(ctx context.Context, name string, args []string) interp.ExitStatus {
+			lastArgs = append([]string(nil), args...)
+			return 42
+		}
+		out := runWithOptions(t, `mybuiltin one two; echo "exit=$?"`,
+			interp.BuiltinHandler("mybuiltin", override),
+		)
+		if out != "exit=42\n" {
+			t.Fatalf("expected exit=42 from override, got %q", out)
+		}
+		if len(lastArgs) != 2 || lastArgs[0] != "one" || lastArgs[1] != "two" {
+			t.Errorf("override saw args %v", lastArgs)
+		}
+	})
+
+	t.Run("ReplacesExistingBuiltin", func(t *testing.T) {
+		override := func(ctx context.Context, name string, args []string) interp.ExitStatus {
+			hc := interp.HandlerCtx(ctx)
+			_, _ = io.WriteString(hc.Stdout, "magic\n")
+			return 0
+		}
+		out := runWithOptions(t, `type printf`, interp.BuiltinHandler("type", override))
+		if out != "magic\n" {
+			t.Fatalf("override didn't replace builtin: %q", out)
+		}
+	})
+
+	t.Run("NilRemovesEntry", func(t *testing.T) {
+		first := func(ctx context.Context, name string, args []string) interp.ExitStatus { return 5 }
+		out := runWithOptions(t,
+			`echo "$?"`,
+			interp.BuiltinHandler("echo", first),
+			interp.BuiltinHandler("echo", nil),
+		)
+		if out != "0\n" {
+			t.Fatalf("expected nil removal, got %q", out)
+		}
+	})
+}
+
+func TestLookupVarHandlers(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ProvidesValue", func(t *testing.T) {
+		mw := func(next interp.LookupVarHandlerFunc) interp.LookupVarHandlerFunc {
+			return func(ctx context.Context, name string) expand.Variable {
+				if name == "MY_DYNAMIC" {
+					return expand.Variable{Set: true, Kind: expand.String, Str: "hello"}
+				}
+				return next(ctx, name)
+			}
+		}
+		out := runWithOptions(t, `echo "[$MY_DYNAMIC]"`, interp.LookupVarHandlers(mw))
+		if out != "[hello]\n" {
+			t.Fatalf("got %q", out)
+		}
+	})
+
+	t.Run("WrapsRunnerDefault", func(t *testing.T) {
+		// Translate the runner's fake bg PID ("g1", "g2", …) into a different
+		// string by wrapping the runner's own $! result.
+		mw := func(next interp.LookupVarHandlerFunc) interp.LookupVarHandlerFunc {
+			return func(ctx context.Context, name string) expand.Variable {
+				vr := next(ctx, name)
+				if name == "!" && vr.Set && strings.HasPrefix(vr.Str, "g") {
+					vr.Str = "1000" + vr.Str[1:]
+				}
+				return vr
+			}
+		}
+		out := runWithOptions(t, `sleep 0 & echo "$!"`, interp.LookupVarHandlers(mw))
+		if out != "10001\n" {
+			t.Fatalf("got %q", out)
+		}
+	})
+
+	t.Run("ChainOrder", func(t *testing.T) {
+		// The outer middleware short-circuits, so the inner one never runs.
+		outer := func(next interp.LookupVarHandlerFunc) interp.LookupVarHandlerFunc {
+			return func(ctx context.Context, name string) expand.Variable {
+				if name == "X" {
+					return expand.Variable{Set: true, Kind: expand.String, Str: "outer"}
+				}
+				return next(ctx, name)
+			}
+		}
+		inner := func(next interp.LookupVarHandlerFunc) interp.LookupVarHandlerFunc {
+			return func(ctx context.Context, name string) expand.Variable {
+				if name == "X" {
+					return expand.Variable{Set: true, Kind: expand.String, Str: "inner"}
+				}
+				return next(ctx, name)
+			}
+		}
+		out := runWithOptions(t, `echo "$X"`, interp.LookupVarHandlers(outer, inner))
+		if out != "outer\n" {
+			t.Fatalf("got %q", out)
+		}
+	})
+}
+
+func TestFuncCallHandlers(t *testing.T) {
+	t.Parallel()
+
+	t.Run("WrapBody", func(t *testing.T) {
+		var stack []string
+		mw := func(next interp.FuncCallHandlerFunc) interp.FuncCallHandlerFunc {
+			return func(ctx context.Context, name string, args []string) {
+				stack = append(stack, name)
+				next(ctx, name, args)
+				stack = stack[:len(stack)-1]
+			}
+		}
+		out := runWithOptions(t, `f() { echo in_f; g; }; g() { echo in_g; }; f`,
+			interp.FuncCallHandlers(mw),
+		)
+		if out != "in_f\nin_g\n" {
+			t.Fatalf("got %q", out)
+		}
+		if len(stack) != 0 {
+			t.Errorf("stack not empty after run: %v", stack)
+		}
+	})
+
+	t.Run("IgnoreBuiltins", func(t *testing.T) {
+		var calls int
+		mw := func(next interp.FuncCallHandlerFunc) interp.FuncCallHandlerFunc {
+			return func(ctx context.Context, name string, args []string) {
+				calls++
+				next(ctx, name, args)
+			}
+		}
+		runWithOptions(t, `echo hi; true; printf x`, interp.FuncCallHandlers(mw))
+		if calls != 0 {
+			t.Errorf("expected 0 func-call hits, got %d", calls)
+		}
+	})
 }

--- a/interp/runner.go
+++ b/interp/runner.go
@@ -42,6 +42,11 @@ const (
 )
 
 func (r *Runner) fillExpandConfig(ctx context.Context) {
+	// Wrap so handlers reached via expand can recover r from ctx.
+	// ctx is nil when [Runner.Subshell] is called before [Runner.Run].
+	if ctx != nil {
+		ctx = runnerWithCtx(ctx, r)
+	}
 	r.ectx = ctx
 	r.ecfg = &expand.Config{
 		Env: expandEnv{r},
@@ -65,7 +70,10 @@ func (r *Runner) fillExpandConfig(ctx context.Context) {
 			}
 			r2 := r.subshell(false)
 			r2.stdout = w
-			r2.stmts(ctx, cs.Stmts)
+			r.subshellHandler(ctx, SubshellKindCmdSubst, func(sctx context.Context) int {
+				r2.stmts(sctx, cs.Stmts)
+				return int(r2.exit.code)
+			})
 			r2.exit.exiting = false // subshells don't exit the parent shell
 			r.lastExpandExit = r2.exit
 			if r2.exit.fatalExit {
@@ -110,7 +118,7 @@ func (r *Runner) fillExpandConfig(ctx context.Context) {
 				exit: new(exitStatus),
 			}
 			r.bgProcs = append(r.bgProcs, bg)
-			go func() {
+			go r.subshellHandler(ctx, SubshellKindProcSubst, func(ctx context.Context) int {
 				defer func() {
 					*bg.exit = r2.exit
 					close(bg.done)
@@ -120,7 +128,7 @@ func (r *Runner) fillExpandConfig(ctx context.Context) {
 					f, err := os.OpenFile(path, os.O_WRONLY, 0)
 					if err != nil {
 						r.errf("cannot open fifo for stdout: %v\n", err)
-						return
+						return int(r2.exit.code)
 					}
 					r2.stdout = f
 					defer func() {
@@ -133,7 +141,7 @@ func (r *Runner) fillExpandConfig(ctx context.Context) {
 					f, err := os.OpenFile(path, os.O_RDONLY, 0)
 					if err != nil {
 						r.errf("cannot open fifo for stdin: %v\n", err)
-						return
+						return int(r2.exit.code)
 					}
 					r2.stdin = f
 					r2.stdout = stdout
@@ -148,7 +156,8 @@ func (r *Runner) fillExpandConfig(ctx context.Context) {
 				}
 				r2.stmts(ctx, ps.Stmts)
 				r2.exit.exiting = false // subshells don't exit the parent shell
-			}()
+				return int(r2.exit.code)
+			})
 			return path, nil
 		},
 	}
@@ -304,23 +313,30 @@ func (r *Runner) stmt(ctx context.Context, st *syntax.Stmt) {
 	if r.stop(ctx) {
 		return
 	}
+	r.stmtHandler(runnerWithCtx(ctx, r), st)
+}
+
+func (r *Runner) dispatchStmt(ctx context.Context, st *syntax.Stmt) {
 	r.exit = exitStatus{}
 	if st.Background || st.Disown {
-		r2 := r.subshell(true)
-		st2 := *st
-		st2.Background = false
-		st2.Disown = false
-		bg := bgProc{
-			done: make(chan struct{}),
-			exit: new(exitStatus),
-		}
-		r.bgProcs = append(r.bgProcs, bg)
-		go func() {
-			r2.Run(ctx, &st2)
-			r2.exit.exiting = false // subshells don't exit the parent shell
-			*bg.exit = r2.exit
-			close(bg.done)
-		}()
+		r.subshellHandler(ctx, SubshellKindBackground, func(ctx context.Context) int {
+			r2 := r.subshell(true)
+			st2 := *st
+			st2.Background = false
+			st2.Disown = false
+			bg := bgProc{
+				done: make(chan struct{}),
+				exit: new(exitStatus),
+			}
+			r.bgProcs = append(r.bgProcs, bg)
+			go func() {
+				r2.Run(ctx, &st2)
+				r2.exit.exiting = false // subshells don't exit the parent shell
+				*bg.exit = r2.exit
+				close(bg.done)
+			}()
+			return 0
+		})
 	} else {
 		r.stmtSync(ctx, st)
 	}
@@ -378,7 +394,10 @@ func (r *Runner) cmd(ctx context.Context, cm syntax.Command) {
 		r.stmts(ctx, cm.Stmts)
 	case *syntax.Subshell:
 		r2 := r.subshell(false)
-		r2.stmts(ctx, cm.Stmts)
+		r.subshellHandler(ctx, SubshellKindParen, func(sctx context.Context) int {
+			r2.stmts(sctx, cm.Stmts)
+			return int(r2.exit.code)
+		})
 		r2.exit.exiting = false // subshells don't exit the parent shell
 		r.exit = r2.exit
 	case *syntax.CallExpr:
@@ -497,9 +516,12 @@ func (r *Runner) cmd(ctx context.Context, cm syntax.Command) {
 			r.stdin = pr
 			var wg sync.WaitGroup
 			wg.Go(func() {
-				r2.stmt(ctx, cm.X)
-				r2.exit.exiting = false // subshells don't exit the parent shell
-				pw.Close()
+				r.subshellHandler(ctx, SubshellKindPipeline, func(ctx context.Context) int {
+					r2.stmt(ctx, cm.X)
+					r2.exit.exiting = false // subshells don't exit the parent shell
+					pw.Close()
+					return int(r2.exit.code)
+				})
 			})
 			r.stmt(ctx, cm.Y)
 			pr.Close()
@@ -1072,25 +1094,13 @@ func (r *Runner) call(ctx context.Context, pos syntax.Pos, args []string) {
 		}
 	}
 	name := args[0]
-	if body := r.Funcs[name]; body != nil {
-		// stack them to support nested func calls
-		oldParams := r.Params
-		r.Params = args[1:]
-		oldInFunc := r.inFunc
-		r.inFunc = true
-
-		// Functions run in a nested scope.
-		// Note that [Runner.exec] below does something similar.
-		origEnv := r.writeEnv
-		r.writeEnv = &overlayEnviron{parent: r.writeEnv, funcScope: true}
-
-		r.stmt(ctx, body)
-
-		r.writeEnv = origEnv
-
-		r.Params = oldParams
-		r.inFunc = oldInFunc
-		r.exit.returning = false
+	if r.Funcs[name] != nil {
+		r.funcCallHandler(ctx, name, args)
+		return
+	}
+	// A [BuiltinHandler] override applies even to non-builtin names.
+	if _, ok := r.builtinOverrides[name]; ok {
+		r.exit = r.builtin(ctx, pos, name, args[1:])
 		return
 	}
 	if IsBuiltin(name) {
@@ -1098,6 +1108,28 @@ func (r *Runner) call(ctx context.Context, pos syntax.Pos, args []string) {
 		return
 	}
 	r.exec(ctx, pos, args)
+}
+
+func (r *Runner) dispatchFuncCall(ctx context.Context, name string, args []string) {
+	body := r.Funcs[name]
+	// stack them to support nested func calls
+	oldParams := r.Params
+	r.Params = args[1:]
+	oldInFunc := r.inFunc
+	r.inFunc = true
+
+	// Functions run in a nested scope.
+	// Note that [Runner.exec] below does something similar.
+	origEnv := r.writeEnv
+	r.writeEnv = &overlayEnviron{parent: r.writeEnv, funcScope: true}
+
+	r.stmt(ctx, body)
+
+	r.writeEnv = origEnv
+
+	r.Params = oldParams
+	r.inFunc = oldInFunc
+	r.exit.returning = false
 }
 
 func (r *Runner) exec(ctx context.Context, pos syntax.Pos, args []string) {

--- a/interp/vars.go
+++ b/interp/vars.go
@@ -4,6 +4,7 @@
 package interp
 
 import (
+	"context"
 	cryptorand "crypto/rand"
 	"encoding/binary"
 	"fmt"
@@ -152,6 +153,10 @@ func (r *Runner) lookupVar(name string) expand.Variable {
 	if name == "" {
 		panic("variable name must not be empty")
 	}
+	return r.lookupVarHandler(r.ectx, name)
+}
+
+func (r *Runner) defaultLookupVar(ctx context.Context, name string) expand.Variable {
 	var vr expand.Variable
 	switch name {
 	case "#":


### PR DESCRIPTION
`ExecHandlers` already lets external code wrap external command execution. Apply the same middleware-chain pattern to five more dispatch points so the interpreter can be extended from outside without patching its internals.

`StmtHandlers` fires around every `syntax.Stmt` before dispatch. `SubshellHandlers` fires around each subshell creation site, with a `SubshellKind` to distinguish background, paren, cmd subst, proc subst, and pipeline. `BuiltinHandler` registers a name-keyed override for a builtin; `BuiltinHandlers` wraps all builtin dispatch with middleware. `FuncCallHandlers` wraps the body of a declared shell function. `LookupVarHandlers` wraps lookupVar on top of the runner's own special-variable and environment resolution, so middlewares can add or override variables without losing the existing behaviour.

Each chain follows `ExecHandlers`' shape: middlewares are chained first-to-last, the bottom of the chain is the runner's own behaviour, and a middleware may short-circuit by not calling next. Chain bottoms recover the active runner from ctx, so the chains are built once in `Reset` and inherited by subshell copies the same way `execHandler` is.

Also add `RunStmts`, a top-level helper for dispatching stmts on the runner attached to `ctx`, useful for handlers that need to execute shell code in the runner's current scope (e.g. a trap body from a Go-side signal handler).