### PR TITLE
syntax: apply BinaryNextLine to test and arithmetic expressions

### DIFF
--- a/syntax/printer.go
+++ b/syntax/printer.go
@@ -886,6 +886,15 @@ func (p *Printer) arithmExprRecurse(expr ArithmExpr, compact, spacePlusMinus boo
 			p.arithmExprRecurse(expr.X, compact, spacePlusMinus)
 			p.w.WriteString(expr.Op.String())
 			p.arithmExprRecurse(expr.Y, compact, false)
+		} else if p.binNextLine && !p.singleLine && expr.Y.Pos().Line() > p.line {
+			p.arithmExprRecurse(expr.X, compact, spacePlusMinus)
+			p.incLevel()
+			p.newline(expr.Y.Pos())
+			p.indent()
+			p.w.WriteString(expr.Op.String())
+			p.space()
+			p.arithmExprRecurse(expr.Y, compact, false)
+			p.decLevel()
 		} else {
 			p.arithmExprRecurse(expr.X, compact, spacePlusMinus)
 			if expr.Op != Comma {
@@ -941,13 +950,23 @@ func (p *Printer) testExprSameLine(expr TestExpr) {
 		p.word(expr)
 	case *BinaryTest:
 		p.testExprSameLine(expr.X)
-		p.space()
-		p.w.WriteString(expr.Op.String())
 		switch expr.Op {
 		case AndTest, OrTest:
-			p.wantSpace = spaceRequired
-			p.testExpr(expr.Y)
+			if p.binNextLine && !p.minify && !p.singleLine && expr.Y.Pos().Line() > p.line {
+				p.newlines(expr.Y.Pos())
+				p.spacePad(expr.Y.Pos())
+				p.w.WriteString(expr.Op.String())
+				p.space()
+				p.testExprSameLine(expr.Y)
+			} else {
+				p.space()
+				p.w.WriteString(expr.Op.String())
+				p.wantSpace = spaceRequired
+				p.testExpr(expr.Y)
+			}
 		default:
+			p.space()
+			p.w.WriteString(expr.Op.String())
 			p.space()
 			p.testExprSameLine(expr.Y)
 		}

--- a/syntax/printer_test.go
+++ b/syntax/printer_test.go
@@ -860,6 +860,36 @@ func TestPrintBinaryNextLine(t *testing.T) {
 			"a \\\n\t| b \\\n\t| c \\\n\t# EOC",
 			"a \\\n\t| b \\\n\t| c\n# EOC",
 		},
+		// BinaryTest: operator moves to next line with -bn
+		samePrint("[[ a && b ]]"),
+		{
+			"[[ a &&\nb ]]",
+			"[[ a\n\t&& b ]]",
+		},
+		{
+			"[[ a ||\nb ]]",
+			"[[ a\n\t|| b ]]",
+		},
+		samePrint("[[ a\n\t&& b ]]"),
+		{
+			"[[ a &&\nb &&\nc ]]",
+			"[[ a\n\t&& b\n\t&& c ]]",
+		},
+		// Issue #813: test expression inside if
+		{
+			"if [[ -z \"${foo}\" ||\n    -z \"${bar}\" ||\n    -z \"${baz}\" ]]; then\n    echo \"Hello world\"\nfi",
+			"if [[ -z \"${foo}\"\n\t|| -z \"${bar}\"\n\t|| -z \"${baz}\" ]]; then\n\techo \"Hello world\"\nfi",
+		},
+		// BinaryArithm: operator moves to next line with -bn
+		samePrint("$((1 + 2))"),
+		{
+			"$(( 1 +\n2 ))",
+			"$((1\n\t+ 2))",
+		},
+		{
+			"$(( 1 +\n2 +\n3 ))",
+			"$((1\n\t+ 2\n\t+ 3))",
+		},
 	}
 	parser := NewParser(KeepComments(true))
 	printer := NewPrinter(BinaryNextLine(true))


### PR DESCRIPTION
Fixes #813.

The `-bn` flag moves binary operators to the start of the next line for pipes and logical operators in commands, but didn't apply to `[[ ]]` test expressions or `$(( ))` arithmetic expressions. This meant `shfmt -bn` would reformat operators back to the end of the line in those contexts.

Handle `BinaryTest` (`&&`, `||`) and `BinaryArithm` (`+`, etc.) the same way `BinaryCmd` already works: when the operand spans multiple lines, move the operator to the beginning of the continuation line with proper indentation.

Test cases cover single-line (unchanged), two-operand, three-operand chaining, and the exact example from the issue.