### PR TITLE
interp: handle bash >|, >>|, &>|, &>>|, <> redirects

### DIFF
--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -1470,6 +1470,26 @@ var runTests = []runTest{
 		"",
 	},
 	{
+		// >| force-overwrite; equivalent to > when noclobber is unset.
+		"echo foo >| a; cat a",
+		"foo\n",
+	},
+	{
+		// >| overwrites an existing file.
+		"echo foo >a; echo bar >| a; cat a",
+		"bar\n",
+	},
+	{
+		// <> opens for read-write; the file must be readable as stdin.
+		"echo foo >a; cat <>a",
+		"foo\n",
+	},
+	{
+		// <> creates the target file if it does not exist.
+		"cat <>missing; ls missing",
+		"missing\n",
+	},
+	{
 		"sed 's/o/a/g' <<EOF\nfoo$foo\nEOF",
 		"faa\n",
 	},

--- a/interp/runner.go
+++ b/interp/runner.go
@@ -998,8 +998,19 @@ func (r *Runner) redir(ctx context.Context, rd *syntax.Redirect) (io.Closer, err
 		}
 		return nil, nil
 	case syntax.RdrIn, syntax.RdrOut, syntax.AppOut,
-		syntax.RdrAll, syntax.AppAll:
-		// done further below
+		syntax.RdrAll, syntax.AppAll,
+		syntax.RdrClob, syntax.AppClob,
+		syntax.RdrAllClob, syntax.AppAllClob,
+		syntax.RdrInOut:
+		// done further below.
+		// The "Clob" variants (>|, >>|, &>|, &>>|) bypass the noclobber
+		// shell option (set -C). Since this interpreter does not enforce
+		// noclobber on file redirects, they are functionally identical to
+		// their plain counterparts.
+		// RdrInOut (<>) opens the target file for read+write and binds it
+		// to the input fd (default 0); we read from the resulting file as
+		// stdin. Writes back through fd 0 are not propagated to the file
+		// since stdin is plumbed as io.Reader internally.
 	case syntax.DplIn:
 		switch arg {
 		case "-":
@@ -1013,25 +1024,27 @@ func (r *Runner) redir(ctx context.Context, rd *syntax.Redirect) (io.Closer, err
 	}
 	mode := os.O_RDONLY
 	switch rd.Op {
-	case syntax.AppOut, syntax.AppAll:
+	case syntax.AppOut, syntax.AppAll, syntax.AppClob, syntax.AppAllClob:
 		mode = os.O_WRONLY | os.O_CREATE | os.O_APPEND
-	case syntax.RdrOut, syntax.RdrAll:
+	case syntax.RdrOut, syntax.RdrAll, syntax.RdrClob, syntax.RdrAllClob:
 		mode = os.O_WRONLY | os.O_CREATE | os.O_TRUNC
+	case syntax.RdrInOut:
+		mode = os.O_RDWR | os.O_CREATE
 	}
 	f, err := r.open(ctx, arg, mode, 0o644, true)
 	if err != nil {
 		return nil, err
 	}
 	switch rd.Op {
-	case syntax.RdrIn:
+	case syntax.RdrIn, syntax.RdrInOut:
 		stdin, err := stdinFile(f)
 		if err != nil {
 			return nil, err
 		}
 		r.stdin = stdin
-	case syntax.RdrOut, syntax.AppOut:
+	case syntax.RdrOut, syntax.AppOut, syntax.RdrClob, syntax.AppClob:
 		*orig = f
-	case syntax.RdrAll, syntax.AppAll:
+	case syntax.RdrAll, syntax.AppAll, syntax.RdrAllClob, syntax.AppAllClob:
 		r.stdout = f
 		r.stderr = f
 	default:


### PR DESCRIPTION
## Summary

`(*Runner).redir` in `interp/runner.go` only threaded `RdrIn`, `RdrOut`, `AppOut`, `RdrAll`, and `AppAll` through its three dispatch switches. The remaining file-redirect operators that the parser already recognises — `RdrClob` (`>|`), `AppClob` (`>>|`), `RdrAllClob` (`&>|`), `AppAllClob` (`&>>|`), and `RdrInOut` (`<>`) — fell to the `default: unhandled redirect op: %v` branch and exited with an error, so any script using them failed even though plain `>`/`>>` worked.

This shows up most often in templates that wrap a user command in a fixed `>|` to force-overwrite a known temp file. With those failing, an embedded interpreter looks broken from the caller's perspective even when the user's command itself succeeded.

## Approach

- Treat the four `*Clob` variants as identical to their plain counterparts. They only differ from `>`/`>>`/`&>`/`&>>` in that they bypass the noclobber shell option (`set -C`), and the interpreter does not enforce noclobber on file redirects today, so the runtime behaviour is the same.
- For `<>` (`RdrInOut`), open the target with `O_RDWR|O_CREATE` and bind it through `stdinFile` so reads work. Writes back through fd 0 are not propagated to the file because stdin is exposed as `io.Reader` internally — sufficient for the read-side use that accounts for nearly all real `<>` usage.

## Test plan

- [x] Four entries added to the existing redirect table in `interp/interp_test.go` covering `>|` (new file, overwrite-existing) and `<>` (read-existing, create-if-missing).
- [x] `go test -short ./interp/ ./syntax/` passes.
- [x] Manual: the new redirect entries match bash 5.3 behaviour.