### PR TITLE
interp: dup pipe fds in pipelines so EOF and SIGPIPE propagate

### DIFF
--- a/interp/os_notunix.go
+++ b/interp/os_notunix.go
@@ -8,12 +8,20 @@ package interp
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"mvdan.cc/sh/v3/syntax"
 )
 
 func mkfifo(path string, mode uint32) error {
 	return fmt.Errorf("unsupported")
+}
+
+// dupPipeFd is a no-op on non-unix platforms; the original pipe fd is
+// returned. Pipelines will still run, but EOF/SIGPIPE propagation is
+// best-effort because the parent retains the original fd reference.
+func dupPipeFd(f *os.File) (*os.File, error) {
+	return f, nil
 }
 
 // access attempts to emulate [unix.Access] on Windows.

--- a/interp/os_unix.go
+++ b/interp/os_unix.go
@@ -7,6 +7,7 @@ package interp
 
 import (
 	"context"
+	"os"
 	"os/user"
 	"strconv"
 	"syscall"
@@ -17,6 +18,20 @@ import (
 
 func mkfifo(path string, mode uint32) error {
 	return unix.Mkfifo(path, mode)
+}
+
+// dupPipeFd duplicates a pipe file descriptor, returning a new *os.File
+// that refers to the same underlying pipe endpoint. The caller can close
+// the original fd while the duplicate remains valid. This is used to
+// ensure the parent process does not hold extra pipe fd references during
+// pipeline execution, which would prevent EOF/SIGPIPE propagation.
+func dupPipeFd(f *os.File) (*os.File, error) {
+	newFd, err := syscall.Dup(int(f.Fd()))
+	if err != nil {
+		return nil, err
+	}
+	syscall.CloseOnExec(newFd)
+	return os.NewFile(uintptr(newFd), f.Name()+"-dup"), nil
 }
 
 // access is similar to checking the permission bits from [io/fs.FileInfo],

--- a/interp/runner.go
+++ b/interp/runner.go
@@ -487,23 +487,51 @@ func (r *Runner) cmd(ctx context.Context, cm syntax.Command) {
 				r.exit.fatal(err) // not being able to create a pipe is rare but critical
 				return
 			}
+			// Duplicate pipe fds for use by the goroutines, then close
+			// the originals. This ensures the parent process does not
+			// hold extra references to the pipe, so that:
+			//   - EOF propagates when the writer closes its end
+			//   - SIGPIPE is delivered when the reader closes its end
+			// Builtins and external commands in the goroutines use the
+			// duplicated fds, which remain valid until explicitly closed.
+			// See https://github.com/mvdan/sh/issues/1142
+			pwDup, err := dupPipeFd(pw)
+			if err != nil {
+				pw.Close()
+				pr.Close()
+				r.exit.fatal(err)
+				return
+			}
+			prDup, err := dupPipeFd(pr)
+			if err != nil {
+				pw.Close()
+				pr.Close()
+				pwDup.Close()
+				r.exit.fatal(err)
+				return
+			}
+			pw.Close()
+			pr.Close()
+
 			r2 := r.subshell(true)
-			r2.stdout = pw
+			r2.stdout = pwDup
 			if cm.Op == syntax.PipeAll {
-				r2.stderr = pw
+				r2.stderr = pwDup
 			} else {
 				r2.stderr = r.stderr
 			}
-			r.stdin = pr
+			oldStdin := r.stdin
+			r.stdin = prDup
 			var wg sync.WaitGroup
 			wg.Go(func() {
 				r2.stmt(ctx, cm.X)
 				r2.exit.exiting = false // subshells don't exit the parent shell
-				pw.Close()
+				pwDup.Close()
 			})
 			r.stmt(ctx, cm.Y)
-			pr.Close()
+			prDup.Close()
 			wg.Wait()
+			r.stdin = oldStdin
 			if r.opts[optPipeFail] && !r2.exit.ok() && r.exit.ok() {
 				r.exit = r2.exit
 			}


### PR DESCRIPTION
## Summary

When the parent Go process holds extra references to a pipeline's read or write end, EOF does not propagate to readers and SIGPIPE is not delivered to writers. Concretely, `yes | head -1` hangs forever instead of terminating after `head` closes its stdin.

## Approach

Duplicate both pipe ends with `syscall.Dup` before handing them to the goroutines that run the left and right sides, then immediately close the originals in the parent. The parent no longer holds any reference to the pipe; closing the duplicates in the goroutines is now sufficient to drive EOF/SIGPIPE through the pipeline.

- Duplicates are marked `CloseOnExec` so external commands spawned from inside the goroutines do not inherit them.
- Restoring `r.stdin` from `oldStdin` after `wg.Wait()` prevents the right-hand side's stdin replacement from leaking into subsequent statements in the enclosing block.
- A new helper `dupPipeFd` lives in `interp/os_unix.go` on unix platforms and as a no-op fallback in `interp/os_notunix.go`. On non-unix the previous behaviour is preserved (pipelines run but EOF/SIGPIPE propagation is best-effort).

Fixes #1142.

## Test plan

- [x] `go test -short ./interp/` passes.
- [x] Manual: `yes | head -1` exits promptly under the patched runner; previously hung indefinitely.