### PR TITLE
cmd/shfmt: add shell completion support

### DIFF
--- a/cmd/shfmt/completion.go
+++ b/cmd/shfmt/completion.go
@@ -1,0 +1,142 @@
+// Copyright (c) 2016, Daniel Martí <mvdan@mvdan.cc>
+// See LICENSE for licensing information
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+)
+
+var completionFlag = flagVal("", "completion", "", flag.StringVar)
+
+func printCompletion(shell string) {
+	switch shell {
+	case "bash":
+		fmt.Print(bashCompletion)
+	case "zsh":
+		fmt.Print(zshCompletion)
+	case "fish":
+		fmt.Print(fishCompletion)
+	default:
+		fmt.Fprintf(os.Stderr, "unsupported shell: %s (supported: bash, zsh, fish)\n", shell)
+		os.Exit(1)
+	}
+}
+
+const bashCompletion = `# bash completion for shfmt
+_shfmt_completions() {
+    local cur prev
+    _init_completion || return
+
+    case "$prev" in
+        --language-dialect|-ln)
+            COMPREPLY=($(compgen -W "bash posix mksh bats zsh auto" -- "$cur"))
+            return
+            ;;
+        --indent|-i)
+            COMPREPLY=($(compgen -W "0 2 4 8" -- "$cur"))
+            return
+            ;;
+        --filename)
+            _filedir
+            return
+            ;;
+    esac
+
+    if [[ "$cur" == -* ]]; then
+        COMPREPLY=($(compgen -W "\
+            --version \
+            -l --list \
+            -w --write \
+            -d --diff \
+            --apply-ignore \
+            --filename \
+            -ln --language-dialect \
+            -p --posix \
+            -s --simplify \
+            -i --indent \
+            -bn --binary-next-line \
+            -ci --case-indent \
+            -sr --space-redirects \
+            -kp --keep-padding \
+            -fn --func-next-line \
+            -mn --minify \
+            -f --find \
+            --to-json \
+            --from-json \
+            --completion \
+            " -- "$cur"))
+    else
+        _filedir 'sh'
+    fi
+}
+
+complete -F _shfmt_completions shfmt
+`
+
+const zshCompletion = `#compdef shfmt
+
+_shfmt() {
+    local -a args
+
+    args=(
+        '(- *)'{-v,--version}'[show version and exit]'
+        '(-l --list)'{-l,--list}'[list files whose formatting differs]'
+        '(-w --write)'{-w,--write}'[write result to file instead of stdout]'
+        '(-d --diff)'{-d,--diff}'[error with a diff when formatting differs]'
+        '--apply-ignore[always apply EditorConfig ignore rules]'
+        '--filename[provide a name for the standard input file]:filename:_files'
+        '(-ln --language-dialect)'{-ln,--language-dialect}'[shell language dialect]:language:(bash posix mksh bats zsh auto)'
+        '(-p --posix)'{-p,--posix}'[shorthand for -ln=posix]'
+        '(-s --simplify)'{-s,--simplify}'[simplify the code]'
+        '(-i --indent)'{-i,--indent}'[indent: 0 for tabs, >0 for spaces]:indent:(0 2 4 8)'
+        '(-bn --binary-next-line)'{-bn,--binary-next-line}'[binary ops may start a line]'
+        '(-ci --case-indent)'{-ci,--case-indent}'[switch cases will be indented]'
+        '(-sr --space-redirects)'{-sr,--space-redirects}'[redirect operators followed by a space]'
+        '(-kp --keep-padding)'{-kp,--keep-padding}'[keep column alignment paddings]'
+        '(-fn --func-next-line)'{-fn,--func-next-line}'[function opening braces on separate line]'
+        '(-mn --minify)'{-mn,--minify}'[minify the code (implies -s)]'
+        '(-f --find)'{-f,--find}'[recursively find all shell files]'
+        '--to-json[print syntax tree as typed JSON]'
+        '--from-json[read syntax tree from stdin as typed JSON]'
+        '--completion[generate shell completion script]:shell:(bash zsh fish)'
+        '*:file:_files -g "*.sh"'
+    )
+
+    _arguments -s $args
+}
+
+_shfmt "$@"
+`
+
+const fishCompletion = `# Fish completion for shfmt
+
+complete -c shfmt -l version -d 'Show version and exit'
+complete -c shfmt -s l -l list -d 'List files whose formatting differs'
+complete -c shfmt -s w -l write -d 'Write result to file instead of stdout'
+complete -c shfmt -s d -l diff -d 'Error with a diff when formatting differs'
+complete -c shfmt -l apply-ignore -d 'Always apply EditorConfig ignore rules'
+complete -c shfmt -l filename -r -d 'Provide a name for the standard input file'
+
+complete -c shfmt -s ln -l language-dialect -r -d 'Shell language dialect' -xa 'bash posix mksh bats zsh auto'
+complete -c shfmt -s p -l posix -d 'Shorthand for -ln=posix'
+complete -c shfmt -s s -l simplify -d 'Simplify the code'
+
+complete -c shfmt -s i -l indent -r -d 'Indent: 0 for tabs, >0 for spaces' -xa '0 2 4 8'
+complete -c shfmt -s bn -l binary-next-line -d 'Binary ops may start a line'
+complete -c shfmt -s ci -l case-indent -d 'Switch cases will be indented'
+complete -c shfmt -s sr -l space-redirects -d 'Redirect operators followed by a space'
+complete -c shfmt -s kp -l keep-padding -d 'Keep column alignment paddings'
+complete -c shfmt -s fn -l func-next-line -d 'Function opening braces on separate line'
+complete -c shfmt -s mn -l minify -d 'Minify the code (implies -s)'
+
+complete -c shfmt -s f -l find -d 'Recursively find all shell files'
+complete -c shfmt -l to-json -d 'Print syntax tree as typed JSON'
+complete -c shfmt -l from-json -d 'Read syntax tree from stdin as typed JSON'
+
+complete -c shfmt -l completion -r -d 'Generate shell completion script' -xa 'bash zsh fish'
+
+complete -c shfmt -F -d 'Shell script file'
+`

--- a/cmd/shfmt/main.go
+++ b/cmd/shfmt/main.go
@@ -144,6 +144,7 @@ Utilities:
                       paths are separated by a newline or a null character if -f=0
   --to-json           print syntax tree to stdout as a typed JSON
   --from-json         read syntax tree from stdin as a typed JSON
+  --completion shell  generate shell completion script (bash, zsh, or fish)
 
 Formatting options can also be read from EditorConfig files; see 'man shfmt'
 for a detailed description of the tool's behavior.
@@ -152,6 +153,10 @@ For more information and to report bugs, see https://github.com/mvdan/sh.
 	}
 	flag.Parse()
 
+	if completionFlag.val != "" {
+		printCompletion(completionFlag.val)
+		return
+	}
 	if versionFlag.val {
 		version := "(unknown)"
 		if info, ok := debug.ReadBuildInfo(); ok {

--- a/cmd/shfmt/shfmt.1.scd
+++ b/cmd/shfmt/shfmt.1.scd
@@ -114,6 +114,14 @@ predictable. Some aspects of the format can be configured via printer flags.
 *--from-json*
 	Read syntax tree from stdin as a typed JSON.
 
+*--completion* <shell>
+	Generate a shell completion script for the given shell.
+	Supported shells: *bash*, *zsh*, *fish*.
+	The script is printed to stdout and can be installed via
+	*source <(shfmt --completion=bash)* for bash,
+	*source <(shfmt --completion=zsh)* for zsh, or
+	*shfmt --completion=fish > ~/.config/fish/completions/shfmt.fish* for fish.
+
 # EXAMPLES
 
 Format all the scripts under the current directory, printing which are modified:
@@ -128,6 +136,10 @@ The following formatting flags closely resemble Google's shell style defined in
 <https://google.github.io/styleguide/shellguide.html>:
 
 	shfmt -i 2 -ci -bn
+
+Install shell completions (bash example):
+
+	source <(shfmt --completion=bash)
 
 Below is a sample EditorConfig file as defined by <https://editorconfig.org/>,
 showing how to set supported options:

--- a/cmd/shfmt/testdata/script/flags.txtar
+++ b/cmd/shfmt/testdata/script/flags.txtar
@@ -157,6 +157,21 @@ stdin flags-input
 exec shfmt --func-next-line
 cmp stdout flags-output.func-next-line-golden
 
+# Test completion flag.
+exec shfmt --completion=bash
+stdout '_shfmt_completions'
+stdout 'complete -F _shfmt_completions shfmt'
+
+exec shfmt --completion=zsh
+stdout '#compdef shfmt'
+stdout '_shfmt'
+
+exec shfmt --completion=fish
+stdout 'complete -c shfmt'
+
+! exec shfmt --completion=invalid
+stderr 'unsupported shell'
+
 -- input-posix --
 let a+
 -- input-bash --


### PR DESCRIPTION
Add `--completion` flag that generates shell completion scripts for bash, zsh, and fish.

## Changes

- New file: `cmd/shfmt/completion.go` - completion script generation
- Modified: `cmd/shfmt/main.go` - add completion flag and handling
- Modified: `cmd/shfmt/shfmt.1.scd` - document the new flag
- Modified: `cmd/shfmt/testdata/script/flags.txtar` - add tests

## Usage

```bash
# Bash
source <(shfmt --completion=bash)

# Zsh
source <(shfmt --completion=zsh)

# Fish
shfmt --completion=fish > ~/.config/fish/completions/shfmt.fish
```

## Features

- Completes all flags (short and long forms)
- Provides value completions for `--language-dialect` (bash/posix/mksh/bats/zsh/auto)
- Provides value completions for `--indent` (0/2/4/8)
- Falls back to file completion for arguments
- Proper error message for unsupported shells

Fixes #914