### PR TITLE
syntax: keep array subscripts compact when written without spaces

### DIFF
--- a/syntax/printer.go
+++ b/syntax/printer.go
@@ -730,13 +730,29 @@ func (p *Printer) wroteIndex(index ArithmExpr) bool {
 		return false
 	}
 	p.w.WriteByte('[')
-	// Note that e.g. foo[1,3]=$bar in Zsh does not allow any spaces around the comma,
-	// as that breaks the assignment word.
+	// In an associative array, [a-b] is a literal key, not arithmetic, so
+	// spacing it to [a - b] would change the key. The printer can't know the
+	// array's type, so it preserves the source spacing instead. A comma stays
+	// compact, as Zsh foo[1,3]=$bar breaks with spaces around it.
 	binary, ok := index.(*BinaryArithm)
-	compact := ok && binary.Op == Comma
+	compact := ok && (binary.Op == Comma || !indexBinaryHadSpace(binary))
 	p.arithmExpr(index, compact, false)
 	p.w.WriteByte(']')
 	return true
+}
+
+// indexBinaryHadSpace reports whether a subscript's operator had surrounding
+// space in the source: false for a-b, true for a - b (or if positions are
+// unset, conservatively preserving the previous spacing).
+func indexBinaryHadSpace(b *BinaryArithm) bool {
+	xEnd, opPos, yPos := b.X.End(), b.OpPos, b.Y.Pos()
+	if !xEnd.IsValid() || !opPos.IsValid() || !yPos.IsValid() {
+		return true
+	}
+	opLen := uint(len(b.Op.String()))
+	adjacent := xEnd.Offset() == opPos.Offset() &&
+		opPos.Offset()+opLen == yPos.Offset()
+	return !adjacent
 }
 
 func (p *Printer) paramExp(pe *ParamExp) {

--- a/syntax/printer_test.go
+++ b/syntax/printer_test.go
@@ -665,8 +665,16 @@ var printTests = []printCase{
 	// 	"$(foo)#bar",
 	// },
 	// samePrint(`$("foo"#bar)#bar`),
+	// An associative-array key like dash-string is parsed as arithmetic but is
+	// really a literal string; spacing it (dash - string) would change the key.
+	// The printer keeps the subscript exactly as the user wrote it, so compact
+	// stays compact (the #956 fix) and any spacing the user chose is preserved.
+	samePrint("${array[dash-string]}"),
+	samePrint("array[dash-string]=123"),
 	samePrint("${array[dash - string]}"),
 	samePrint("array[dash - string]=123"),
+	samePrint("${array[1 + 2]}"),
+	samePrint("array[1 + 2]=x"),
 	samePrint("${arr[0,1]}"),
 	samePrint("arr[0,1]=x"),
 }


### PR DESCRIPTION
### Problem

An array subscript like `${array[a-b]}` or `array[a-b]=x` is parsed as an arithmetic expression, but for an **associative** array it is a literal string key. The printer is not language-aware, so it cannot tell the two apart. It currently spaces the operator (`a - b`), which **silently changes the key** for an associative array and breaks the script at runtime:

```sh
$ shfmt -i 2 <<'EOF'
declare -A m=(
	[a-b]="x"
)
EOF
declare -A m=(
  [a - b]="x"     # <- different key; script now broken
)
```

The same happens with the parameter-expansion form from #956, e.g. `${args[--no-cache]}` → `${args[--no - cache]}`.

### Cause

This regressed in d2b044b4 ("syntax: only make index expressions compact when it's a comma"), which fixed #1314 (`${array[1 + 2]}` should keep its spaces) but reintroduced the hyphen-key breakage previously reported in #956. Before that commit the index was always printed compact; afterwards only a `Comma` operator is compacted, so `-`/`+` get spaced again.

The two reports are in tension under the current always-arithmetic parse: `[1 + 2]` is genuine arithmetic that wants spaces, while `[a-b]` is a literal key that must stay compact, and both parse to the same `BinaryArithm` node.

### Fix

Decide spacing from **what the user wrote**, using the operand and operator source positions:

- keep the subscript compact when the source had no spaces around the operator (`a-b`; the literal-key case, fixing #956);
- preserve spaces when the user wrote them (`1 + 2`; genuine arithmetic, keeping #1314 fixed).

This needs no language- or array-type awareness in the printer. When position offsets are unavailable it conservatively falls back to the previous (spaced) behavior. `Comma` stays always-compact, as before, because zsh `foo[1,3]=$bar` disallows spaces there.

### Verification

```sh
$ shfmt -i 2 <<'EOF'
declare -A m=(
	[a-b]="x"
)
m[c-d]="y"
echo "${m[a-b]}"
EOF
declare -A m=(
  [a-b]="x"
)
m[c-d]="y"
echo "${m[a-b]}"

$ shfmt <<'EOF'              # #1314 still spaced
echo "${array[1 + 2]}"
EOF
echo "${array[1 + 2]}"
```

Added round-trip tests in `syntax/printer_test.go` for the compact key, the spaced-arithmetic case, and the preserved-spacing case. Full module test suite passes (`go test ./...`) on Linux with a real `bash`.

Fixes #956. Keeps #1314 fixed.
