### PR TITLE
interp: respect StatHandler in Unix access fallback

### DIFF
--- a/interp/os_unix.go
+++ b/interp/os_unix.go
@@ -7,6 +7,8 @@ package interp
 
 import (
 	"context"
+	"errors"
+	"io/fs"
 	"os/user"
 	"strconv"
 	"syscall"
@@ -23,7 +25,31 @@ func mkfifo(path string, mode uint32) error {
 // but it also takes into account the current user's role.
 func (r *Runner) access(ctx context.Context, path string, mode uint32) error {
 	// TODO(v4): "access" may need to become part of a handler, like "open" or "stat".
-	return unix.Access(path, mode)
+	err := unix.Access(path, mode)
+	if err == nil {
+		return nil
+	}
+	if !errors.Is(err, unix.ENOENT) && !errors.Is(err, unix.ENOTDIR) {
+		return err
+	}
+	info, statErr := r.stat(ctx, path)
+	if statErr != nil {
+		return err
+	}
+	return accessFileMode(info.Mode(), mode)
+}
+
+func accessFileMode(mode fs.FileMode, access uint32) error {
+	if access&access_R_OK != 0 && mode&0o400 == 0 {
+		return errors.New("file is not readable")
+	}
+	if access&access_W_OK != 0 && mode&0o200 == 0 {
+		return errors.New("file is not writable")
+	}
+	if access&access_X_OK != 0 && mode&0o100 == 0 {
+		return errors.New("file is not executable")
+	}
+	return nil
 }
 
 // unTestOwnOrGrp implements the -O and -G unary tests. If the file does not

--- a/interp/unix_test.go
+++ b/interp/unix_test.go
@@ -9,14 +9,51 @@ import (
 	"bufio"
 	"context"
 	"io"
+	"io/fs"
 	"os"
 	"os/exec"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/creack/pty"
 	"mvdan.cc/sh/v3/interp"
 )
+
+type virtualDirInfo struct{}
+
+func (virtualDirInfo) Name() string       { return "virtual" }
+func (virtualDirInfo) Size() int64        { return 0 }
+func (virtualDirInfo) Mode() fs.FileMode  { return fs.ModeDir | 0o755 }
+func (virtualDirInfo) ModTime() time.Time { return time.Time{} }
+func (virtualDirInfo) IsDir() bool        { return true }
+func (virtualDirInfo) Sys() any           { return nil }
+
+func TestRunnerAccessStatHandlerVirtualDir(t *testing.T) {
+	t.Parallel()
+
+	file := parse(t, nil, "cd /virtual; pwd")
+	stat := func(ctx context.Context, name string, followSymlinks bool) (fs.FileInfo, error) {
+		if name == "/virtual" {
+			return virtualDirInfo{}, nil
+		}
+		return interp.DefaultStatHandler()(ctx, name, followSymlinks)
+	}
+	var cb concBuffer
+	r, err := interp.New(
+		interp.StdIO(nil, &cb, &cb),
+		interp.StatHandler(stat),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Run(context.Background(), file); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := cb.String(), "/virtual\n"; got != want {
+		t.Fatalf("\nwant: %q\ngot:  %q", want, got)
+	}
+}
 
 func TestRunnerTerminalStdIO(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Fixes #1318.

## Summary

- keep `unix.Access` as the primary Unix permission check for real filesystem paths
- fall back to the runner's `StatHandler` only when the host path is missing, so virtual filesystems can authorize access by mode bits
- add a Unix regression test for `cd /virtual` with a custom `StatHandler`

## Validation

- `go test ./interp -run TestRunnerAccessStatHandlerVirtualDir -count=1`
- `go test ./interp -count=1`
- `go test ./...`
- `cd moreinterp && go test ./...`
- `go vet ./...`
