### PR TITLE
syntax: don't duplicate a heredoc's inline comment in an indented block

### DIFF
--- a/syntax/printer.go
+++ b/syntax/printer.go
@@ -571,12 +571,14 @@ func (p *Printer) semiRsrv(s string, pos Pos) {
 }
 
 func (p *Printer) flushComments() {
+	if len(p.pendingComments) > 0 {
+		// Flush any pending heredocs first. Otherwise, the comments would
+		// become part of a heredoc body. flushHeredocs may print and consume
+		// an inline comment, so range over pendingComments only after flushing,
+		// not over a stale copy that would reprint it after the heredoc.
+		p.flushHeredocs()
+	}
 	for i, c := range p.pendingComments {
-		if i == 0 {
-			// Flush any pending heredocs first. Otherwise, the
-			// comments would become part of a heredoc body.
-			p.flushHeredocs()
-		}
 		p.firstLine = false
 		// We can't call any of the newline methods, as they call this
 		// function and we'd recurse forever.

--- a/syntax/printer_test.go
+++ b/syntax/printer_test.go
@@ -115,6 +115,7 @@ var printTests = []printCase{
 	samePrint("foo <<'EOF'\nEOF\n\nbar"),
 	samePrint("if cmd <<EOF\nbody\nEOF\nthen\n\tfoo\nfi"),
 	samePrint("while cmd <<EOF\nbody\nEOF\ndo\n\tfoo\ndone"),
+	samePrint("if true; then\n\tcat <<-EOF # comment\n\t\tcontent\n\tEOF\nfi"),
 	{
 		"{ foo; bar; }",
 		"{\n\tfoo\n\tbar\n}",


### PR DESCRIPTION
Fixes #1246.

## the problem

an inline trailing comment on a heredoc redirect line, when the statement is inside an indented block, gets duplicated after the heredoc terminator on every format pass:

```
$ cat test.sh
if true; then
	cat <<-EOF # comment
		content
	EOF
fi

$ shfmt test.sh   # and again, and again
if true; then
	cat <<-EOF # comment
		content
	EOF
	# comment
fi
```

each run adds another copy, so the output is never stable. it happens for both `<<EOF` and `<<-EOF`, at any nesting depth; top-level heredocs are fine.

## root cause

`flushComments` ranges over `p.pendingComments`, and at `i == 0` it called `flushHeredocs` to flush heredocs before printing the comments. but `flushHeredocs` has its own logic: when the first pending comment sits inline on the current line, it prints that comment (before the heredoc body) and removes it from `p.pendingComments`. the outer `flushComments` range had already captured the slice, so after `flushHeredocs` printed and consumed the comment, the loop still held it and printed it a second time, after the heredoc.

top-level heredocs don't hit this because they flush via a direct `flushHeredocs` call from `newline`; only closing a nested block routes the flush through `flushComments`.

## the fix

flush the heredocs once before the loop instead of inside it, so the loop ranges over `p.pendingComments` after `flushHeredocs` may have consumed the inline comment, rather than over a stale copy. the `len > 0` guard keeps the original "only flush when there's a pending comment" behavior, and `flushHeredocs` already sets `mustNewline`, so the remaining comments format identically.

## tests

added a `samePrint` case for the indented heredoc-with-comment to `printTests`; it fails on master (both the initial print and the table's idempotency re-check add the duplicate) and passes with the fix. full `go test ./...`, `-race`, `go vet`, and `gofmt -s` are clean.
