### PR TITLE
readme: remove unsupported vscode extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,6 @@ The following editor integrations wrap `shfmt`:
 - [intellij-shellscript] - Intellij Jetbrains `shell script` plugin
 - [micro] - Editor with a built-in plugin
 - [neoformat] - (Neo)Vim plugin
-- [shell-format] - VS Code plugin
 - [vscode-shfmt] - VS Code plugin
 - [shfmt.el] - Emacs package
 - [Sublime-Pretty-Shell] - Sublime Text 3 plugin


### PR DESCRIPTION
Update the list of VSCode extensions to only include those being actively maintained:
- ❌ Remove [shell-format](https://marketplace.visualstudio.com/items?itemName=foxundermoon.shell-format):
  - Doesn't appear to be supported anymore
  - Hasn't been changed in a while, lots of issues
- ✅ Keep [vscode-shfmt](https://marketplace.visualstudio.com/items?itemName=mkhl.shfmt):
  - It's actively maintained and functional
  - Recent commit, just installed and used it successfully