### PR TITLE
syntax: parse arithmetic array index with # subscript key

### DIFF
--- a/syntax/filetests_test.go
+++ b/syntax/filetests_test.go
@@ -3414,6 +3414,18 @@ var fileTests = []fileTestCase{
 		}), LangBash|LangMirBSDKorn|LangZsh),
 	),
 	fileTest(
+		[]string{`$((ARGS[COMMAND,#]))`},
+		langFile(arithmExp(word(&ParamExp{
+			Short: true,
+			Param: lit("ARGS"),
+			Index: &BinaryArithm{
+				Op: Comma,
+				X:  litWord("COMMAND"),
+				Y:  litWord("#"),
+			},
+		})), LangBash|LangMirBSDKorn|LangZsh),
+	),
+	fileTest(
 		[]string{"$((a += 2, b -= 3))"},
 		langFile(arithmExp(&BinaryArithm{
 			Op: Comma,

--- a/syntax/lexer.go
+++ b/syntax/lexer.go
@@ -17,6 +17,20 @@ func asciiDigit[T rune | byte](r T) bool {
 	return r >= '0' && r <= '9'
 }
 
+// allDigits reports whether bs is non-empty and consists entirely of ASCII
+// digits, as in the base of a base-N numeric literal like 16#FF.
+func allDigits(bs []byte) bool {
+	if len(bs) == 0 {
+		return false
+	}
+	for _, b := range bs {
+		if !asciiDigit(b) {
+			return false
+		}
+	}
+	return true
+}
+
 // bytes that form or start a token
 func regOps(r rune) bool {
 	switch r {
@@ -1026,6 +1040,13 @@ loop:
 			}
 		case ':', '=', '%', '^', ',', '?', '!', '~', '*':
 			if p.quote&allArithmExpr != 0 {
+				break loop
+			}
+		case '#':
+			// Don't split up a base-N numeric literal like 16#FF, which is
+			// entirely made up of ASCII digits up to the '#'. Otherwise, as
+			// in an array subscript like a[COMMAND,#], '#' is its own token.
+			if p.quote&allArithmExpr != 0 && !allDigits(p.litBs[:len(p.litBs)-1]) {
 				break loop
 			}
 		case '.':

--- a/syntax/parser_arithm.go
+++ b/syntax/parser_arithm.go
@@ -203,6 +203,13 @@ func (p *Parser) arithmExprValue(compact bool) ArithmExpr {
 		pe := &ParamExp{Short: true, Param: l}
 		pe.Index = p.eitherIndex()
 		x = p.wordOne(pe)
+	case hash:
+		// A bare `#` can appear as a literal array subscript key, e.g.
+		// `a[COMMAND,#]` for an associative array; it is not always the
+		// length-of-parameter operator, which is parsed separately.
+		l := p.lit(p.pos, p.tok.String())
+		p.next()
+		x = p.wordOne(l)
 	case bckQuote:
 		if p.quote == arithmExprLet && p.openBquotes > 0 {
 			return nil


### PR DESCRIPTION
`shfmt` fails to parse the valid bash arithmetic array index `ARGS[COMMAND,#]` with "`,` must be followed by an expression", and on the quoted workaround it corrupts the code on re-format (#1285).

Two parts, both needed:
- `syntax/lexer.go`: in arithmetic mode, `#` was glued onto the preceding literal instead of breaking into its own token. It now breaks, except after a pure-digit prefix so base-N literals like `16#FF` and `3#20` keep working.
- `syntax/parser_arithm.go`: a bare `#` token is now accepted as a subscript key value in `arithmExprValue`.

Added a fixture to `syntax/filetests_test.go`, which also checks print idempotency. It fails without the fix (parse error across bash/mksh/zsh) and passes with it, with round-trip formatting stable. `go test ./syntax/...`, `go vet` and `gofmt` clean.

Closes #1285
