### PR TITLE
interp: don't permanently disable traps after a trap callback parse error

### DIFF
--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -2654,6 +2654,8 @@ done <<< 2`,
 	// TODO: our builtin appears to not receive the piped bytes?
 	// {"trap 'echo on_err' ERR; trap | grep -q '.*echo on_err.*'", "trap -- \"echo on_err\" ERR\n"},
 	{"trap 'false' ERR EXIT; false", "exit status 1"},
+	// A parse error in one trap callback must not disable later ones.
+	{"trap '(' ERR; false; trap 'echo ok' ERR; false; :", "errortrap: error trap:1:1: `(` must be followed by a statement list\nok\n #IGNORE"},
 
 	// eval
 	{"eval", ""},

--- a/interp/runner.go
+++ b/interp/runner.go
@@ -826,6 +826,7 @@ func (r *Runner) trapCallback(ctx context.Context, callback, name string) {
 		return // don't recurse, as that could lead to cycles
 	}
 	r.handlingTrap = true
+	defer func() { r.handlingTrap = false }()
 
 	p := syntax.NewParser()
 	// TODO: do this parsing when "trap" is called?
@@ -838,8 +839,6 @@ func (r *Runner) trapCallback(ctx context.Context, callback, name string) {
 	oldExit := r.exit
 	r.stmts(ctx, file.Stmts)
 	r.exit = oldExit // traps on EXIT or ERR should not modify the result
-
-	r.handlingTrap = false
 }
 
 func (r *Runner) flattenAssigns(args []*syntax.Assign) iter.Seq[*syntax.Assign] {


### PR DESCRIPTION
When a trap callback failed to parse, r.handlingTrip didn't get reset.
As a result, all subsequent trap callbacks were silently
skipped for the rest of the runner's lifetime.

