### PR TITLE
interp: provide HandlerContext to stat handlers

### DIFF
--- a/interp/handler.go
+++ b/interp/handler.go
@@ -41,6 +41,7 @@ const (
 	handlerKindCall                // [CallHandlerFunc]
 	handlerKindOpen                // [OpenHandlerFunc]
 	handlerKindReadDir             // [ReadDirHandlerFunc2]
+	handlerKindStat                // [StatHandlerFunc]
 )
 
 // HandlerContext is the data passed to all the handler functions via [context.WithValue].

--- a/interp/runner.go
+++ b/interp/runner.go
@@ -1134,10 +1134,10 @@ func (r *Runner) open(ctx context.Context, path string, flags int, mode os.FileM
 
 func (r *Runner) stat(ctx context.Context, name string) (fs.FileInfo, error) {
 	path := absPath(r.Dir, name)
-	return r.statHandler(ctx, path, true)
+	return r.statHandler(r.handlerCtx(ctx, handlerKindStat, todoPos), path, true)
 }
 
 func (r *Runner) lstat(ctx context.Context, name string) (fs.FileInfo, error) {
 	path := absPath(r.Dir, name)
-	return r.statHandler(ctx, path, false)
+	return r.statHandler(r.handlerCtx(ctx, handlerKindStat, todoPos), path, false)
 }


### PR DESCRIPTION
StatHandlerFunc is supposed to get a HandlerContext.
It doesn't, and hasn't since the option was introduced.
Fix that.