### PR TITLE
syntax: preserve comments terminating continued commands

### DIFF
--- a/syntax/parser.go
+++ b/syntax/parser.go
@@ -2144,7 +2144,9 @@ func (p *Parser) getStmt(readEnd, binCmd, fnBody bool) *Stmt {
 	}
 	if len(p.accComs) > 0 && !binCmd && !fnBody {
 		c := p.accComs[0]
-		if c.Pos().Line() == s.End().Line() {
+		// A later-line comment can only be reached here through an escaped
+		// newline, as a regular newline ends getStmt first.
+		if c.Pos().Line() >= s.End().Line() {
 			s.Comments = append(s.Comments, c)
 			p.accComs = p.accComs[1:]
 		}

--- a/syntax/parser_test.go
+++ b/syntax/parser_test.go
@@ -144,6 +144,52 @@ func TestParseBashKeepComments(t *testing.T) {
 	}
 }
 
+func TestParseContinuedComment(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name                  string
+		input                 string
+		firstComs, secondComs int
+	}{
+		{
+			"EscapedNewline",
+			"cmd \\\n\targ \\\n\t# EOL\nnext",
+			1, 0,
+		},
+		{
+			"OrdinaryNewline",
+			"cmd \\\n\targ  \n\t# EOL\nnext",
+			0, 1,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			prog, err := NewParser(KeepComments(true)).Parse(strings.NewReader(test.input), "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := len(prog.Stmts); got != 2 {
+				t.Fatalf("got %d statements, want 2", got)
+			}
+			if got := len(prog.Stmts[0].Comments); got != test.firstComs {
+				t.Fatalf("first statement has %d comments, want %d", got, test.firstComs)
+			}
+			if got := len(prog.Stmts[1].Comments); got != test.secondComs {
+				t.Fatalf("second statement has %d comments, want %d", got, test.secondComs)
+			}
+			var comment Comment
+			if test.firstComs > 0 {
+				comment = prog.Stmts[0].Comments[0]
+			} else {
+				comment = prog.Stmts[1].Comments[0]
+			}
+			if comment.Text != " EOL" || comment.Pos().Line() != 3 {
+				t.Errorf("got comment %q at line %d", comment.Text, comment.Pos().Line())
+			}
+		})
+	}
+}
+
 func TestParsePosOverflow(t *testing.T) {
 	t.Parallel()
 

--- a/syntax/printer.go
+++ b/syntax/printer.go
@@ -1439,6 +1439,28 @@ func (p *Printer) ifClause(ic *IfClause, elif bool) {
 	p.semiRsrv("fi", ic.FiPos)
 }
 
+func (p *Printer) printContinuedComment(s *Stmt, comments []Comment) []Comment {
+	if !p.binNextLine || p.minify || p.singleLine || len(comments) == 0 || p.mustNewline ||
+		p.wantSpace != spaceRequired || s.Semicolon.IsValid() {
+		return comments
+	}
+	if len(p.pendingHdocs) > 0 {
+		// Do not change the ordering of pending heredoc bodies and comments.
+		return comments
+	}
+	comment := comments[0]
+	if comment.Pos().Line() <= s.End().Line() {
+		return comments
+	}
+	p.incLevel()
+	p.bslashNewl()
+	p.advanceLine(comment.Pos().Line())
+	p.comments(comment)
+	p.flushComments()
+	p.decLevel()
+	return comments[1:]
+}
+
 func (p *Printer) stmtList(stmts []*Stmt, last []Comment) {
 	sep := p.wantNewline || (len(stmts) > 0 && stmts[0].Pos().Line() > p.line)
 	for i, s := range stmts {
@@ -1473,6 +1495,7 @@ func (p *Printer) stmtList(stmts []*Stmt, last []Comment) {
 		p.advanceLine(pos.Line())
 		p.comments(midComs...)
 		p.stmt(s)
+		endComs = p.printContinuedComment(s, endComs)
 		p.comments(endComs...)
 		p.wantNewline = true
 	}

--- a/syntax/printer_test.go
+++ b/syntax/printer_test.go
@@ -87,6 +87,10 @@ var printTests = []printCase{
 	samePrint("a=b # inline\nbar"),
 	samePrint("a=$(b) # inline"),
 	samePrint("foo # inline\n# after"),
+	{
+		"a \\\n\tb \\\n\t# EOC",
+		"a \\\n\tb\n# EOC",
+	},
 	samePrint("$(a) $(b)"),
 	{"if a\nthen\n\tb\nfi", "if a; then\n\tb\nfi"},
 	samePrint("if a; then\n\tb\nelse\n\tc\nfi"),
@@ -855,13 +859,32 @@ func TestPrintBinaryNextLine(t *testing.T) {
 			"a \\\n\t| b \\\n\t|\n\t#c2\n\tc",
 		},
 		samePrint("a \\\n\t&"),
+		samePrint("a \\\n\tb \\\n\tc \\\n\t# EOC"),
+		samePrint("a \\\n\t| b \\\n\t| c \\\n\t# EOC"),
 		{
-			"a \\\n\tb \\\n\tc \\\n\t# EOC",
-			"a \\\n\tb \\\n\tc\n# EOC",
+			"a   \\\n\tb \\\n\t# EOC",
+			"a \\\n\tb \\\n\t# EOC",
 		},
 		{
-			"a \\\n\t| b \\\n\t| c \\\n\t# EOC",
-			"a \\\n\t| b \\\n\t| c\n# EOC",
+			"a \\\n\tb  \n\t# ordinary",
+			"a \\\n\tb\n# ordinary",
+		},
+		{
+			"a \\\r\n\tb \\\r\n\t# EOC",
+			"a \\\n\tb \\\n\t# EOC",
+		},
+		{
+			"a\\\n\tb\\\n\t# EOC",
+			"a b # EOC",
+		},
+		samePrint("a \\\n\tb \\\n\t# EOC\nnext"),
+		{
+			"a \\\n\tb \\\n\t# EOC\n\t# ordinary",
+			"a \\\n\tb \\\n\t# EOC\n# ordinary",
+		},
+		{
+			"a; \\\n\t# ordinary",
+			"a\n# ordinary",
 		},
 	}
 	parser := NewParser(KeepComments(true))


### PR DESCRIPTION
Fixes #1290.

Associate a terminal comment reached through an escaped newline with its
statement. When `BinaryNextLine` is enabled, the printer can then keep the
final continuation instead of moving the comment out of the command.

Ordinary following comments remain unchanged. Tests cover both issue examples,
variable whitespace, CRLF, following statements, multiple comments, and
word-internal or semicolon-terminated negative cases.