### PR TITLE
syntax: support zsh short form for loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- **syntax**
+  - Support Zsh short `for` loops with a parenthesized word list, such as
+    `for i ($arr) echo $i` and `for i (1 2 3) { echo $i }`
+
 ## [3.13.1] - 2026-03-09
 
 - **cmd/shfmt**

--- a/syntax/filetests_test.go
+++ b/syntax/filetests_test.go
@@ -617,6 +617,45 @@ var fileTests = []fileTestCase{
 		[]string{"select foo bar"},
 		langFile(litStmt("select", "foo", "bar"), LangPOSIX),
 	),
+	// Zsh parenthesized word list with a `do`/`done` body.
+	fileTest(
+		[]string{
+			"for i (1 2 3); do echo $i; done",
+			"for i (1 2 3)\ndo echo $i\ndone",
+			"for i (1 2 3) { echo $i; }",
+		},
+		langFile(&ForClause{
+			Loop: &WordIter{
+				Name:   lit("i"),
+				Parens: true,
+				Items:  litWords("1", "2", "3"),
+			},
+			Do: stmts(call(
+				litWord("echo"),
+				word(litParamExp("i")),
+			)),
+		}, LangZsh),
+	),
+	// Zsh short loop form: a parenthesized word list followed by a single
+	// statement, without do/done or braces.
+	fileTest(
+		[]string{
+			"for i (1 2 3) echo $i",
+			"for i (1 2 3)\necho $i",
+		},
+		langFile(&ForClause{
+			Short: true,
+			Loop: &WordIter{
+				Name:   lit("i"),
+				Parens: true,
+				Items:  litWords("1", "2", "3"),
+			},
+			Do: stmts(call(
+				litWord("echo"),
+				word(litParamExp("i")),
+			)),
+		}, LangZsh),
+	),
 	fileTest(
 		[]string{`' ' "foo bar"`},
 		langFile(call(
@@ -5610,7 +5649,9 @@ func (c sanityChecker) visit(node Node) bool {
 		} else {
 			c.checkPos(node, node.ForPos, "for")
 		}
-		if node.Braces {
+		if node.Short {
+			// Zsh short form: no do/done or braces.
+		} else if node.Braces {
 			c.checkPos(node, node.DoPos, "{")
 			c.checkPos(node, node.DonePos, "}")
 			// Zero out Braces, to not duplicate all the test cases.
@@ -5621,6 +5662,10 @@ func (c sanityChecker) visit(node Node) bool {
 			c.checkPos(node, node.DonePos, "done")
 		}
 	case *WordIter:
+		if node.Parens {
+			c.checkPos(node, node.Lparen, "(")
+			c.checkPos(node, node.Rparen, ")")
+		}
 		if node.InPos.IsValid() {
 			c.checkPos(node, node.InPos, "in")
 		}

--- a/syntax/nodes.go
+++ b/syntax/nodes.go
@@ -427,6 +427,7 @@ type ForClause struct {
 	ForPos, DoPos, DonePos Pos
 	Select                 bool
 	Braces                 bool // deprecated form with { } instead of do/done
+	Short                  bool // Zsh short form; the body is a single statement without do/done or braces
 	Loop                   Loop
 
 	Do     []*Stmt
@@ -434,7 +435,16 @@ type ForClause struct {
 }
 
 func (f *ForClause) Pos() Pos { return f.ForPos }
-func (f *ForClause) End() Pos { return posAddCol(f.DonePos, 4) }
+func (f *ForClause) End() Pos {
+	if f.Short {
+		// Zsh short form: no do/done, so the clause ends with its body.
+		if len(f.Do) > 0 {
+			return f.Do[len(f.Do)-1].End()
+		}
+		return f.Loop.End()
+	}
+	return posAddCol(f.DonePos, 4)
+}
 
 // Loop holds either [*WordIter] or [*CStyleLoop].
 type Loop interface {
@@ -448,14 +458,23 @@ func (*CStyleLoop) loopNode() {}
 // WordIter represents the iteration of a variable over a series of words in a
 // for clause. If InPos is an invalid position, the "in" token was missing, so
 // the iteration is over the shell's positional parameters.
+//
+// In Zsh, the list of words may be given inside parentheses instead of after
+// "in", such as `for name (word...)`. In that case Parens is true and Lparen
+// and Rparen hold the positions of the surrounding parentheses.
 type WordIter struct {
-	Name  *Lit
-	InPos Pos // position of "in"
-	Items []*Word
+	Name           *Lit
+	InPos          Pos // position of "in"
+	Parens         bool
+	Lparen, Rparen Pos // position of "(" and ")" when Parens is true
+	Items          []*Word
 }
 
 func (w *WordIter) Pos() Pos { return w.Name.Pos() }
 func (w *WordIter) End() Pos {
+	if w.Parens {
+		return posAddCol(w.Rparen, 1)
+	}
 	if len(w.Items) > 0 {
 		return wordLastEnd(w.Items)
 	}

--- a/syntax/parser.go
+++ b/syntax/parser.go
@@ -2432,12 +2432,32 @@ func (p *Parser) forClause(s *Stmt) {
 	p.next()
 	fc.Loop = p.loop(fc.ForPos)
 
+	// A Zsh parenthesized word list, `for name (word...)`, may be followed by
+	// a short loop body: braces, do/done, or a single statement.
+	parens := false
+	if wi, ok := fc.Loop.(*WordIter); ok {
+		parens = wi.Parens
+	}
+
 	start, end := "do", "done"
 	if pos, ok := p.gotRsrv("{"); ok {
-		p.checkLang(pos, langBashLike|LangMirBSDKorn, "for loops with braces")
+		p.checkLang(pos, langBashLike|LangMirBSDKorn|LangZsh, "for loops with braces")
 		fc.DoPos = pos
 		fc.Braces = true
 		start, end = "{", "}"
+	} else if parens && !(p.tok == _LitWord && p.val == "do") {
+		// Zsh short loop form: the body is a single statement without
+		// do/done or braces, such as `for i (1 2 3) echo $i`.
+		fc.Short = true
+		s.Comments = append(s.Comments, p.accComs...)
+		p.accComs = nil
+		if st := p.getStmt(false, false, false); st != nil {
+			fc.Do = []*Stmt{st}
+		} else {
+			p.followErr(fc.ForPos, "for foo [in words]", noQuote("a statement"))
+		}
+		s.Cmd = fc
+		return
 	} else {
 		fc.DoPos = p.followRsrv(fc.ForPos, "for foo [in words]", start)
 	}
@@ -2477,6 +2497,24 @@ func (p *Parser) wordIter(ftok string, fpos Pos) *WordIter {
 	wi := &WordIter{}
 	if wi.Name = p.getLit(); wi.Name == nil {
 		p.followErr(fpos, ftok, noQuote("a literal"))
+	}
+	// Zsh allows the list of words to be given in parentheses instead of
+	// after "in", such as `for name (word...)`.
+	if p.tok == leftParen && p.lang == LangZsh {
+		wi.Parens = true
+		wi.Lparen = p.pos
+		p.next()
+		for !p.stopToken() && p.tok != rightParen {
+			if w := p.getWord(); w == nil {
+				p.curErr("word list can only contain words")
+			} else {
+				wi.Items = append(wi.Items, w)
+			}
+		}
+		wi.Rparen = p.matched(wi.Lparen, leftParen, rightParen)
+		p.got(semicolon)
+		p.got(_Newl)
+		return wi
 	}
 	if p.got(semicolon) {
 		p.got(_Newl)

--- a/syntax/parser_test.go
+++ b/syntax/parser_test.go
@@ -1990,7 +1990,7 @@ var errorCases = []errorCase{
 	),
 	errCase(
 		"for i in 1 2 3; { echo; }",
-		langErr("1:17: for loops with braces are a bash/mksh feature; tried parsing as LANG", LangPOSIX),
+		langErr("1:17: for loops with braces are a bash/mksh/zsh feature; tried parsing as LANG", LangPOSIX),
 	),
 	errCase(
 		"echo !(a)",

--- a/syntax/printer.go
+++ b/syntax/printer.go
@@ -867,7 +867,15 @@ func (p *Printer) loop(loop Loop) {
 	switch loop := loop.(type) {
 	case *WordIter:
 		p.writeLit(loop.Name.Value)
-		if loop.InPos.IsValid() {
+		if loop.Parens {
+			p.space()
+			p.w.WriteByte('(')
+			p.wantSpace = spaceNotRequired
+			p.wordJoin(loop.Items)
+			p.wantSpace = spaceNotRequired
+			p.w.WriteByte(')')
+			p.wantSpace = spaceRequired
+		} else if loop.InPos.IsValid() {
 			p.spacedString(" in", Pos{})
 			p.wordJoin(loop.Items)
 		}
@@ -1230,6 +1238,14 @@ func (p *Printer) command(cmd Command, redirs []*Redirect) (startRedirs int) {
 			p.w.WriteString("for ")
 		}
 		p.loop(cmd.Loop)
+		if cmd.Short {
+			// Zsh short loop form: a single statement with no do/done.
+			p.space()
+			if len(cmd.Do) > 0 {
+				p.stmt(cmd.Do[0])
+			}
+			break
+		}
 		p.semiOrNewl("do", cmd.DoPos)
 		p.nestedStmts(cmd.Do, cmd.DoLast, cmd.DonePos)
 		p.semiRsrv("done", cmd.DonePos)


### PR DESCRIPTION
`zsh` supports short-form for loops like this:

```zsh
% arr=(1 2 3)
% for i ($arr) echo $i
1
2
3
```

Today, when i try to format a script that uses this, i get this error:

```
% shfmt aliases.sh
aliases.sh:1345:5: `for foo` must be followed by `in`, `do`, `;`, or a newline
```

this PR adds support for this syntax. The resulting output format is this:

```zsh
# file contents -------------------------------
% cat test.sh
#!/usr/bin/env zsh

set -euo pipefail

main() {
    for    e    (1 2 3) echo $e
      }

main "$@"
% # validate syntax  -------------------------------
% zsh test.sh
1
2
3
% # with this pr -------------------------------
% go run ./cmd/shfmt test.sh
#!/usr/bin/env zsh

set -euo pipefail

main() {
	for e (1 2 3) echo $e
}

main "$@"
```