### PR TITLE
interp: add HandlerContext.LastExitStatus

### DIFF
--- a/interp/api.go
+++ b/interp/api.go
@@ -926,6 +926,8 @@ func (r *Runner) Run(ctx context.Context, node syntax.Node) error {
 	default:
 		return fmt.Errorf("node can only be File, Stmt, or Command: %T", node)
 	}
+	// A bare Command bypasses stmt, which normally updates lastExit.
+	r.lastExit = r.exit
 	r.trapCallback(ctx, r.callbackExit, "exit")
 	maps.Insert(r.Vars, r.writeEnv.Each)
 	// Return the first of: a fatal error, a non-fatal handler error, or the exit code.

--- a/interp/handler.go
+++ b/interp/handler.go
@@ -75,6 +75,12 @@ type HandlerContext struct {
 	Stdout io.Writer
 	// Stderr is the interpreter's current standard error writer.
 	Stderr io.Writer
+
+	// LastExitStatus is the value that "$?" would hold when the handler is called.
+	// A [CallHandlerFunc] or [ExecHandlerFunc] runs as part of its own command,
+	// so this refers to the command before it.
+	// At the start of a trap callback, it is the status of the command which triggered the trap.
+	LastExitStatus int
 }
 
 // CallHandlerFunc is a handler which runs on every [syntax.CallExpr].

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -2656,6 +2656,13 @@ done <<< 2`,
 	{"trap 'false' ERR EXIT; false", "exit status 1"},
 	// A parse error in one trap callback must not disable later ones.
 	{"trap '(' ERR; false; trap 'echo ok' ERR; false; :", "errortrap: error trap:1:1: `(` must be followed by a statement list\nok\n #IGNORE"},
+	// On entry to a trap, "$?" is the status of the command which triggered it.
+	{"trap 'echo err $?' ERR; false; echo after $?", "err 1\nafter 1\n"},
+	{"trap 'echo exit $?' EXIT; false", "exit 1\nexit status 1"},
+	{"trap 'echo exit $?' EXIT; true", "exit 0\n"},
+	{"trap 'false; echo next $?' EXIT; true", "next 1\n"},
+	{"trap 'echo err $?' ERR; trap 'echo exit $?' EXIT; false; true", "err 1\nexit 0\n"},
+	{"false; trap 'echo exit $?' EXIT; true", "exit 0\n"},
 
 	// eval
 	{"eval", ""},

--- a/interp/runner.go
+++ b/interp/runner.go
@@ -259,13 +259,14 @@ var todoPos syntax.Pos // for handlerCtx callers where we don't yet have a posit
 
 func (r *Runner) handlerCtx(ctx context.Context, kind handlerKind, pos syntax.Pos) context.Context {
 	hc := HandlerContext{
-		runner: r,
-		kind:   kind,
-		Env:    &overlayEnviron{parent: r.writeEnv},
-		Dir:    r.Dir,
-		Pos:    pos,
-		Stdout: r.stdout,
-		Stderr: r.stderr,
+		runner:         r,
+		kind:           kind,
+		Env:            &overlayEnviron{parent: r.writeEnv},
+		Dir:            r.Dir,
+		Pos:            pos,
+		Stdout:         r.stdout,
+		Stderr:         r.stderr,
+		LastExitStatus: int(r.lastExit.code),
 	}
 	if r.stdin != nil { // do not leave hc.Stdin as a typed nil
 		hc.Stdin = r.stdin
@@ -836,9 +837,10 @@ func (r *Runner) trapCallback(ctx context.Context, callback, name string) {
 		// ignore errors in the callback
 		return
 	}
-	oldExit := r.exit
+	oldExit, oldLastExit := r.exit, r.lastExit
+	r.lastExit = r.exit
 	r.stmts(ctx, file.Stmts)
-	r.exit = oldExit // traps on EXIT or ERR should not modify the result
+	r.exit, r.lastExit = oldExit, oldLastExit // traps on EXIT or ERR should not modify the result
 }
 
 func (r *Runner) flattenAssigns(args []*syntax.Assign) iter.Seq[*syntax.Assign] {


### PR DESCRIPTION
I've been doing some error handling work,
and have been missing the ability for handlers
to observe the exit status of the previous command.

Expose that value (i.e. what "$?" would expand to)
as HandlerContext.LastExitStatus.

Happily, doing that fixes two related bugs:

Inside a trap callback, "$?" now holds the status of the command
that triggered the trap, rather than its predecessor.

Run now records the exit status of a bare Command,
so an exit trap and subsequent incremental calls to Run see it in "$?".
