### PR TITLE
interp: run ENOEXEC scripts via /bin/sh

### DIFF
--- a/interp/handler.go
+++ b/interp/handler.go
@@ -5,6 +5,7 @@ package interp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -14,6 +15,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"syscall"
 	"time"
 
 	"mvdan.cc/sh/v3/expand"
@@ -147,6 +149,30 @@ func DefaultExecHandler(killTimeout time.Duration) ExecHandlerFunc {
 		}
 
 		err = cmd.Start()
+		// Bash retries executable scripts that the kernel rejects with ENOEXEC
+		// (for example a missing shebang) by running them via /bin/sh.
+		// Match that behavior so "./script" without a shebang still works.
+		if err != nil && runtime.GOOS != "windows" && isExecFormatError(err) {
+			// Prefer sh from PATH, but bash still falls back to /bin/sh when PATH is empty.
+			shPath, shErr := LookPathDir(hc.Dir, hc.Env, "sh")
+			if shErr != nil {
+				if _, statErr := os.Stat("/bin/sh"); statErr == nil {
+					shPath, shErr = "/bin/sh", nil
+				}
+			}
+			if shErr == nil {
+				cmd = exec.Cmd{
+					Path:   shPath,
+					Args:   append([]string{shPath, path}, args[1:]...),
+					Env:    execEnv(hc.Env),
+					Dir:    hc.Dir,
+					Stdin:  hc.Stdin,
+					Stdout: hc.Stdout,
+					Stderr: hc.Stderr,
+				}
+				err = cmd.Start()
+			}
+		}
 		if err == nil {
 			stopf := context.AfterFunc(ctx, func() {
 				if killTimeout <= 0 || runtime.GOOS == "windows" {
@@ -184,6 +210,21 @@ func DefaultExecHandler(killTimeout time.Duration) ExecHandlerFunc {
 			return err
 		}
 	}
+}
+
+// isExecFormatError reports whether err is the kernel's ENOEXEC failure when
+// trying to execute a text script without a valid interpreter header.
+func isExecFormatError(err error) bool {
+	if errors.Is(err, syscall.ENOEXEC) {
+		return true
+	}
+	// Go's os/exec often wraps ENOEXEC as PathError from fork/exec.
+	var pe *os.PathError
+	if errors.As(err, &pe) && errors.Is(pe.Err, syscall.ENOEXEC) {
+		return true
+	}
+	// Last resort: portable message used by syscall.Errno.
+	return strings.Contains(err.Error(), "exec format error")
 }
 
 func checkStat(dir, file string, checkExec bool) (string, error) {

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -3872,6 +3872,15 @@ var runTestsUnix = []runTest{
 		"b\n",
 	},
 	{
+		// executable script without shebang: kernel returns ENOEXEC; bash runs via sh
+		"echo 'echo b' >a; chmod 0755 a; PATH=; a",
+		"b\n",
+	},
+	{
+		"mkdir c; cd c; echo 'echo b' >a; chmod 0755 a; PATH=; a",
+		"b\n",
+	},
+	{
 		"GOSH_CMD=lookpath $GOSH_PROG",
 		"sh found\n",
 	},


### PR DESCRIPTION
#### Description
When the kernel rejects an executable text script with `ENOEXEC` (commonly a missing shebang), bash retries the script via `/bin/sh`. `interp.DefaultExecHandler` previously surfaced the fork/exec error instead.

This matches bash for that case:
- detect `ENOEXEC` from `cmd.Start`
- re-run via `sh` from `PATH`, falling back to `/bin/sh` when `PATH` is empty
- keep Windows behavior unchanged

Includes regression tests for relative scripts with and without a working directory change.

Closes #1065

#### Checklist
- [x] tests: `go test ./interp`
