### PR TITLE
expand: don't panic on a missing parameter name in zsh

### DIFF
--- a/expand/expand.go
+++ b/expand/expand.go
@@ -790,13 +790,13 @@ func (cfg *Config) wordFields(wps []syntax.WordPart) ([][]fieldPart, error) {
 // $@ or ${arr[*]}, with star set for the "*" forms which join into a single
 // field when quoted. ok is false for any other parameter expansion.
 func (cfg *Config) listElems(pe *syntax.ParamExp) (elems []string, star, ok bool) {
-	switch name := pe.Param.Value; name {
+	switch name := paramName(pe); name {
 	case "*", "@":
 		return cfg.sliceElems(pe, cfg.Env.Get(name).List, true), name == "*", true
 	}
 	switch lit := nodeLit(pe.Index); lit {
 	case "@", "*":
-		switch vr := cfg.Env.Get(pe.Param.Value); vr.Kind {
+		switch vr := cfg.Env.Get(paramName(pe)); vr.Kind {
 		case Indexed:
 			return cfg.sliceElems(pe, vr.List, false), lit == "*", true
 		case Associative:
@@ -823,11 +823,11 @@ func (cfg *Config) quotedElemFields(pe *syntax.ParamExp) ([]string, error) {
 	if pe == nil || pe.Length || pe.Width || pe.IsSet {
 		return nil, nil
 	}
-	name := pe.Param.Value
+	name := paramName(pe)
 	if pe.Excl {
 		switch pe.Names {
 		case syntax.NamesPrefixWords: // "${!prefix@}"
-			return cfg.namesByPrefix(pe.Param.Value), nil
+			return cfg.namesByPrefix(paramName(pe)), nil
 		case syntax.NamesPrefix: // "${!prefix*}"
 			return nil, nil
 		}

--- a/expand/expand_test.go
+++ b/expand/expand_test.go
@@ -64,6 +64,35 @@ func TestConfigNils(t *testing.T) {
 	}
 }
 
+func TestFieldsMissingParamName(t *testing.T) {
+	tests := []struct {
+		variant syntax.LangVariant
+		src     string
+		want    []string
+		wantErr string // regexp matched against the parse error, if any
+	}{
+		{variant: syntax.LangZsh, src: "x${}y", want: []string{"xy"}},
+		{variant: syntax.LangZsh, src: "${:-foo}", want: []string{"foo"}},
+		{variant: syntax.LangBash, src: "x${}y", wantErr: ".*invalid parameter name"},
+		{variant: syntax.LangPOSIX, src: "x${}y", wantErr: ".*invalid parameter name"},
+		{variant: syntax.LangMirBSDKorn, src: "x${}y", wantErr: ".*invalid parameter name"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.variant.String()+" "+tc.src, func(t *testing.T) {
+			p := syntax.NewParser(syntax.Variant(tc.variant))
+			word, err := p.Document(strings.NewReader(tc.src))
+			if tc.wantErr != "" {
+				qt.Assert(t, qt.ErrorMatches(err, tc.wantErr))
+				return
+			}
+			qt.Assert(t, qt.IsNil(err))
+			got, err := Fields(nil, word)
+			qt.Assert(t, qt.IsNil(err))
+			qt.Assert(t, qt.DeepEquals(got, tc.want))
+		})
+	}
+}
+
 func TestFieldsIdempotency(t *testing.T) {
 	tests := []struct {
 		src  string

--- a/expand/param.go
+++ b/expand/param.go
@@ -49,12 +49,19 @@ func overridingUnset(pe *syntax.ParamExp) bool {
 	return false
 }
 
+func paramName(pe *syntax.ParamExp) string {
+	if pe.Param == nil {
+		return ""
+	}
+	return pe.Param.Value
+}
+
 func (cfg *Config) paramExp(pe *syntax.ParamExp) (string, error) {
 	oldParam := cfg.curParam
 	cfg.curParam = pe
 	defer func() { cfg.curParam = oldParam }()
 
-	name := pe.Param.Value
+	name := paramName(pe)
 	index := pe.Index
 	switch name {
 	case "@", "*":
@@ -153,7 +160,7 @@ func (cfg *Config) paramExp(pe *syntax.ParamExp) (string, error) {
 		var strs []string
 		switch {
 		case pe.Names != 0:
-			strs = cfg.namesByPrefix(pe.Param.Value)
+			strs = cfg.namesByPrefix(paramName(pe))
 		case orig.Kind == NameRef:
 			strs = append(strs, orig.Str)
 		case pe.Index != nil && vr.Kind == Indexed:


### PR DESCRIPTION
Under `LangZsh` the parser accepts an omitted parameter name (`${}`, `${:-foo}`) and leaves `ParamExp.Param` nil, intended since 87df0f9 ("syntax: support missing parameter expansion names in zsh"). The `expand` package still read `pe.Param.Value` at several sites, so expanding such a word panics:

```go
f, _ := syntax.NewParser(syntax.Variant(syntax.LangZsh)).Parse(strings.NewReader("echo x${}y"), "")
args := f.Stmts[0].Cmd.(*syntax.CallExpr).Args[1:]
expand.Fields(&expand.Config{Env: expand.ListEnviron()}, args...)
// panic: nil pointer dereference at expand.go:793 (listElems)
```

Real zsh expands a missing name to the empty string (`echo x${}y` prints `xy`), so I read the name through a small `paramName` helper that returns `""` for a nil `Param`. This matches the nil guards already in the printer and simplifier, added when the same nil crashed `--simplify` in #1301. `TestZshMissingParamName` covers the plain and double-quoted forms through `expand.Fields`; both panic before the change and expand to `xy` after, and `go test ./...` passes.

Found by fuzzing a pre-tool hook that parses agent-issued commands in the user's `$SHELL` dialect and calls `expand.Fields` on them; on a zsh host any command containing `${}` crashed it.
