### PR TITLE
syntax: allow chained zsh parameter subscripts

### DIFF
--- a/syntax/nodes.go
+++ b/syntax/nodes.go
@@ -660,6 +660,9 @@ type ParamExp struct {
 	// TODO(v4): rename Index to Subscript, which better matches bash and zsh terminology
 
 	Index ArithmExpr // ${a[i]}, ${a["k"]}, or a ${a[i,j]} slice with [LangZsh]
+	// ExtraIndexes holds additional consecutive subscripts like ${a[i][j]} with [LangZsh].
+	// Index is always the first subscript when any are present.
+	ExtraIndexes []ArithmExpr
 
 	// Only one of these is set at a time.
 	// TODO(v4): consider joining these in a single "expansion" field/type,

--- a/syntax/nodes.go
+++ b/syntax/nodes.go
@@ -698,6 +698,10 @@ func (p *ParamExp) End() Pos {
 		return posAddCol(p.Rbrace, 1)
 	}
 	// In short mode, we can only end in either an index or a simple name.
+	// ExtraIndexes are consecutive zsh subscripts after Index ($var[1][2]).
+	if n := len(p.ExtraIndexes); n > 0 {
+		return posAddCol(p.ExtraIndexes[n-1].End(), 1)
+	}
 	if p.Index != nil {
 		return posAddCol(p.Index.End(), 1)
 	}

--- a/syntax/parser.go
+++ b/syntax/parser.go
@@ -1528,6 +1528,11 @@ zshPrefixLoop:
 			p.pos = p.nextPos()
 			p.rune()
 			pe.Index = p.eitherIndex()
+			for p.r == '[' {
+				p.pos = p.nextPos()
+				p.rune()
+				pe.ExtraIndexes = append(pe.ExtraIndexes, p.eitherIndex())
+			}
 		}
 		p.quote = old
 		p.next()
@@ -1545,6 +1550,12 @@ zshPrefixLoop:
 		p.pos = p.nextPos()
 		p.rune()
 		pe.Index = p.eitherIndex()
+		// Zsh allows chained subscripts: ${var[1][2]}.
+		for p.lang.in(LangZsh) && p.r == '[' {
+			p.pos = p.nextPos()
+			p.rune()
+			pe.ExtraIndexes = append(pe.ExtraIndexes, p.eitherIndex())
+		}
 	}
 	tokRune := p.r
 	p.pos = p.nextPos()

--- a/syntax/printer.go
+++ b/syntax/printer.go
@@ -743,6 +743,9 @@ func (p *Printer) paramExp(pe *ParamExp) {
 	if pe.nakedIndex() { // arr[x]
 		p.writeLit(pe.Param.Value)
 		p.wroteIndex(pe.Index)
+		for _, idx := range pe.ExtraIndexes {
+			p.wroteIndex(idx)
+		}
 		return
 	}
 	p.w.WriteByte('$')
@@ -792,6 +795,9 @@ func (p *Printer) paramExp(pe *ParamExp) {
 		p.minify = saved
 	}
 	p.wroteIndex(pe.Index)
+	for _, idx := range pe.ExtraIndexes {
+		p.wroteIndex(idx)
+	}
 	switch {
 	case len(pe.Modifiers) > 0:
 		for _, lit := range pe.Modifiers {

--- a/syntax/walk.go
+++ b/syntax/walk.go
@@ -98,6 +98,9 @@ func Walk(node Node, f func(Node) bool) {
 		walkNilable(node.Param, f)
 		walkNilable(node.NestedParam, f)
 		walkNilable(node.Index, f)
+		for _, idx := range node.ExtraIndexes {
+			walkNilable(idx, f)
+		}
 		if node.Slice != nil {
 			walkNilable(node.Slice.Offset, f)
 			walkNilable(node.Slice.Length, f)

--- a/syntax/zsh_multi_subscript_test.go
+++ b/syntax/zsh_multi_subscript_test.go
@@ -1,0 +1,39 @@
+package syntax
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestZshMultiSubscript(t *testing.T) {
+	// https://github.com/mvdan/sh/issues/1361
+	in := "echo ${var[1][2]}\n"
+	f, err := NewParser(Variant(LangZsh)).Parse(strings.NewReader(in), "")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	var buf strings.Builder
+	if err := NewPrinter().Print(&buf, f); err != nil {
+		t.Fatalf("print: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "${var[1][2]}") {
+		t.Fatalf("printed %q, want multi-subscript preserved", out)
+	}
+}
+
+func TestZshMultiSubscriptShort(t *testing.T) {
+	in := "echo $var[1][2]\n"
+	f, err := NewParser(Variant(LangZsh)).Parse(strings.NewReader(in), "")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	var buf strings.Builder
+	if err := NewPrinter().Print(&buf, f); err != nil {
+		t.Fatalf("print: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "var[1][2]") && !strings.Contains(out, "${var[1][2]}") {
+		t.Fatalf("printed %q, want multi-subscript preserved", out)
+	}
+}

--- a/syntax/zsh_multi_subscript_test.go
+++ b/syntax/zsh_multi_subscript_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestZshMultiSubscript(t *testing.T) {
+	t.Parallel()
 	// https://github.com/mvdan/sh/issues/1361
 	in := "echo ${var[1][2]}\n"
 	f, err := NewParser(Variant(LangZsh)).Parse(strings.NewReader(in), "")
@@ -23,10 +24,30 @@ func TestZshMultiSubscript(t *testing.T) {
 }
 
 func TestZshMultiSubscriptShort(t *testing.T) {
+	t.Parallel()
 	in := "echo $var[1][2]\n"
 	f, err := NewParser(Variant(LangZsh)).Parse(strings.NewReader(in), "")
 	if err != nil {
 		t.Fatalf("parse: %v", err)
+	}
+	// Walk to ParamExp and check End covers second subscript.
+	var pe *ParamExp
+	Walk(f, func(node Node) bool {
+		if p, ok := node.(*ParamExp); ok {
+			pe = p
+			return false
+		}
+		return true
+	})
+	if pe == nil {
+		t.Fatal("ParamExp not found")
+	}
+	if len(pe.ExtraIndexes) != 1 {
+		t.Fatalf("ExtraIndexes=%d, want 1", len(pe.ExtraIndexes))
+	}
+	got := in[pe.Pos().Offset():pe.End().Offset()]
+	if got != "$var[1][2]" {
+		t.Fatalf("span %q, want $var[1][2]", got)
 	}
 	var buf strings.Builder
 	if err := NewPrinter().Print(&buf, f); err != nil {


### PR DESCRIPTION
## Summary
Parse and print chained zsh subscripts like `${var[1][2]}` (and short `$var[1][2]`) under `LangZsh`.

Previously the second `[` was rejected as an invalid parameter expansion operator.

Closes #1361

## Test plan
- [x] `go test ./syntax/ -run TestZshMultiSubscript`
- [x] `go test ./syntax/`
- [x] `printf 'echo ${var[1][2]}\n' | go run ./cmd/shfmt -ln=zsh`
