### PR TITLE
syntax: preserve trailing backslashes when printing

### DIFF
--- a/syntax/filetests_test.go
+++ b/syntax/filetests_test.go
@@ -191,14 +191,6 @@ var fileTests = []fileTestCase{
 		langFile(litWord("foo")),
 	),
 	fileTest(
-		[]string{`\`},
-		langFile(litWord(`\`)),
-	),
-	fileTest(
-		[]string{`foo\`, "f\\\noo\\"},
-		langFile(litWord(`foo\`)),
-	),
-	fileTest(
 		[]string{`foo\a`, "f\\\noo\\a"},
 		langFile(litWord(`foo\a`)),
 	),
@@ -5385,6 +5377,14 @@ var fileTests = []fileTestCase{
 
 // these don't have a canonical format with the same syntax tree
 var fileTestsNoPrint = []fileTestCase{
+	fileTest(
+		[]string{`\`},
+		langFile(litWord(`\`)),
+	),
+	fileTest(
+		[]string{`foo\`, "f\\\noo\\"},
+		langFile(litWord(`foo\`)),
+	),
 	fileTest(
 		[]string{`$[foo]`},
 		langFile(word(lit("$"), lit("[foo]")), LangPOSIX),

--- a/syntax/printer.go
+++ b/syntax/printer.go
@@ -65,13 +65,13 @@ func KeepPadding(enabled bool) PrinterOption {
 		if enabled && !p.keepPadding {
 			// Enable the flag, and set up the writer wrapper.
 			p.keepPadding = true
-			p.cols.Writer = p.w.(*bufio.Writer)
-			p.w = &p.cols
+			p.cols.Writer = p.w.bufWriter.(*bufio.Writer)
+			p.w.bufWriter = &p.cols
 
 		} else if !enabled && p.keepPadding {
 			// Ensure we reset the state to that of NewPrinter.
 			p.keepPadding = false
-			p.w = p.cols.Writer
+			p.w.bufWriter = p.cols.Writer
 			p.cols = colCounter{}
 		}
 	}
@@ -101,8 +101,9 @@ func FunctionNextLine(enabled bool) PrinterOption {
 
 // NewPrinter allocates a new Printer and applies any number of options.
 func NewPrinter(opts ...PrinterOption) *Printer {
+	bw := bufio.NewWriter(nil)
 	p := &Printer{
-		w:         bufio.NewWriter(nil),
+		w:         &printerWriter{bufWriter: bw},
 		tabWriter: new(tabwriter.Writer),
 	}
 	for _, opt := range opts {
@@ -142,7 +143,7 @@ func (p *Printer) Print(w io.Writer, node Node) error {
 	switch node := node.(type) {
 	case *File:
 		p.stmtList(node.Stmts, node.Last)
-		p.newline(Pos{})
+		p.finalNewline(Pos{})
 	case *Stmt:
 		p.stmtList([]*Stmt{node}, nil)
 	case Command:
@@ -180,6 +181,55 @@ type bufWriter interface {
 	WriteByte(byte) error
 	Reset(io.Writer)
 	Flush() error
+}
+
+// printerWriter tracks whether the output ends in backslashes from an unquoted
+// literal, so the File's final newline cannot turn an odd count into a continuation.
+type printerWriter struct {
+	bufWriter
+	trailingBackslashes int
+	trailingUnquotedLit bool
+}
+
+func (w *printerWriter) track(bs []byte, unquotedLit bool) {
+	for _, b := range bs {
+		if b == tabwriter.Escape {
+			continue
+		}
+		if b == '\\' {
+			w.trailingBackslashes++
+			w.trailingUnquotedLit = unquotedLit
+		} else {
+			w.trailingBackslashes = 0
+			w.trailingUnquotedLit = false
+		}
+	}
+}
+
+func (w *printerWriter) Write(bs []byte) (int, error) {
+	w.track(bs, false)
+	return w.bufWriter.Write(bs)
+}
+
+func (w *printerWriter) WriteString(s string) (int, error) {
+	w.track([]byte(s), false)
+	return w.bufWriter.WriteString(s)
+}
+
+func (w *printerWriter) WriteByte(b byte) error {
+	w.track([]byte{b}, false)
+	return w.bufWriter.WriteByte(b)
+}
+
+func (w *printerWriter) writeUnquotedLit(s string) {
+	w.track([]byte(s), true)
+	w.bufWriter.WriteString(s)
+}
+
+func (w *printerWriter) Reset(dst io.Writer) {
+	w.trailingBackslashes = 0
+	w.trailingUnquotedLit = false
+	w.bufWriter.Reset(dst)
 }
 
 type colCounter struct {
@@ -221,7 +271,7 @@ func (c *colCounter) Reset(w io.Writer) {
 // Printer holds the internal state of the printing mechanism of a
 // program.
 type Printer struct {
-	w         bufWriter
+	w         *printerWriter
 	tabWriter *tabwriter.Writer
 	cols      colCounter // used for [KeepPadding]
 
@@ -386,6 +436,14 @@ func (p *Printer) writeLit(s string) {
 	p.w.WriteString(s)
 }
 
+func (p *Printer) writeUnquotedLit(s string) {
+	if p.tabWriter != nil && strings.Contains(s, "\t") {
+		p.w.WriteByte(tabwriter.Escape)
+		defer p.w.WriteByte(tabwriter.Escape)
+	}
+	p.w.writeUnquotedLit(s)
+}
+
 func (p *Printer) incLevel() {
 	inc := false
 	if p.level <= p.lastLevel || len(p.levelIncs) == 0 {
@@ -427,8 +485,19 @@ func (p *Printer) indent() {
 
 // newline prints one newline and advances p.line to pos.Line().
 func (p *Printer) newline(pos Pos) {
+	p.newlineWithMode(pos, false)
+}
+
+func (p *Printer) finalNewline(pos Pos) {
+	p.newlineWithMode(pos, true)
+}
+
+func (p *Printer) newlineWithMode(pos Pos, final bool) {
 	p.flushHeredocs()
 	p.flushComments()
+	if final && p.w.trailingUnquotedLit && p.w.trailingBackslashes%2 == 1 {
+		p.w.writeUnquotedLit("\\")
+	}
 	p.w.WriteByte('\n')
 	p.wantSpace = spaceWritten
 	p.wantNewline, p.mustNewline = false, false
@@ -476,7 +545,7 @@ func (p *Printer) flushHeredocs() {
 					firstIndent: -1,
 				}
 				p.tabsPrinter = &Printer{
-					w: &extra,
+					w: &printerWriter{bufWriter: &extra},
 
 					// The options need to persist.
 					indentSpaces:   p.indentSpaces,
@@ -655,7 +724,7 @@ func (p *Printer) wordParts(wps []WordPart, quoted bool) {
 func (p *Printer) wordPart(wp, next WordPart) {
 	switch wp := wp.(type) {
 	case *Lit:
-		p.writeLit(wp.Value)
+		p.writeUnquotedLit(wp.Value)
 	case *SglQuoted:
 		if wp.Dollar {
 			p.w.WriteByte('$')

--- a/syntax/printer_test.go
+++ b/syntax/printer_test.go
@@ -689,6 +689,36 @@ func TestPrintTable(t *testing.T) {
 	}
 }
 
+func TestPrintTrailingBackslashes(t *testing.T) {
+	t.Parallel()
+	parser := NewParser(KeepComments(true))
+	printer := NewPrinter()
+	trailing := func(n int) string {
+		return "echo foo" + strings.Repeat("\\", n)
+	}
+	tests := []struct {
+		name     string
+		in, want string
+	}{
+		{"one", trailing(1), trailing(2)},
+		{"two", trailing(2), trailing(2)},
+		{"three", trailing(3), trailing(4)},
+		{"four", trailing(4), trailing(4)},
+		{"five", trailing(5), trailing(6)},
+		{"six", trailing(6), trailing(6)},
+		{"line-continuation", "echo foo \\\nbar", "echo foo \\\n\tbar"},
+		{"single-quoted", `echo 'foo\'`, `echo 'foo\'`},
+		{"double-quoted", `echo "foo\\"`, `echo "foo\\"`},
+		{"quoted-heredoc", "cat <<'EOF'\nfoo\\\nEOF", "cat <<'EOF'\nfoo\\\nEOF"},
+		{"comment", `# foo\`, `# foo\`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			printTest(t, parser, printer, tc.in, tc.want)
+		})
+	}
+}
+
 func parsePath(tb testing.TB, path string) *File {
 	f, err := os.Open(path)
 	if err != nil {
@@ -1253,7 +1283,6 @@ func printTest(t *testing.T, parser *Parser, printer *Printer, in, want string) 
 	if err != nil {
 		t.Fatalf("parsing got an error: %s:\n%s", err, in)
 	}
-	origWant := want
 	want += "\n"
 	got, err := strPrint(printer, prog)
 	if err != nil {
@@ -1263,11 +1292,9 @@ func printTest(t *testing.T, parser *Parser, printer *Printer, in, want string) 
 		t.Fatalf("Print mismatch:\nwant:\n%q\ngot:\n%q", want, got)
 	}
 
-	// With the original "want" output string,
-	// make sure that it's idempotent when formatted again.
-	// Note that we don't want the added newline,
-	// as that can change the meaning of trailing backslashes.
-	progAgain, err := parser.Parse(strings.NewReader(origWant), "")
+	// Reparse the exact output to make sure that it is idempotent when formatted
+	// again.
+	progAgain, err := parser.Parse(strings.NewReader(want), "")
 	if err != nil {
 		t.Fatalf("Result is not valid shell:\n%s", want)
 	}


### PR DESCRIPTION
## Summary

- duplicate an odd trailing backslash from an unquoted literal before the final file newline, preserving its meaning on reparse
- leave even backslash counts, valid line continuations, quoted literals, heredoc bodies, and comments unchanged
- make printer idempotence tests reparse the exact emitted output

## Tests

- `go test ./syntax -run TestPrintTrailingBackslashes -count=1`
- `go test ./...`
- `(cd moreinterp && go test ./...)`
- `gofmt -s -d .`
- `go vet ./...`
- `(cd moreinterp && go vet ./...)`

Fixes #1354