### PR TITLE
syntax: keep multiline commands out of inline bodies

### DIFF
--- a/syntax/printer.go
+++ b/syntax/printer.go
@@ -1487,6 +1487,10 @@ func (p *Printer) nestedStmts(stmts []*Stmt, last []Comment, closing Pos) {
 		// Force a newline if we find:
 		//     { stmt; stmt; }
 		p.wantNewline = true
+	case stmtsWillBeMultiline(stmts):
+		// Force a newline if the only statement expands while printing:
+		//     { if foo; then stmt; stmt; fi; }
+		p.wantNewline = true
 	case closing.Line() > p.line && len(stmts) > 0 &&
 		stmtsEnd(stmts, last).Line() < closing.Line():
 		// Force a newline if we find:
@@ -1504,6 +1508,47 @@ func (p *Printer) nestedStmts(stmts []*Stmt, last []Comment, closing Pos) {
 		p.flushComments()
 	}
 	p.decLevel()
+}
+
+func stmtsWillBeMultiline(stmts []*Stmt) bool {
+	if len(stmts) != 1 {
+		return len(stmts) > 1
+	}
+	return commandWillBeMultiline(stmts[0].Cmd)
+}
+
+func commandWillBeMultiline(cmd Command) bool {
+	switch cmd := cmd.(type) {
+	case *Block:
+		return stmtsWillBeMultiline(cmd.Stmts)
+	case *Subshell:
+		return stmtsWillBeMultiline(cmd.Stmts)
+	case *IfClause:
+		return stmtsWillBeMultiline(cmd.Cond) ||
+			stmtsWillBeMultiline(cmd.Then) ||
+			cmd.Else != nil && commandWillBeMultiline(cmd.Else)
+	case *WhileClause:
+		return stmtsWillBeMultiline(cmd.Cond) || stmtsWillBeMultiline(cmd.Do)
+	case *ForClause:
+		return stmtsWillBeMultiline(cmd.Do)
+	case *BinaryCmd:
+		return commandWillBeMultiline(cmd.X.Cmd) || commandWillBeMultiline(cmd.Y.Cmd)
+	case *FuncDecl:
+		return commandWillBeMultiline(cmd.Body.Cmd)
+	case *CaseClause:
+		for _, item := range cmd.Items {
+			if stmtsWillBeMultiline(item.Stmts) {
+				return true
+			}
+		}
+	case *TimeClause:
+		return cmd.Stmt != nil && commandWillBeMultiline(cmd.Stmt.Cmd)
+	case *CoprocClause:
+		return commandWillBeMultiline(cmd.Stmt.Cmd)
+	case *TestDecl:
+		return commandWillBeMultiline(cmd.Body.Cmd)
+	}
+	return false
 }
 
 func (p *Printer) assigns(assigns []*Assign) {

--- a/syntax/printer_test.go
+++ b/syntax/printer_test.go
@@ -120,6 +120,11 @@ var printTests = []printCase{
 		"{ foo; bar; }",
 		"{\n\tfoo\n\tbar\n}",
 	},
+	samePrint("for i in 1 2 3; do if true; then foo; fi; done"),
+	{
+		"for i in 1 2 3; do if true; then foo; bar; fi; done",
+		"for i in 1 2 3; do\n\tif true; then\n\t\tfoo\n\t\tbar\n\tfi\ndone",
+	},
 	{
 		"{ foo; bar; }\n#etc",
 		"{\n\tfoo\n\tbar\n}\n#etc",


### PR DESCRIPTION
Fixes #720

A body containing one compound command was considered inline solely from the number and source positions of its direct statements. When that compound command formatted its own nested body across multiple lines, the outer body stayed inline, producing incorrect indentation.

Detect whether the sole nested compound command will itself expand to multiple lines and force the containing body onto separate lines. Single-line compound commands remain compact.

Tests:
- `go test ./syntax -run '^TestPrintTable$' -count=1`
- `go test ./...`
- `go vet ./...`
- `cd moreinterp && go test ./...`