### PR TITLE
expand: give printf numbers a leading-quote character value

### DIFF
--- a/expand/expand.go
+++ b/expand/expand.go
@@ -378,7 +378,7 @@ func formatInto(sb *strings.Builder, format string, args []string) (int, error) 
 						return 0, err
 					}
 				} else if c != 's' {
-					n, _ := strconv.ParseInt(arg, 0, 0)
+					n := formatNum(arg)
 					if c == 'i' || c == 'd' {
 						farg = int(n)
 					} else {
@@ -410,6 +410,20 @@ func formatInto(sb *strings.Builder, format string, args []string) (int, error) 
 		return 0, fmt.Errorf("missing format char")
 	}
 	return initialArgs - len(args), nil
+}
+
+// formatNum parses a printf numeric argument. Following POSIX, if the argument
+// begins with a single- or double-quote character, its value is the numeric
+// value of the character right after the quote, rather than a parsed number.
+// For example, `printf %d "'A"` prints 65. Any characters beyond the first are
+// ignored, as in other shells.
+func formatNum(arg string) int64 {
+	if len(arg) > 1 && (arg[0] == '\'' || arg[0] == '"') {
+		r, _ := utf8.DecodeRuneInString(arg[1:])
+		return int64(r)
+	}
+	n, _ := strconv.ParseInt(arg, 0, 0)
+	return n
 }
 
 func (cfg *Config) fieldJoin(parts []fieldPart) string {

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -313,6 +313,12 @@ var runTests = []runTest{
 	{"printf %d,%i 3 4", "3,4"},
 	{"printf %d", "0"},
 	{"printf %d,%d 010 0x10", "8,16"},
+	{`printf %d "'A"`, "65"},
+	{`printf %d '"A'`, "65"},
+	{`printf %d "'0"`, "48"},
+	{`printf %d "'AB"`, "65"},
+	{`printf %x,%o "'A" "'A"`, "41,101"},
+	{`printf %d "'"`, "0"},
 	{"printf %c,%c,%c foo àa", "f,\xc3,\x00"}, // TODO: use a rune?
 	{"printf %3s a", "  a"},
 	{"printf %3i 1", "  1"},


### PR DESCRIPTION
POSIX printf takes a numeric argument beginning with a single or double
quote as the value of the character right after the quote, so
`printf %d "'A"` prints 65. We passed the argument straight to
strconv.ParseInt, so any such argument became 0.

formatNum now handles the quote prefix for the numeric verbs (d, i, u, o,
x), taking the value of the first rune after the quote and ignoring the
rest:

    $ printf '%d %x %o\n' "'A" "'A" "'A"
    65 41 101

That matches bash, dash, and ksh for ASCII. I decode a rune rather than a
byte, matching the "// TODO: use a rune?" note by the %c test; the two
only differ for multi-byte input, where those shells disagree with each
other anyway.

Added interp printf cases for both quote forms, '0 (48, not 0), a
trailing character after the first, and a lone quote (still 0).