### PR TITLE
syntax: recover missing ] in $[...] arithmetic expansion

### DIFF
--- a/syntax/parser.go
+++ b/syntax/parser.go
@@ -1238,11 +1238,17 @@ func (p *Parser) wordPart() WordPart {
 		ar.X = p.followArithm(left, ar.Left)
 		if ar.Bracket {
 			if p.tok != rightBrack {
-				p.arithmMatchingErr(ar.Left, dollBrack, rightBrack)
+				if p.recoverError() {
+					ar.Right = recoveredPos
+				} else {
+					p.arithmMatchingErr(ar.Left, dollBrack, rightBrack)
+				}
 			}
-			p.postNested(old)
-			ar.Right = p.pos
-			p.next()
+			if !ar.Right.IsRecovered() {
+				p.postNested(old)
+				ar.Right = p.pos
+				p.next()
+			}
 		} else {
 			ar.Right = p.arithmEnd(dollDblParen, ar.Left, old)
 		}

--- a/syntax/parser_test.go
+++ b/syntax/parser_test.go
@@ -2684,6 +2684,10 @@ func TestParseRecoverErrors(t *testing.T) {
 			wantMissing: 1,
 		},
 		{
+			src:         "$[incomp",
+			wantMissing: 1,
+		},
+		{
 			src:         "if foo",
 			wantMissing: 3,
 		},


### PR DESCRIPTION
Fixes #1375

## Summary

`RecoverErrors` recovers a missing closing `))` for `$((...))` arithmetic expansions, but not a missing `]` for the deprecated `$[...]` form. As a result `echo $[1+2` fails to parse even with `RecoverErrors`, while `echo $((1+2` recovers fine.

## Root cause

Both forms are parsed in `wordPart()` (`syntax/parser.go`):

- `$((...))` reaches `recoverError()` through `arithmEnd`, which returns `recoveredPos` when the closing `))` is missing and the recovery budget allows it.
- `$[...]` reported the error directly via `arithmMatchingErr` when `]` was absent, bypassing the recovery machinery entirely.

## Fix

Route the `$[...]` branch through `recoverError()` too, mirroring `arithmEnd`:

- When `]` is missing and `recoverError()` succeeds, mark `ArithmExp.Right` as recovered (`recoveredPos`) and skip the closing-token consumption.
- Otherwise fall through to the existing `arithmMatchingErr` path, unchanged.

## Test

Added a `$[incomp` case to `TestParseRecoverErrors` (`wantMissing: 1`), mirroring the existing `$((incomp` case.

## Verification

- `go test ./syntax/...` passes
- `go test ./...` passes (the only failing test, `TestRunnerRun/#1246`, also fails on `master` in this environment — it is unrelated to this change)
- `gofmt -s -d .` and `git diff --check` clean
- `go vet ./syntax/` clean

Note: `go test -race` cannot run in this container (`ThreadSanitizer: unsupported VMA range`), also unrelated to this change.