### PR TITLE
syntax: preserve trailing backslashes at EOF

### DIFF
--- a/syntax/filetests_test.go
+++ b/syntax/filetests_test.go
@@ -123,6 +123,7 @@ func fullProg(v any) *File {
 
 type fileTestCase struct {
 	inputs []string // input sources; the first is the canonical formatting
+	print  string   // optional canonical formatting when it differs from inputs[0]
 
 	// Each language in [langResolvedVariants] has an entry:
 	// - nil:    nothing to test
@@ -132,6 +133,10 @@ type fileTestCase struct {
 
 	// The real shells where testing the input succeeds or fails in the opposite way.
 	flipConfirmSet LangVariant
+}
+
+func printAs(want string) func(*fileTestCase) {
+	return func(c *fileTestCase) { c.print = want }
 }
 
 func flipConfirm2(langSet LangVariant) func(*fileTestCase) {
@@ -193,10 +198,12 @@ var fileTests = []fileTestCase{
 	fileTest(
 		[]string{`\`},
 		langFile(litWord(`\`)),
+		printAs("\\\\"),
 	),
 	fileTest(
 		[]string{`foo\`, "f\\\noo\\"},
 		langFile(litWord(`foo\`)),
+		printAs("foo\\\\"),
 	),
 	fileTest(
 		[]string{`foo\a`, "f\\\noo\\a"},

--- a/syntax/printer.go
+++ b/syntax/printer.go
@@ -62,6 +62,7 @@ func SpaceRedirects(enabled bool) PrinterOption {
 // See: https://github.com/mvdan/sh/issues/658
 func KeepPadding(enabled bool) PrinterOption {
 	return func(p *Printer) {
+		p.stopTracking()
 		if enabled && !p.keepPadding {
 			// Enable the flag, and set up the writer wrapper.
 			p.keepPadding = true
@@ -142,7 +143,7 @@ func (p *Printer) Print(w io.Writer, node Node) error {
 	switch node := node.(type) {
 	case *File:
 		p.stmtList(node.Stmts, node.Last)
-		p.newline(Pos{})
+		p.finalNewline()
 	case *Stmt:
 		p.stmtList([]*Stmt{node}, nil)
 	case Command:
@@ -180,6 +181,49 @@ type bufWriter interface {
 	WriteByte(byte) error
 	Reset(io.Writer)
 	Flush() error
+}
+
+// trackingWriter is only installed after an unquoted literal ends in an
+// unpaired backslash.
+type trackingWriter struct {
+	bufWriter
+	pending bool
+}
+
+func (w *trackingWriter) wroteVisibleBytes(bs []byte) {
+	for _, b := range bs {
+		if b != tabwriter.Escape {
+			w.pending = false
+			return
+		}
+	}
+}
+
+func (w *trackingWriter) Write(bs []byte) (int, error) {
+	n, err := w.bufWriter.Write(bs)
+	w.wroteVisibleBytes(bs[:n])
+	return n, err
+}
+
+func (w *trackingWriter) WriteString(s string) (int, error) {
+	n, err := w.bufWriter.WriteString(s)
+	for i := 0; i < n; i++ {
+		if s[i] != tabwriter.Escape {
+			w.pending = false
+			break
+		}
+	}
+	return n, err
+}
+
+func (w *trackingWriter) WriteByte(b byte) error {
+	if err := w.bufWriter.WriteByte(b); err != nil {
+		return err
+	}
+	if b != tabwriter.Escape {
+		w.pending = false
+	}
+	return nil
 }
 
 type colCounter struct {
@@ -269,7 +313,25 @@ type Printer struct {
 	tabsPrinter *Printer
 }
 
+func (p *Printer) startTracking() {
+	if tracker, ok := p.w.(*trackingWriter); ok {
+		tracker.pending = true
+		return
+	}
+	p.w = &trackingWriter{
+		bufWriter: p.w,
+		pending:   true,
+	}
+}
+
+func (p *Printer) stopTracking() {
+	if tracker, ok := p.w.(*trackingWriter); ok {
+		p.w = tracker.bufWriter
+	}
+}
+
 func (p *Printer) reset() {
+	p.stopTracking()
 	p.wantSpace = spaceWritten
 	p.wantNewline, p.mustNewline = false, false
 	p.pendingComments = p.pendingComments[:0]
@@ -433,6 +495,19 @@ func (p *Printer) newline(pos Pos) {
 	p.wantSpace = spaceWritten
 	p.wantNewline, p.mustNewline = false, false
 	p.advanceLine(pos.Line())
+}
+
+func (p *Printer) finalNewline() {
+	p.flushHeredocs()
+	p.flushComments()
+	// An unpaired backslash at EOF is literal, but before a newline it would
+	// escape that newline. Pair it to preserve the literal value.
+	if tracker, ok := p.w.(*trackingWriter); ok && tracker.pending {
+		p.w.WriteByte('\\')
+	}
+	p.w.WriteByte('\n')
+	p.wantSpace = spaceWritten
+	p.wantNewline, p.mustNewline = false, false
 }
 
 func (p *Printer) advanceLine(line uint) {
@@ -655,7 +730,25 @@ func (p *Printer) wordParts(wps []WordPart, quoted bool) {
 func (p *Printer) wordPart(wp, next WordPart) {
 	switch wp := wp.(type) {
 	case *Lit:
+		tracker, _ := p.w.(*trackingWriter)
+		wasTracking := tracker != nil && tracker.pending
 		p.writeLit(wp.Value)
+		if wp.Value == "" || wp.Value[len(wp.Value)-1] != '\\' {
+			break
+		}
+		trailing := 1
+		for i := len(wp.Value) - 2; i >= 0 && wp.Value[i] == '\\'; i-- {
+			trailing++
+		}
+		needsTracking := trailing%2 == 1
+		if wasTracking && trailing == len(wp.Value) {
+			needsTracking = trailing%2 == 0
+		}
+		if needsTracking {
+			p.startTracking()
+		} else if tracker != nil {
+			tracker.pending = false
+		}
 	case *SglQuoted:
 		if wp.Dollar {
 			p.w.WriteByte('$')

--- a/syntax/printer_regression_test.go
+++ b/syntax/printer_regression_test.go
@@ -1,0 +1,123 @@
+// Copyright (c) 2026, Daniel Martí <mvdan@mvdan.cc>
+// See LICENSE for licensing information
+
+package syntax_test
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"mvdan.cc/sh/v3/expand"
+	"mvdan.cc/sh/v3/syntax"
+)
+
+func TestPrintTrailingBackslashes(t *testing.T) {
+	t.Parallel()
+	langs := [...]syntax.LangVariant{
+		syntax.LangBash,
+		syntax.LangPOSIX,
+		syntax.LangMirBSDKorn,
+		syntax.LangBats,
+		syntax.LangZsh,
+	}
+	for _, lang := range langs {
+		t.Run(lang.String(), func(t *testing.T) {
+			t.Parallel()
+			for slashCount := 1; slashCount <= 4; slashCount++ {
+				for _, quoted := range []bool{false, true} {
+					for _, finalNewline := range []bool{false, true} {
+						name := fmt.Sprintf("slashes=%d/quoted=%t/newline=%t", slashCount, quoted, finalNewline)
+						t.Run(name, func(t *testing.T) {
+							slashes := strings.Repeat("\\", slashCount)
+							word := "foo" + slashes
+							if quoted {
+								word = "'" + word + "'"
+							}
+							in := "echo " + word
+							if finalNewline {
+								in += "\n"
+							}
+
+							wantSlashCount := slashCount
+							wantNewlineCount := 1
+							if !quoted && slashCount%2 == 1 {
+								if finalNewline {
+									switch slashCount {
+									case 1:
+										wantSlashCount = 0
+									case 3:
+										wantNewlineCount = 2
+									}
+								} else {
+									wantSlashCount++
+								}
+							}
+							wantWord := "foo" + strings.Repeat("\\", wantSlashCount)
+							if quoted {
+								wantWord = "'" + wantWord + "'"
+							}
+							want := "echo " + wantWord + strings.Repeat("\n", wantNewlineCount)
+
+							parser := syntax.NewParser(syntax.Variant(lang))
+							prog := parseProgram(t, parser, in)
+							wantValue := commandArgValue(t, prog)
+							once := printProgram(t, prog)
+							if once != want {
+								t.Fatalf("first format mismatch:\nwant: %q\ngot:  %q", want, once)
+							}
+
+							progAgain := parseProgram(t, parser, once)
+							gotValue := commandArgValue(t, progAgain)
+							if gotValue != wantValue {
+								t.Fatalf("argument changed after formatting: want %q, got %q", wantValue, gotValue)
+							}
+							twice := printProgram(t, progAgain)
+							if twice != once {
+								t.Fatalf("second format changed output:\nonce:  %q\ntwice: %q", once, twice)
+							}
+						})
+					}
+				}
+			}
+		})
+	}
+}
+
+func parseProgram(t *testing.T, parser *syntax.Parser, src string) *syntax.File {
+	t.Helper()
+	prog, err := parser.Parse(strings.NewReader(src), "")
+	if err != nil {
+		t.Fatalf("parse %q: %v", src, err)
+	}
+	return prog
+}
+
+func printProgram(t *testing.T, prog *syntax.File) string {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := syntax.NewPrinter().Print(&buf, prog); err != nil {
+		t.Fatal(err)
+	}
+	return buf.String()
+}
+
+func commandArgValue(t *testing.T, prog *syntax.File) string {
+	t.Helper()
+	if len(prog.Stmts) != 1 {
+		t.Fatalf("got %d statements, want one", len(prog.Stmts))
+	}
+	call, ok := prog.Stmts[0].Cmd.(*syntax.CallExpr)
+	if !ok || len(call.Args) != 2 {
+		t.Fatalf("got command %#v, want a call with two arguments", prog.Stmts[0].Cmd)
+	}
+	fields, err := expand.Fields(&expand.Config{}, call.Args[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fields) != 1 {
+		t.Fatalf("expanded to %d fields, want one", len(fields))
+	}
+	return fields[0]
+}

--- a/syntax/printer_test.go
+++ b/syntax/printer_test.go
@@ -31,7 +31,11 @@ func TestPrintFiles(t *testing.T) {
 				}
 				t.Run("", func(t *testing.T) {
 					in := c.inputs[0]
-					printTest(t, parser, printer, in, in)
+					want := c.print
+					if want == "" {
+						want = in
+					}
+					printTest(t, parser, printer, in, want)
 				})
 			}
 		})
@@ -79,6 +83,7 @@ var printTests = []printCase{
 	{"\n\nfoo", "foo"},
 	{"# foo \n # bar\t", "# foo\n# bar"},
 	samePrint("#"),
+	samePrint("# trailing \\"),
 	samePrint("#c1\\\n#c2"),
 	samePrint("#\\\n#"),
 	{"#\\\r\n#", "#\\\n#"},
@@ -1257,7 +1262,6 @@ func printTest(t *testing.T, parser *Parser, printer *Printer, in, want string) 
 	if err != nil {
 		t.Fatalf("parsing got an error: %s:\n%s", err, in)
 	}
-	origWant := want
 	want += "\n"
 	got, err := strPrint(printer, prog)
 	if err != nil {
@@ -1267,11 +1271,8 @@ func printTest(t *testing.T, parser *Parser, printer *Printer, in, want string) 
 		t.Fatalf("Print mismatch:\nwant:\n%q\ngot:\n%q", want, got)
 	}
 
-	// With the original "want" output string,
-	// make sure that it's idempotent when formatted again.
-	// Note that we don't want the added newline,
-	// as that can change the meaning of trailing backslashes.
-	progAgain, err := parser.Parse(strings.NewReader(origWant), "")
+	// Make sure that the exact output is idempotent when formatted again.
+	progAgain, err := parser.Parse(strings.NewReader(want), "")
 	if err != nil {
 		t.Fatalf("Result is not valid shell:\n%s", want)
 	}


### PR DESCRIPTION
Fixes #1354.

An odd run of unquoted backslashes at EOF is literal, but the printer's final newline turned its last backslash into a line continuation. Pair the final backslash before writing that newline so formatting preserves the argument value and reaches a fixed point.

Tests cover all five parser variants with 1–4 trailing backslashes, quoted and unquoted, with and without a source newline (80 matrix cases). I also ran the full test suite with the race detector, 386 tests, and the CI cross-builds for plan9/amd64 and js/wasm.

Developed with AI assistance and independently reviewed; all changes and test results were manually verified.
