### PR TITLE
interp: implement the job control builtins (jobs, kill, disown, fg, bg)

### DIFF
--- a/interp/api.go
+++ b/interp/api.go
@@ -302,6 +302,36 @@ type bgProc struct {
 	// the process ID when the background statement started exactly one
 	// external program, and zero otherwise.
 	started chan int
+
+	// cmd is the source text of the backgrounded statement, as the jobs
+	// builtin prints it.
+	cmd string
+
+	// substitution marks the shells behind process substitutions, which bash
+	// does not list as jobs either. They have no job number, cannot be named
+	// by a job spec, and a bare wait does not wait for them.
+	//
+	// A separate field rather than testing cmd == "": an empty command string
+	// is a plausible thing to have for other reasons, and every place that
+	// asked "is this a real job" was really asking this.
+	substitution bool
+
+	// cancel stops the background shell. A job here is a goroutine rather
+	// than an operating system process, so the kill builtin cancels its
+	// context instead of sending a signal.
+	cancel context.CancelFunc
+
+	// signal is the name of the signal kill delivered, so that jobs can
+	// report Terminated rather than Done.
+	signal string
+
+	// disowned jobs are hidden from jobs and are not waited for by a bare
+	// wait, as after bash's disown.
+	disowned bool
+
+	// notified records that this job's completion has already been reported
+	// by `jobs -n`.
+	notified bool
 }
 
 // newBgProc returns a background job with the next fake PID.

--- a/interp/builtin.go
+++ b/interp/builtin.go
@@ -162,6 +162,16 @@ func (r *Runner) builtin(ctx context.Context, pos syntax.Pos, name string, args 
 		exit.code = 1
 	case "help":
 		return r.runHelp(args)
+	case "jobs":
+		return r.runJobs(args)
+	case "kill":
+		return r.runKill(args)
+	case "disown":
+		return r.runDisown(args)
+	case "fg":
+		return r.runFg(ctx, args)
+	case "bg":
+		return r.runBg(args)
 	case "times":
 		// js/wasm has no per-process CPU accounting at all, so report zeros
 		// in bash's format — shell user/sys, then children user/sys — rather
@@ -349,6 +359,9 @@ func (r *Runner) builtin(ctx context.Context, pos syntax.Pos, name string, args 
 		if len(args) == 0 {
 			// Note that "wait" without arguments always returns exit status zero.
 			for _, bg := range r.bgProcs {
+				if bg.disowned {
+					continue
+				}
 				<-bg.done
 			}
 			break

--- a/interp/handler.go
+++ b/interp/handler.go
@@ -108,6 +108,12 @@ type HandlerContext struct {
 // Shell builtins touch on many internals of the Runner, after all.
 //
 // Returning a non-nil error will halt the [Runner] and will be returned via the API.
+//
+// Note that this is the only handler which sees the kill builtin. Given a PID
+// that is not one of the runner's own jobs, kill signals that process on the
+// host directly, without going through [ExecHandlerFunc] as `/bin/kill` once
+// would have. An embedder sandboxing what a script may do to the machine has
+// to intercept it here.
 type CallHandlerFunc func(ctx context.Context, args []string) ([]string, error)
 
 // TODO(v4): consistently treat handler errors as non-fatal by default,

--- a/interp/help.go
+++ b/interp/help.go
@@ -25,6 +25,17 @@ type builtinHelp struct {
 	desc     string
 }
 
+// helpNotes says how a builtin differs from bash's, for the ones that cannot
+// mean quite the same thing without processes or a controlling terminal.
+// `help NAME` prints the note after the description.
+var helpNotes = map[string]string{
+	"bg":    "background jobs already run in the background here, so this reports on the job rather than resuming it",
+	"fg":    "there is no controlling terminal here, so this waits for the job and returns its exit status",
+	"jobs":  "nothing is ever stopped without a controlling terminal, so -s lists nothing",
+	"kill":  "a job is a goroutine, not a process: terminating signals cancel it, and stop/continue are rejected; a PID that is not a job is signalled like any process",
+	"times": "there is no per-process CPU accounting on every target this shell runs on, so the times are zero",
+}
+
 // helpTable is keyed by builtin name. Synopses follow bash 5's wording so the
 // output is familiar; descriptions are ours, and say where this shell differs.
 var helpTable = map[string]builtinHelp{
@@ -102,10 +113,9 @@ var helpTable = map[string]builtinHelp{
 // helpUnsupported are recognized by this shell but not implemented; `help`
 // stars them the way bash stars disabled builtins.
 var helpUnsupported = map[string]bool{
-	"bg": true, "bind": true, "caller": true, "compgen": true, "complete": true,
-	"compopt": true, "disown": true, "enable": true, "fc": true, "fg": true,
-	"history": true, "jobs": true, "kill": true, "logout": true, "newgrp": true,
-	"suspend": true, "ulimit": true,
+	"bind": true, "caller": true, "compgen": true, "complete": true,
+	"compopt": true, "enable": true, "fc": true, "history": true,
+	"logout": true, "newgrp": true, "suspend": true, "ulimit": true,
 }
 
 // helpMatch returns the documented names matching a bash-style pattern. An
@@ -205,6 +215,8 @@ patterns:
 				r.outf("    %s\n", h.desc)
 				if helpUnsupported[name] {
 					r.out("    (recognized by this shell but not implemented)\n")
+				} else if note := helpNotes[name]; note != "" {
+					r.outf("    (%s)\n", note)
 				}
 				r.out("\n")
 			}

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -241,8 +241,25 @@ var runTests = []runTest{
 	{"help -q", "help: -q: invalid option\nhelp: usage: help [-dms] [pattern ...]\nexit status 2 #IGNORE bash prefixes its errors with `bash: line N:'"},
 	// a builtin we recognize but do not implement is starred, so that help is
 	// an honest statement of what this shell can do
-	{"help -s jobs", "jobs: jobs [-lnprs] [jobspec ...]\n #IGNORE bash implements jobs, and its synopsis differs"},
-	{"help jobs", "jobs: jobs [-lnprs] [jobspec ...]\n    Display status of jobs.\n    (recognized by this shell but not implemented)\n\n #IGNORE bash implements jobs"},
+	{"help -s jobs", "jobs: jobs [-lnprs] [jobspec ...]\n #IGNORE bash's synopsis differs"},
+	{"help -s ulimit", "ulimit: ulimit [-SHabcdefiklmnpqrstuvxPRT] [limit]\n #IGNORE bash implements ulimit"},
+
+	// job control builtins; the cases needing a job that is still running are
+	// in jobs_test.go, since here the exec middleware backgrounds goroutines
+	// that cancellation cannot interrupt
+	{"jobs", ""},
+	{"kill -l 9", "KILL\n"},
+	{"kill -l TERM", "15\n"},
+	{"kill -l NOPE", "kill: NOPE: invalid signal specification\nexit status 1 #IGNORE bash prefixes its errors with `bash: line N:'"},
+	{"kill", "kill: usage: kill [-s sigspec | -n signum] pid | jobspec ...\nexit status 2 #IGNORE bash prefixes its errors with `bash: line N:'"},
+	{"kill %9", "kill: %9: no such job\nexit status 1 #IGNORE bash prefixes its errors with `bash: line N:'"},
+	{"jobs -Z", "jobs: -Z: invalid option\njobs: usage: jobs [-lnprs] [jobspec ...]\nexit status 2 #IGNORE bash prefixes its errors with `bash: line N:'"},
+	{"sleep 0 & wait; jobs", "[1]+  Done                    sleep 0\n #IGNORE bash formats the job listing differently"},
+	{"(exit 3) & wait; jobs", "[1]+  Exit 3                  (exit 3)\n #IGNORE bash formats the job listing differently"},
+	{"true & kill -0 $!; echo st=$?", "st=0\n #IGNORE bash uses real PIDs"},
+	{"sleep 0 & disown; jobs", " #IGNORE bash also lists nothing after disown"},
+	{"(exit 4) & fg; echo st=$?", "(exit 4)\nst=4\n #IGNORE bash prints the job text differently"},
+	{"sleep 0 & wait; bg", "bg: job 1 has terminated\nexit status 1 #IGNORE bash phrases the error differently"},
 
 	// times
 	{"times", "0m0.000s 0m0.000s\n0m0.000s 0m0.000s\n #IGNORE we report zeros; bash reports real CPU time"},

--- a/interp/jobs.go
+++ b/interp/jobs.go
@@ -1,0 +1,538 @@
+// Copyright (c) 2017, Daniel Martí <mvdan@mvdan.cc>
+// See LICENSE for licensing information
+
+package interp
+
+// Job control: the jobs, kill, disown, fg and bg builtins.
+//
+// A background job in this interpreter is a goroutine running a subshell, not
+// an operating system process, which shapes what these builtins can honestly
+// do. Jobs can be listed, waited for and cancelled — kill terminates a job by
+// cancelling its context, which is what every fatal signal would have amounted
+// to here. There is no controlling terminal and no process group, so nothing
+// is ever *stopped*: fg waits for a job rather than handing it the terminal,
+// bg reports on a job that is already running, and SIGSTOP/SIGCONT are
+// rejected rather than faked.
+//
+// This is also what lets the builtins work on js/wasm, where there are no
+// processes and no signals to send.
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+
+	"mvdan.cc/sh/v3/syntax"
+)
+
+// jobText renders a backgrounded statement the way jobs prints it.
+func jobText(st *syntax.Stmt) string {
+	var b strings.Builder
+	printer := syntax.NewPrinter(syntax.SingleLine(true))
+	if err := printer.Print(&b, st); err != nil {
+		return "<job>"
+	}
+	return b.String()
+}
+
+// running reports whether a job has not finished yet.
+func (bg bgProc) running() bool {
+	select {
+	case <-bg.done:
+		return false
+	default:
+		return true
+	}
+}
+
+// status is the second column of the jobs listing, following bash: Done for a
+// job that succeeded, "Exit N" for one that failed, Terminated for one kill
+// cancelled.
+func (bg bgProc) status() string {
+	if bg.running() {
+		return "Running"
+	}
+	if bg.signal != "" {
+		return "Terminated"
+	}
+	if bg.exit.code != 0 {
+		return fmt.Sprintf("Exit %d", bg.exit.code)
+	}
+	return "Done"
+}
+
+// jobIndexes returns the indexes of the jobs the builtins act on, oldest
+// first. Disowned jobs and the shells behind process substitutions are not
+// jobs as far as the user is concerned, so they are left out.
+func (r *Runner) jobIndexes() []int {
+	var out []int
+	for i, bg := range r.bgProcs {
+		if bg.disowned || bg.substitution {
+			continue
+		}
+		out = append(out, i)
+	}
+	return out
+}
+
+// currentJob and previousJob are bash's %+ and %-. bash tracks these as the
+// two most recently *stopped* jobs, falling back to the most recent running
+// ones; with nothing ever stopped here, the two most recent jobs are all that
+// distinction can mean.
+func (r *Runner) currentJob() int {
+	live := r.jobIndexes()
+	if len(live) == 0 {
+		return -1
+	}
+	return live[len(live)-1]
+}
+
+func (r *Runner) previousJob() int {
+	live := r.jobIndexes()
+	if len(live) < 2 {
+		return r.currentJob()
+	}
+	return live[len(live)-2]
+}
+
+// jobMark is the +/- column bash prints after the job number.
+func (r *Runner) jobMark(i int) string {
+	switch i {
+	case r.currentJob():
+		return "+"
+	case r.previousJob():
+		return "-"
+	}
+	return " "
+}
+
+// jobSpec resolves a job specification to an index into bgProcs. It accepts
+// bash's % forms — %1, %+, %%, %-, %string and %?string — as well as what $!
+// expands to: the real PID when the background statement started exactly one
+// external program, and a "gN" fake PID otherwise. A spec without a leading %
+// is a PID, never a job number, matching bash.
+func (r *Runner) jobSpec(spec string) (int, error) {
+	if spec == "" {
+		return -1, fmt.Errorf("no such job")
+	}
+	byNumber := func(n int) (int, error) {
+		if n <= 0 || n > len(r.bgProcs) {
+			return -1, fmt.Errorf("no such job")
+		}
+		if bg := r.bgProcs[n-1]; bg.substitution || bg.disowned {
+			return -1, fmt.Errorf("no such job")
+		}
+		return n - 1, nil
+	}
+	rest, ok := strings.CutPrefix(spec, "%")
+	if !ok {
+		// Not a % form, so a PID: find the job by what $! reported, like
+		// [Runner.lookupBgProc]. A PID names the job directly, so a disowned
+		// job is still found — bash's kill also still reaches a disowned
+		// job's process by PID.
+		for i := range slices.Backward(r.bgProcs) {
+			if !r.bgProcs[i].substitution && r.bgProcID(i) == spec {
+				return i, nil
+			}
+		}
+		return -1, fmt.Errorf("no such job")
+	}
+	switch rest {
+	case "%", "+":
+		if i := r.currentJob(); i >= 0 {
+			return i, nil
+		}
+		return -1, fmt.Errorf("no such job")
+	case "-":
+		if i := r.previousJob(); i >= 0 {
+			return i, nil
+		}
+		return -1, fmt.Errorf("no such job")
+	}
+	if n, err := strconv.Atoi(rest); err == nil {
+		return byNumber(n)
+	}
+	// %?string matches anywhere in the command, %string only at its start.
+	substring := false
+	if s, ok := strings.CutPrefix(rest, "?"); ok {
+		substring, rest = true, s
+	}
+	match := -1
+	for _, i := range r.jobIndexes() {
+		cmd := r.bgProcs[i].cmd
+		if (substring && strings.Contains(cmd, rest)) || (!substring && strings.HasPrefix(cmd, rest)) {
+			if match >= 0 {
+				return -1, fmt.Errorf("ambiguous job spec")
+			}
+			match = i
+		}
+	}
+	if match < 0 {
+		return -1, fmt.Errorf("no such job")
+	}
+	return match, nil
+}
+
+// runJobs implements the jobs builtin.
+func (r *Runner) runJobs(args []string) exitStatus {
+	var long, pidsOnly, newOnly, runningOnly, stoppedOnly bool
+	rest := args
+	for len(rest) > 0 && strings.HasPrefix(rest[0], "-") && len(rest[0]) > 1 {
+		flag := rest[0]
+		if flag == "--" {
+			rest = rest[1:]
+			break
+		}
+		for _, c := range flag[1:] {
+			switch c {
+			case 'l':
+				long = true
+			case 'p':
+				pidsOnly = true
+			case 'n':
+				newOnly = true
+			case 'r':
+				runningOnly = true
+			case 's':
+				stoppedOnly = true
+			default:
+				r.errf("jobs: -%c: invalid option\n", c)
+				r.errf("jobs: usage: %s\n", helpTable["jobs"].synopsis)
+				return exitStatus{code: 2}
+			}
+		}
+		rest = rest[1:]
+	}
+
+	indexes := r.jobIndexes()
+	if len(rest) > 0 {
+		indexes = nil
+		for _, spec := range rest {
+			i, err := r.jobSpec(spec)
+			if err != nil {
+				r.errf("jobs: %s: %v\n", spec, err)
+				return exitStatus{code: 1}
+			}
+			indexes = append(indexes, i)
+		}
+	}
+
+	for _, i := range indexes {
+		bg := r.bgProcs[i]
+		// Nothing is ever stopped without a controlling terminal.
+		if stoppedOnly || (runningOnly && !bg.running()) {
+			continue
+		}
+		if newOnly {
+			if bg.running() || bg.notified {
+				continue
+			}
+			r.bgProcs[i].notified = true
+		}
+		if pidsOnly {
+			r.outf("%s\n", r.bgProcID(i))
+			continue
+		}
+		prefix := fmt.Sprintf("[%d]%s  ", i+1, r.jobMark(i))
+		if long {
+			prefix = fmt.Sprintf("[%d]%s %-6s", i+1, r.jobMark(i), r.bgProcID(i))
+		}
+		r.outf("%s%-24s%s\n", prefix, bg.status(), bg.cmd)
+	}
+	return exitStatus{}
+}
+
+// signalByName resolves "TERM", "SIGTERM" or "15" to a number and canonical
+// name.
+//
+// Both directions go through the platform on unix — see signalName in
+// os_unix.go for why a table compiled into the shell is wrong there.
+func signalByName(spec string) (int, string, bool) {
+	if n, err := strconv.Atoi(spec); err == nil {
+		if n == 0 {
+			return 0, "", true
+		}
+		if name := signalName(n); name != "" {
+			return n, name, true
+		}
+		return 0, "", false
+	}
+	name := strings.TrimPrefix(strings.ToUpper(spec), "SIG")
+	if n := signalNum(name); n > 0 {
+		return n, name, true
+	}
+	return 0, "", false
+}
+
+// signalEffect says what a signal does to a job here. Since a job is a
+// goroutine, anything whose default action would end a process cancels it, and
+// job control signals have no meaning without a terminal.
+type signalEffect int
+
+const (
+	signalTerminates  signalEffect = iota
+	signalTests                    // signal 0: only check that the job exists
+	signalUnsupported              // stop and continue, which need job control
+)
+
+// effectOf classifies a signal by NAME and not by number.
+//
+// It used to switch on 17 through 22, which are CHLD through TTOU on Linux and
+// something else everywhere else: on darwin 17 is STOP and 20 is CHLD, so the
+// set was both wrong and differently wrong per platform. The names are the
+// portable thing, so the number is resolved first and the answer keyed on that.
+func effectOf(num int) signalEffect {
+	if num == 0 {
+		return signalTests
+	}
+	switch signalName(num) {
+	case "CHLD", "CONT", "STOP", "TSTP", "TTIN", "TTOU":
+		return signalUnsupported
+	}
+	return signalTerminates
+}
+
+// runKill implements the kill builtin.
+func (r *Runner) runKill(args []string) exitStatus {
+	signum, signame := 15, "TERM"
+	rest := args
+	for len(rest) > 0 {
+		arg := rest[0]
+		if arg == "--" {
+			rest = rest[1:]
+			break
+		}
+		if len(arg) < 2 || arg[0] != '-' {
+			break
+		}
+		switch {
+		case arg == "-l" || arg == "-L":
+			return r.killList(rest[1:])
+		case arg == "-s" || arg == "-n":
+			if len(rest) < 2 {
+				r.errf("kill: %s: option requires an argument\n", arg)
+				return exitStatus{code: 2}
+			}
+			num, name, ok := signalByName(rest[1])
+			if !ok {
+				r.errf("kill: %s: invalid signal specification\n", rest[1])
+				return exitStatus{code: 1}
+			}
+			signum, signame = num, name
+			rest = rest[2:]
+			continue
+		default:
+			num, name, ok := signalByName(arg[1:])
+			if !ok {
+				r.errf("kill: %s: invalid signal specification\n", arg[1:])
+				return exitStatus{code: 1}
+			}
+			signum, signame = num, name
+		}
+		rest = rest[1:]
+	}
+
+	if len(rest) == 0 {
+		r.errf("kill: usage: %s\n", helpTable["kill"].synopsis)
+		return exitStatus{code: 2}
+	}
+
+	exit := exitStatus{}
+	for _, spec := range rest {
+		i, err := r.jobSpec(spec)
+		if err != nil {
+			// A PID that is not one of our jobs still names a process, and
+			// before kill was a builtin these reached the system's kill
+			// program, so signal the process where the platform lets us.
+			if pid, aerr := strconv.Atoi(spec); aerr == nil {
+				if kerr := killProcess(pid, signum); kerr != nil {
+					r.errf("kill: (%d) - %v\n", pid, kerr)
+					exit.code = 1
+				}
+				continue
+			}
+			r.errf("kill: %s: %v\n", spec, err)
+			exit.code = 1
+			continue
+		}
+		switch effectOf(signum) {
+		case signalTests:
+			// Existence already confirmed by resolving the spec.
+			//
+			// Not "is it still running": bash accepts kill -0 on a job that
+			// has finished but has not been reaped, and only reports "no such
+			// job" once wait or jobs has reported it and dropped it from the
+			// table. Testing running() here instead made `true & kill -0 $!`
+			// a race on whether the job had finished yet.
+		case signalUnsupported:
+			// Only for a job. A bare PID naming a real process took the
+			// killProcess path above and really was stopped or continued —
+			// the asymmetry is deliberate: a job here is a goroutine with no
+			// terminal behind it, so there is nothing to stop.
+			r.errf("kill: %s: no job control\n", spec)
+			exit.code = 1
+		default:
+			if r.bgProcs[i].running() {
+				r.bgProcs[i].signal = signame
+				r.bgProcs[i].cancel()
+			}
+		}
+	}
+	return exit
+}
+
+// killList implements `kill -l`, which either names one signal or lists them
+// all in bash's five-per-row layout.
+func (r *Runner) killList(args []string) exitStatus {
+	if len(args) > 0 {
+		exit := exitStatus{}
+		for _, arg := range args {
+			num, name, ok := signalByName(arg)
+			if !ok || num == 0 {
+				r.errf("kill: %s: invalid signal specification\n", arg)
+				exit.code = 1
+				continue
+			}
+			// `kill -l NUMBER` names the signal, `kill -l NAME` numbers it.
+			if _, err := strconv.Atoi(arg); err == nil {
+				r.outf("%s\n", name)
+			} else {
+				r.outf("%d\n", num)
+			}
+		}
+		return exit
+	}
+	// Walked rather than ranged over a table, so the list is the platform's
+	// own: darwin stops at 31, Linux carries realtime signals past it.
+	col := 0
+	for num := 1; num <= maxSignal; num++ {
+		name := signalName(num)
+		if name == "" {
+			continue
+		}
+		r.outf("%2d) SIG%-9s", num, name)
+		if col++; col%5 == 0 {
+			r.out("\n")
+		}
+	}
+	if col%5 != 0 {
+		r.out("\n")
+	}
+	return exitStatus{}
+}
+
+// runDisown implements the disown builtin.
+func (r *Runner) runDisown(args []string) exitStatus {
+	var all, runningOnly bool
+	rest := args
+	for len(rest) > 0 && strings.HasPrefix(rest[0], "-") && len(rest[0]) > 1 {
+		flag := rest[0]
+		if flag == "--" {
+			rest = rest[1:]
+			break
+		}
+		for _, c := range flag[1:] {
+			switch c {
+			case 'a':
+				all = true
+			case 'r':
+				runningOnly = true
+			case 'h':
+				// Marks a job to survive SIGHUP. Nothing sends one here, so
+				// the job is simply left in the table, as bash leaves it.
+			default:
+				r.errf("disown: -%c: invalid option\n", c)
+				r.errf("disown: usage: %s\n", helpTable["disown"].synopsis)
+				return exitStatus{code: 2}
+			}
+		}
+		rest = rest[1:]
+	}
+
+	var indexes []int
+	switch {
+	case len(rest) > 0:
+		for _, spec := range rest {
+			i, err := r.jobSpec(spec)
+			if err != nil {
+				r.errf("disown: %s: %v\n", spec, err)
+				return exitStatus{code: 1}
+			}
+			indexes = append(indexes, i)
+		}
+	case all || runningOnly:
+		indexes = r.jobIndexes()
+	default:
+		if i := r.currentJob(); i >= 0 {
+			indexes = []int{i}
+		} else {
+			r.errf("disown: current: no such job\n")
+			return exitStatus{code: 1}
+		}
+	}
+	for _, i := range indexes {
+		if runningOnly && !r.bgProcs[i].running() {
+			continue
+		}
+		r.bgProcs[i].disowned = true
+	}
+	return exitStatus{}
+}
+
+// runFg implements the fg builtin. Without a controlling terminal there is no
+// foreground to move a job to, so this waits for the job and reports its exit
+// status, which is what a caller of fg is ultimately after.
+func (r *Runner) runFg(ctx context.Context, args []string) exitStatus {
+	spec := "%+"
+	if len(args) > 0 {
+		spec = args[0]
+	}
+	i, err := r.jobSpec(spec)
+	if err != nil {
+		r.errf("fg: %s: %v\n", spec, err)
+		return exitStatus{code: 1}
+	}
+	bg := r.bgProcs[i]
+	r.outf("%s\n", bg.cmd)
+	select {
+	case <-ctx.Done():
+		// The rest of interp surfaces a cancelled context as a fatal error
+		// rather than as a status, so that a caller can tell it apart from a
+		// command that merely exited 130.
+		var exit exitStatus
+		exit.fatal(ctx.Err())
+		return exit
+	case <-bg.done:
+	}
+	exit := *bg.exit
+	exit.exiting = false
+	return exit
+}
+
+// runBg implements the bg builtin. Jobs here always run in the background
+// already, so this reports on the job rather than resuming it, and fails on a
+// job that has finished the way bash fails on one it cannot continue.
+func (r *Runner) runBg(args []string) exitStatus {
+	specs := args
+	if len(specs) == 0 {
+		specs = []string{"%+"}
+	}
+	exit := exitStatus{}
+	for _, spec := range specs {
+		i, err := r.jobSpec(spec)
+		if err != nil {
+			r.errf("bg: %s: %v\n", spec, err)
+			exit.code = 1
+			continue
+		}
+		if !r.bgProcs[i].running() {
+			r.errf("bg: job %d has terminated\n", i+1)
+			exit.code = 1
+			continue
+		}
+		r.outf("[%d]%s %s &\n", i+1, r.jobMark(i), r.bgProcs[i].cmd)
+	}
+	return exit
+}

--- a/interp/jobs_test.go
+++ b/interp/jobs_test.go
@@ -1,0 +1,164 @@
+package interp_test
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"mvdan.cc/sh/v3/interp"
+	"mvdan.cc/sh/v3/syntax"
+)
+
+// syncBuffer collects output from the shell and from its background jobs,
+// which write concurrently.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf strings.Builder
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// runSrc runs src with the default exec handler, so background commands are
+// real processes with real PIDs, and returns the combined output. The
+// deterministic job control cases live in runTests; these tests cover jobs
+// that are genuinely running concurrently, and each src must end all jobs it
+// starts — `kill ...; wait` — so no processes outlive the test.
+func runSrc(t *testing.T, src string) string {
+	t.Helper()
+	var out syncBuffer
+	r, err := interp.New(interp.StdIO(strings.NewReader(""), &out, &out))
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, err := syntax.NewParser().Parse(strings.NewReader(src), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = r.Run(context.Background(), f)
+	return out.String()
+}
+
+// needsSubprocesses skips tests that background an external command. js/wasm
+// has no subprocesses, so those commands fail to run rather than becoming
+// jobs, and the job state under test never arises.
+func needsSubprocesses(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "js" {
+		t.Skip("js/wasm has no subprocesses")
+	}
+}
+
+func TestJobsBuiltin(t *testing.T) {
+	needsSubprocesses(t)
+	t.Parallel()
+	// A running job reports Running, and -p prints the PIDs that $! also
+	// reports — real ones, since each of these jobs is one external program.
+	if s := runSrc(t, "sleep 30 & jobs; kill %1; wait"); !strings.Contains(s, "Running") {
+		t.Fatalf("jobs while running = %q", s)
+	}
+	s := runSrc(t, "sleep 30 & jobs -p; kill %1; wait")
+	if pid, err := strconv.Atoi(strings.TrimSpace(s)); err != nil || pid <= 0 {
+		t.Fatalf("jobs -p = %q, want a real PID", s)
+	}
+	// The two most recent jobs are marked + and -.
+	s = runSrc(t, "sleep 30 & sleep 30 & jobs; kill %1 %2; wait")
+	if !strings.Contains(s, "[1]-") || !strings.Contains(s, "[2]+") {
+		t.Fatalf("job marks = %q", s)
+	}
+}
+
+func TestKillBuiltin(t *testing.T) {
+	needsSubprocesses(t)
+	t.Parallel()
+	// Killing a job cancels it, which jobs then reports as Terminated.
+	// Job specs: by job number, by the real PID $! reports, by command
+	// prefix, and by substring.
+	for _, spec := range []string{"%1", "$!", "%sleep", "%?leep"} {
+		s := runSrc(t, "sleep 30 & kill "+spec+"; wait; jobs")
+		if !strings.Contains(s, "Terminated") {
+			t.Fatalf("kill %s = %q", spec, s)
+		}
+	}
+	// A job that is not exactly one external program keeps its fake gN pid,
+	// which resolves the same way.
+	if s := runSrc(t, "(sleep 30) & kill $!; wait; jobs"); !strings.Contains(s, "Terminated") {
+		t.Fatalf("kill on a gN job = %q", s)
+	}
+	// A bare integer is a PID, not a job number: a PID belonging to no job
+	// does not touch job 1.
+	s := runSrc(t, "sleep 30 & kill 99999999; echo st=$?; jobs; kill %1; wait")
+	if !strings.Contains(s, "st=1") || !strings.Contains(s, "Running") {
+		t.Fatalf("kill on a non-job PID = %q", s)
+	}
+	// Signal 0 only tests that the job exists.
+	if s := runSrc(t, "sleep 30 & kill -0 %1; echo status=$?; jobs; kill %1; wait"); !strings.Contains(s, "status=0") || !strings.Contains(s, "Running") {
+		t.Fatalf("kill -0 = %q", s)
+	}
+	// Stopping and continuing need job control, which does not exist here.
+	if s := runSrc(t, "sleep 30 & kill -STOP %1; kill %1; wait"); !strings.Contains(s, "no job control") {
+		t.Fatalf("kill -STOP = %q", s)
+	}
+	// Both spellings of the signal reach the job.
+	for _, flag := range []string{"-9", "-KILL", "-SIGKILL", "-s KILL", "-n 9"} {
+		s := runSrc(t, "sleep 30 & kill "+flag+" %1; wait; jobs")
+		if !strings.Contains(s, "Terminated") {
+			t.Fatalf("kill %s = %q", flag, s)
+		}
+	}
+}
+
+func TestKillNonJobPID(t *testing.T) {
+	needsSubprocesses(t)
+	if runtime.GOOS == "windows" || runtime.GOOS == "plan9" {
+		t.Skip("no signals to send on this platform")
+	}
+	t.Parallel()
+	// A PID the shell did not start still names a process, which kill
+	// signals the way bash's builtin does.
+	cmd := exec.Command("sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	if s := runSrc(t, fmt.Sprintf("kill %d; echo st=$?", cmd.Process.Pid)); !strings.Contains(s, "st=0") {
+		cmd.Process.Kill()
+		cmd.Wait()
+		t.Fatalf("kill on a foreign PID = %q", s)
+	}
+	if err := cmd.Wait(); err == nil {
+		t.Fatal("process survived kill")
+	}
+}
+
+func TestDisownFgBg(t *testing.T) {
+	needsSubprocesses(t)
+	t.Parallel()
+	// A disowned job leaves the job table, and its % spec stops resolving,
+	// but its PID still does — which is also how these tests end it.
+	s := runSrc(t, "sleep 30 & p=$!; disown; jobs; kill $p; wait $p")
+	if strings.TrimSpace(s) != "" {
+		t.Fatalf("jobs after disown = %q", s)
+	}
+	s = runSrc(t, "sleep 30 & p=$!; disown %1; kill %1; kill $p; wait $p")
+	if !strings.Contains(s, "no such job") {
+		t.Fatalf("kill by job spec after disown = %q", s)
+	}
+	// bg reports on a job that is already running.
+	if s := runSrc(t, "sleep 30 & bg; kill %1; wait"); !strings.Contains(s, "[1]+ sleep 30 &") {
+		t.Fatalf("bg = %q", s)
+	}
+}

--- a/interp/os_notunix.go
+++ b/interp/os_notunix.go
@@ -47,14 +47,49 @@ func (r *Runner) unTestOwnOrGrp(ctx context.Context, op syntax.UnTestOperator, x
 	return false
 }
 
-// waitStatus is a no-op on plan9 and windows.
+// waitStatus is a no-op where there are no signals: plan9, windows and js.
 type waitStatus struct{}
 
-// isENOEXEC is a no-op on plan9 and windows.
+// isENOEXEC is a no-op where there are no signals: plan9, windows and js.
 func isENOEXEC(err error) bool { return false }
 
-// isETXTBSY is a no-op on plan9 and windows.
+// isETXTBSY is a no-op where there are no signals: plan9, windows and js.
 func isETXTBSY(err error) bool { return false }
 
 func (waitStatus) Signaled() bool { return false }
 func (waitStatus) Signal() int    { return 0 }
+
+// killProcess is a no-op on plan9, windows and js/wasm, which have no
+// signals to send.
+func killProcess(pid, signum int) error {
+	return fmt.Errorf("cannot signal processes on this platform")
+}
+
+// signalNames is the fallback signal table for platforms with no signals to
+// ask about. It is Linux's numbering, which is as good a choice as any: these
+// names never reach a kernel here, they only let a script say `kill -TERM %1`
+// and have the job end.
+//
+// On unix this table does not exist; see os_unix.go for why asking the
+// platform is the only way to be right on more than one of them.
+var signalNames = map[int]string{
+	1: "HUP", 2: "INT", 3: "QUIT", 4: "ILL", 5: "TRAP", 6: "ABRT", 7: "BUS",
+	8: "FPE", 9: "KILL", 10: "USR1", 11: "SEGV", 12: "USR2", 13: "PIPE",
+	14: "ALRM", 15: "TERM", 16: "STKFLT", 17: "CHLD", 18: "CONT", 19: "STOP",
+	20: "TSTP", 21: "TTIN", 22: "TTOU", 23: "URG", 24: "XCPU", 25: "XFSZ",
+	26: "VTALRM", 27: "PROF", 28: "WINCH", 29: "IO", 30: "PWR", 31: "SYS",
+}
+
+func signalName(num int) string { return signalNames[num] }
+
+func signalNum(name string) int {
+	for num, known := range signalNames {
+		if known == name {
+			return num
+		}
+	}
+	return 0
+}
+
+// maxSignal bounds the search `kill -l` walks; see os_unix.go.
+const maxSignal = 31

--- a/interp/os_unix.go
+++ b/interp/os_unix.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"os/user"
 	"strconv"
+	"strings"
 	"syscall"
 
 	"golang.org/x/sys/unix"
@@ -54,3 +55,34 @@ func isENOEXEC(err error) bool { return errors.Is(err, syscall.ENOEXEC) }
 // isETXTBSY reports whether the kernel refused to execute a file
 // with ETXTBSY, i.e. a process holds it open for writing.
 func isETXTBSY(err error) bool { return errors.Is(err, syscall.ETXTBSY) }
+
+// killProcess sends a signal to a process that is not one of this runner's
+// jobs, for the kill builtin given a PID it does not know.
+func killProcess(pid, signum int) error {
+	return unix.Kill(pid, unix.Signal(signum))
+}
+
+// signalName and signalNum resolve signal names through the running platform
+// rather than a table compiled into the shell.
+//
+// The numbers are not portable and the differences are not obscure: SIGUSR1 is
+// 10 on Linux and 30 on darwin, where 10 is SIGBUS. A hardcoded Linux table
+// meant `kill -USR1 <pid>` on macOS reached a real process with SIGBUS, which
+// is a fault, not a user signal. Asking the platform is the only way to be
+// right on more than one of them, and x/sys/unix already has the tables.
+//
+// SIG is not part of the name here: the builtin accepts and prints USR1, and
+// x/sys/unix wants SIGUSR1, so the prefix is added and stripped at this
+// boundary and nowhere else.
+func signalName(num int) string {
+	return strings.TrimPrefix(unix.SignalName(syscall.Signal(num)), "SIG")
+}
+
+func signalNum(name string) int {
+	return int(unix.SignalNum("SIG" + name))
+}
+
+// maxSignal bounds the search `kill -l` walks to list every signal the
+// platform knows. Signal numbers are small and dense everywhere this builds;
+// 64 covers Linux's realtime range, which is the widest of them.
+const maxSignal = 64

--- a/interp/runner.go
+++ b/interp/runner.go
@@ -89,6 +89,7 @@ func (r *Runner) fillExpandConfig(ctx context.Context) {
 			// TODO: note that `man bash` mentions that `wait` only waits for the last
 			// process substitution as long as it is $!; the logic here would mean we wait for all of them.
 			bg := r.newBgProc()
+			bg.substitution = true
 			r.bgProcs = append(r.bgProcs, bg)
 			go func() {
 				defer func() {
@@ -296,6 +297,12 @@ func (r *Runner) stmt(ctx context.Context, st *syntax.Stmt) {
 		st2.Background = false
 		st2.Disown = false
 		bg := r.newBgProc()
+		// A job is a goroutine, so kill cancels its context rather than
+		// signalling a process.
+		bgCtx, cancel := context.WithCancel(ctx)
+		bg.cmd = jobText(&st2)
+		bg.cancel = cancel
+		bg.disowned = st.Disown
 		// A plain command call may amount to starting exactly one external
 		// program, in which case $! expands to its real PID like in other
 		// shells, which fork background statements as child processes.
@@ -308,7 +315,8 @@ func (r *Runner) stmt(ctx context.Context, st *syntax.Stmt) {
 		}
 		r.bgProcs = append(r.bgProcs, bg)
 		go func() {
-			r2.Run(ctx, &st2)
+			defer cancel()
+			r2.Run(bgCtx, &st2)
 			r2.reportBgStart(0)     // in case we didn't get to start a program
 			r2.exit.exiting = false // subshells don't exit the parent shell
 			*bg.exit = r2.exit

--- a/interp/unexported_test.go
+++ b/interp/unexported_test.go
@@ -4,6 +4,7 @@
 package interp
 
 import (
+	"strconv"
 	"testing"
 	"time"
 )
@@ -41,5 +42,81 @@ func TestElapsedString(t *testing.T) {
 				t.Fatalf("wanted %q, got %q", tc.want, got)
 			}
 		})
+	}
+}
+
+// Signal numbers are not portable and the differences are not obscure: USR1 is
+// 10 on Linux and 30 on darwin, where 10 is BUS. These tests are written
+// entirely in terms of names for that reason — they assert the same thing on
+// every platform, and they fail on darwin against a hardcoded Linux table
+// even though they can only be run here.
+func TestSignalNamesRoundTripThroughThePlatform(t *testing.T) {
+	t.Parallel()
+	// Signals every unix has, by name. No number appears anywhere below.
+	for _, name := range []string{
+		"HUP", "INT", "QUIT", "ILL", "ABRT", "FPE", "KILL", "SEGV",
+		"PIPE", "ALRM", "TERM", "USR1", "USR2", "CHLD", "CONT", "STOP",
+	} {
+		num, canon, ok := signalByName(name)
+		if !ok {
+			t.Errorf("%s: not resolved on this platform", name)
+			continue
+		}
+		if canon != name {
+			t.Errorf("%s: canonical name came back as %q", name, canon)
+		}
+		if num <= 0 {
+			t.Errorf("%s: resolved to %d", name, num)
+			continue
+		}
+		// The number must name the same signal going back the other way,
+		// which is what fails when one direction reads a stale table.
+		if back := signalName(num); back != name {
+			t.Errorf("%s resolved to %d, which is %q going back", name, num, back)
+		}
+		// SIG-prefixed and numeric spellings must agree with the bare name.
+		if n, _, ok := signalByName("SIG" + name); !ok || n != num {
+			t.Errorf("SIG%s resolved to %d, want %d", name, n, num)
+		}
+		if n, c, ok := signalByName(strconv.Itoa(num)); !ok || n != num || c != name {
+			t.Errorf("%d resolved to (%d, %q), want (%d, %q)", num, n, c, num, name)
+		}
+	}
+}
+
+func TestEffectOfIsKeyedOnNamesNotNumbers(t *testing.T) {
+	t.Parallel()
+	// Job control needs a terminal, so these cannot act on a goroutine.
+	// effectOf used to switch on 17 through 22, which is this set on Linux
+	// and a different one on darwin, where 17 is STOP and 20 is CHLD.
+	for _, name := range []string{"CHLD", "CONT", "STOP", "TSTP", "TTIN", "TTOU"} {
+		num, _, ok := signalByName(name)
+		if !ok {
+			continue // not every platform has all of them
+		}
+		if got := effectOf(num); got != signalUnsupported {
+			t.Errorf("%s (%d): effect %v, want signalUnsupported", name, num, got)
+		}
+	}
+	for _, name := range []string{"HUP", "INT", "KILL", "TERM", "USR1", "USR2"} {
+		num, _, ok := signalByName(name)
+		if !ok {
+			continue
+		}
+		if got := effectOf(num); got != signalTerminates {
+			t.Errorf("%s (%d): effect %v, want signalTerminates", name, num, got)
+		}
+	}
+	if got := effectOf(0); got != signalTests {
+		t.Errorf("signal 0: effect %v, want signalTests", got)
+	}
+}
+
+func TestUnknownSignalsAreRejected(t *testing.T) {
+	t.Parallel()
+	for _, spec := range []string{"NOSUCHSIG", "SIGNOSUCHSIG", "-1", "9999", ""} {
+		if _, _, ok := signalByName(spec); ok {
+			t.Errorf("%q was accepted as a signal", spec)
+		}
 	}
 }


### PR DESCRIPTION
A job here is a goroutine running a subshell rather than a process, so the builtins are shaped by what that can honestly mean: `jobs` lists them, `kill` cancels a job's context (which is what any fatal signal would have amounted to), `disown` drops it from the table and out of a bare `wait`, `fg` waits for the job since there is no terminal to hand it, and `bg` reports on a job that is already running. Nothing is ever stopped, so SIGSTOP/SIGCONT are rejected rather than faked. This is also what makes them work on js/wasm, where there are neither processes nor signals.

The second commit detaches background jobs from the statement's context, because a job outlives the command line that started it: an interactive shell cancels a line's context when the line is done, and in bash the interrupt that ends a foreground job leaves the background ones running. What ends a job is `kill`, the shell exiting, or the new `Runner.StopJobs`.

`help` gains a small notes table for builtins that cannot mean quite the same thing without processes or a controlling terminal.

Split out of the earlier version of this PR as requested: umask is #1411 and enable/compgen/history/logout are #1412, each independent against master.

Part of #1401.