### PR TITLE
syntax: keep backquotes ending in here-documents idempotent

### DIFF
--- a/syntax/printer.go
+++ b/syntax/printer.go
@@ -863,6 +863,14 @@ func (p *Printer) cmdSubst(cs *CmdSubst) {
 		} else {
 			p.wantSpace = spaceNotRequired
 		}
+		// A here-document's terminator needs a line of its own, but a closing
+		// backquote may directly follow it, as in "`foo <<EOF\nbar\nEOF`".
+		// We always print command substitutions as $(...), and a closing
+		// parenthesis cannot share the terminator's line, so the body is going
+		// to span multiple lines no matter what cs.Right says.
+		if cs.Backquotes && endsWithHeredocBody(cs.Stmts) {
+			p.wantNewline = true
+		}
 		p.nestedStmts(cs.Stmts, cs.Last, cs.Right)
 		p.closingParen(cs.Stmts, cs.Last, cs.Left, cs.Right)
 	}
@@ -1632,6 +1640,22 @@ func startsWithLparen(node Node) bool {
 		return true // keep ( ((
 	}
 	return false
+}
+
+// endsWithHeredocBody reports whether the printed form of the last statement
+// ends with the body and terminator line of a here-document.
+func endsWithHeredocBody(stmts []*Stmt) bool {
+	if len(stmts) == 0 {
+		return false
+	}
+	redirs := stmts[len(stmts)-1].Redirs
+	if len(redirs) == 0 {
+		return false
+	}
+	last := redirs[len(redirs)-1]
+	// An empty body leaves the terminator on the redirect's own line, which
+	// the position of the closing token already reflects.
+	return last.Hdoc != nil && (last.Op == Hdoc || last.Op == DashHdoc)
 }
 
 func endsWithRparen(node Node) bool {

--- a/syntax/printer_test.go
+++ b/syntax/printer_test.go
@@ -116,6 +116,11 @@ var printTests = []printCase{
 	samePrint("<<EOF\nEOF"),
 	samePrint("foo <<EOF\nEOF\n\nbar"),
 	samePrint("foo <<'EOF'\nEOF\n\nbar"),
+	// A closing backquote may share a line with a here-document's terminator,
+	// but the closing parenthesis we print in its place may not.
+	{"`foo <<EOF\nbar\nEOF`", "$(\n\tfoo <<EOF\nbar\nEOF\n)"},
+	{"`foo <<-EOF\n\tbar\n\tEOF`", "$(\n\tfoo <<-EOF\n\t\tbar\n\tEOF\n)"},
+	{"`foo <<EOF\nbar\nEOF` `baz <<EOF\nqux\nEOF`", "$(\n\tfoo <<EOF\nbar\nEOF\n) $(\n\tbaz <<EOF\nqux\nEOF\n)"},
 	samePrint("if cmd <<EOF\nbody\nEOF\nthen\n\tfoo\nfi"),
 	samePrint("while cmd <<EOF\nbody\nEOF\ndo\n\tfoo\ndone"),
 	samePrint("if true; then\n\tcat <<-EOF # comment\n\t\tcontent\n\tEOF\nfi"),


### PR DESCRIPTION
`shfmt` is not idempotent on a command substitution written with backquotes whose body ends in a here-document. Running it twice changes the file:

```console
$ cat in.sh
`foo <<EOF
bar
EOF`

$ shfmt in.sh
$(foo <<EOF
bar
EOF
)

$ shfmt in.sh | shfmt
$(
	foo <<EOF
bar
EOF
)
```

The third output is stable, so it converges after two passes rather than one.

### Cause

A closing backquote may share a line with a here-document's terminator; a closing parenthesis may not. `Printer.cmdSubst` always prints command substitutions as `$(...)`, but `nestedStmts` still decides whether the body goes on separate lines by comparing `stmtsEnd(...)` against `cs.Right` — the position of the closing *backquote*. For the input above those are both `3:4`, so the body is printed compactly, even though the `)` we then emit is forced onto line 4. Reparsing that output sees `)` on a line of its own and expands the body.

`filetests_test.go` already records the expanded form as the canonical spelling for exactly this construct:

```go
fileTest(
	[]string{
		"$(\n\tfoo <<EOF\nbar\nEOF\n)",
		"$(foo <<EOF\nbar\nEOF\n)",
		"`\nfoo <<EOF\nbar\nEOF\n`",
		"`foo <<EOF\nbar\nEOF`",
	},
	...
```

The first three inputs all print as that canonical form today; only the fourth does not.

### Fix

When printing a backquoted command substitution whose last statement ends with a here-document body, force the multi-line form, since the source positions cannot describe the layout of the `$(...)` we are about to write.

The check deliberately requires `Hdoc != nil`: with an empty body such as `` `foo <<EOF\nEOF` `` the terminator already sits on the redirect's own line, the closing token's position reflects that, and the existing logic handles it.

### Tests

Three cases added to `printTests`, covering `<<`, `<<-`, and two substitutions on one line. `TestPrintTable` runs each through `printTest`, which asserts both the expected output and that reprinting it is a fixed point. All three fail on master and pass with the change; their `-redo` variants pass either way.

### Verification

Everything CI runs is green, matching an unmodified `master` on the same machine:

- `go test ./...`
- `go test -race ./...`
- `GOARCH=386 go test -count=1 ./...`
- `cd moreinterp && go test ./...`
- `go vet ./...`
- `gofmt -s -l .` (no output)

Separately, I ran a parse/print/reparse/reprint harness over the seed corpus already used by `FuzzParsePrint` (all `printTests` and `fileTests` inputs, across all five language variants, with nine printer option sets and both `KeepComments` values). It found 209 non-idempotent cases on master and 71 with this change; every remaining case is either `KeepPadding` (already deprecated, #658) or one of two `SingleLine` cases with nested here-documents. Nothing re-parsed incorrectly in either run. I'm happy to open separate issues for the `SingleLine` ones if useful.
