### PR TITLE
interp: support js/wasm

### DIFF
--- a/interp/api.go
+++ b/interp/api.go
@@ -19,6 +19,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strconv"
 	"time"
@@ -98,7 +99,7 @@ type Runner struct {
 	// accessHandler is a function responsible for checking file access. It must be non-nil.
 	accessHandler AccessHandlerFunc
 
-	stdin  *os.File // e.g. the read end of a pipe
+	stdin  stdinFile // e.g. the read end of a pipe
 	stdout io.Writer
 	stderr io.Writer
 
@@ -151,7 +152,7 @@ type Runner struct {
 	origDir    string
 	origParams []string
 	origOpts   runnerOpts
-	origStdin  *os.File
+	origStdin  stdinFile
 	origStdout io.Writer
 	origStderr io.Writer
 
@@ -326,6 +327,12 @@ func Dir(path string) RunnerOption {
 		if path == "" {
 			path, err := os.Getwd()
 			if err != nil {
+				if runtime.GOOS == "js" {
+					// js/wasm has no working directory; virtual
+					// filesystems set Runner.Dir themselves
+					r.Dir = "/"
+					return nil
+				}
 				return fmt.Errorf("could not get current dir: %w", err)
 			}
 			r.Dir = path
@@ -521,25 +528,6 @@ func AccessHandler(f AccessHandlerFunc) RunnerOption {
 	}
 }
 
-func stdinFile(r io.Reader) (*os.File, error) {
-	switch r := r.(type) {
-	case *os.File:
-		return r, nil
-	case nil:
-		return nil, nil
-	default:
-		pr, pw, err := os.Pipe()
-		if err != nil {
-			return nil, err
-		}
-		go func() {
-			io.Copy(pw, r)
-			pw.Close()
-		}()
-		return pr, nil
-	}
-}
-
 // StdIO configures an interpreter's standard input, standard output, and
 // standard error. If out or err are nil, they default to a writer that discards
 // the output.
@@ -553,9 +541,13 @@ func stdinFile(r io.Reader) (*os.File, error) {
 // When providing an [*os.File] as standard input, consider using an [os.Pipe]
 // as it has the best chance to support cancellable reads via [os.File.SetReadDeadline],
 // so that cancelling the runner's context can stop a blocked standard input read.
+//
+// On js/wasm, where there are no subprocesses nor OS pipes, any reader is used
+// directly, and read deadlines are not supported: cancelling the runner's
+// context cannot stop a blocked standard input read.
 func StdIO(in io.Reader, out, err io.Writer) RunnerOption {
 	return func(r *Runner) error {
-		stdin, _err := stdinFile(in)
+		stdin, _err := newStdinFile(in)
 		if _err != nil {
 			return _err
 		}

--- a/interp/handler.go
+++ b/interp/handler.go
@@ -70,7 +70,8 @@ type HandlerContext struct {
 	// TODO(v4): use an os.File for stdin below directly.
 
 	// Stdin is the interpreter's current standard input reader.
-	// It is always an [*os.File], but the type here remains an [io.Reader]
+	// It is always an [*os.File], except on js/wasm, where it may be
+	// any reader; the type here remains an [io.Reader]
 	// due to backwards compatibility.
 	Stdin io.Reader
 	// Stdout is the interpreter's current standard output writer.

--- a/interp/other_test.go
+++ b/interp/other_test.go
@@ -1,0 +1,13 @@
+// Copyright (c) 2026, Daniel Martí <mvdan@mvdan.cc>
+// See LICENSE for licensing information
+
+//go:build !unix && !windows
+
+package interp_test
+
+// shortPathName only means anything on Windows; the call site is guarded by a
+// runtime GOOS check. It is defined here as well so that the test binary
+// builds on platforms which are neither unix nor windows, such as js/wasm.
+func shortPathName(path string) (string, error) {
+	panic("only works on windows")
+}

--- a/interp/runner.go
+++ b/interp/runner.go
@@ -496,7 +496,7 @@ func (r *Runner) cmd(ctx context.Context, cm syntax.Command) {
 				r.stmt(ctx, cm.Y)
 			}
 		case syntax.Pipe, syntax.PipeAll:
-			pr, pw, err := os.Pipe()
+			pr, pw, err := newPipe()
 			if err != nil {
 				r.exit.fatal(err) // not being able to create a pipe is rare but critical
 				return
@@ -919,8 +919,8 @@ func (r *Runner) stmts(ctx context.Context, stmts []*syntax.Stmt) {
 	}
 }
 
-func (r *Runner) hdocReader(rd *syntax.Redirect) (*os.File, error) {
-	pr, pw, err := os.Pipe()
+func (r *Runner) hdocReader(rd *syntax.Redirect) (stdinFile, error) {
+	pr, pw, err := newPipe()
 	if err != nil {
 		return nil, err
 	}
@@ -931,7 +931,7 @@ func (r *Runner) hdocReader(rd *syntax.Redirect) (*os.File, error) {
 	if rd.Op != syntax.DashHdoc {
 		hdoc := r.document(rd.Hdoc)
 		go func() {
-			pw.WriteString(hdoc)
+			io.WriteString(pw, hdoc)
 			pw.Close()
 		}()
 		return pr, nil
@@ -997,7 +997,7 @@ func (r *Runner) redir(ctx context.Context, rd *syntax.Redirect) (io.Closer, err
 	arg := r.literal(rd.Word)
 	switch rd.Op {
 	case syntax.WordHdoc:
-		pr, pw, err := os.Pipe()
+		pr, pw, err := newPipe()
 		if err != nil {
 			return nil, err
 		}
@@ -1005,8 +1005,8 @@ func (r *Runner) redir(ctx context.Context, rd *syntax.Redirect) (io.Closer, err
 		// We write to the pipe in a new goroutine,
 		// as pipe writes may block once the buffer gets full.
 		go func() {
-			pw.WriteString(arg)
-			pw.WriteString("\n")
+			io.WriteString(pw, arg)
+			io.WriteString(pw, "\n")
 			pw.Close()
 		}()
 		return pr, nil
@@ -1049,7 +1049,7 @@ func (r *Runner) redir(ctx context.Context, rd *syntax.Redirect) (io.Closer, err
 	}
 	switch rd.Op {
 	case syntax.RdrIn:
-		stdin, err := stdinFile(f)
+		stdin, err := newStdinFile(f)
 		if err != nil {
 			return nil, err
 		}

--- a/interp/stdin_js.go
+++ b/interp/stdin_js.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2017, Daniel Martí <mvdan@mvdan.cc>
+// See LICENSE for licensing information
+
+//go:build js
+
+package interp
+
+import (
+	"io"
+	"time"
+)
+
+// js/wasm has no OS pipes and no subprocesses, so pipes are in-process
+// [io.Pipe]s and any reader can be used as stdin directly. Read
+// deadlines are not supported: SetReadDeadline is a no-op, so a
+// blocked `read` builtin unblocks on the next write rather than on
+// context cancellation.
+
+// stdinFile is the runner's standard input; elsewhere it is an
+// [*os.File], but on js/wasm any reader satisfying this interface works.
+type stdinFile interface {
+	io.ReadCloser
+	SetReadDeadline(t time.Time) error
+}
+
+// jsReader adapts a plain reader into a stdinFile.
+type jsReader struct {
+	io.Reader
+}
+
+func (r jsReader) Close() error {
+	if c, ok := r.Reader.(io.Closer); ok {
+		return c.Close()
+	}
+	return nil
+}
+
+func (jsReader) SetReadDeadline(t time.Time) error { return nil }
+
+// newPipe returns an in-process pipe.
+func newPipe() (stdinFile, *io.PipeWriter, error) {
+	pr, pw := io.Pipe()
+	return jsReader{pr}, pw, nil
+}
+
+// newStdinFile converts a reader into the runner's stdin. Without
+// subprocesses there is no need to copy through a pipe.
+func newStdinFile(r io.Reader) (stdinFile, error) {
+	if r == nil {
+		return nil, nil
+	}
+	return jsReader{r}, nil
+}

--- a/interp/stdin_os.go
+++ b/interp/stdin_os.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2017, Daniel Martí <mvdan@mvdan.cc>
+// See LICENSE for licensing information
+
+//go:build !js
+
+package interp
+
+import (
+	"io"
+	"os"
+)
+
+// stdinFile is the runner's standard input. Outside of js/wasm it is
+// always an [*os.File]: the only type that subprocesses can inherit,
+// and one supporting cancellable reads via [os.File.SetReadDeadline].
+type stdinFile = *os.File
+
+// newPipe returns an OS pipe; both ends are [*os.File] so they can
+// be inherited by subprocesses.
+func newPipe() (stdinFile, *os.File, error) {
+	return os.Pipe()
+}
+
+// newStdinFile converts a reader into the runner's stdin. Readers
+// other than [*os.File] require an [os.Pipe] and a copying goroutine,
+// as an [os.File] is the only way to share a reader with subprocesses.
+func newStdinFile(r io.Reader) (stdinFile, error) {
+	switch r := r.(type) {
+	case *os.File:
+		return r, nil
+	case nil:
+		return nil, nil
+	default:
+		pr, pw, err := os.Pipe()
+		if err != nil {
+			return nil, err
+		}
+		go func() {
+			io.Copy(pw, r)
+			pw.Close()
+		}()
+		return pr, nil
+	}
+}


### PR DESCRIPTION
Makes `interp` usable under `GOOS=js GOARCH=wasm`, where there are neither subprocesses nor OS pipes. Two independent changes.

**Abstract the runner's stdin.** `Runner.stdin` was an `*os.File` throughout. That type is load-bearing on OSes — it is the only thing a subprocess can inherit, and it is what supports cancellable reads via `SetReadDeadline` — but neither property exists on js/wasm, so the field cannot be constructed there at all.

It is now a small `stdinFile` interface (`io.ReadCloser` plus `SetReadDeadline`), with the OS path in `stdin_os.go` still backed by `*os.File` and unchanged in behaviour, and a js/wasm path in `stdin_js.go` backed by in-process pipes. `api.go` and `runner.go` go through the interface.

**Fall back to `/` when `Getwd` fails.** On js/wasm there is no working directory to report; `Runner` currently propagates the error and cannot be constructed. Seven lines.

Tested: `go test ./interp/` passes, and `GOOS=js GOARCH=wasm go build ./interp/` succeeds, which it did not before.

Happy to split these into two PRs if you would prefer — they share only the theme.

For context, these come out of running `interp` in a browser. There is one more portability patch in that work, an `os.SameFile` shim for TinyGo, which I have deliberately not included here: it is a workaround for a missing stdlib function rather than something js/wasm needs, and it seems more likely you would rather not carry a TinyGo build tag. Say if you would take it and I will send it separately.