### PR TITLE
interp: support exec's -a, -c and -l flags

### DIFF
--- a/interp/builtin.go
+++ b/interp/builtin.go
@@ -528,12 +528,43 @@ func (r *Runner) builtin(ctx context.Context, pos syntax.Pos, name string, args 
 		// the process. It's in theory what a shell should do,
 		// but in practice it would kill the entire Go process
 		// and it's not available on Windows.
+		argv0 := ""
+		login, clearEnv := false, false
+		fp := flagParser{remaining: args}
+		for fp.more() {
+			switch flag := fp.flag(); flag {
+			case "-a":
+				if len(fp.remaining) == 0 {
+					return failf(2, "exec: -a: option requires an argument\n")
+				}
+				argv0 = fp.value()
+			case "-l":
+				login = true
+			case "-c":
+				clearEnv = true
+			default:
+				return failf(2, "exec: invalid option %q\n", flag)
+			}
+		}
+		args := fp.args()
 		if len(args) == 0 {
+			// "exec" on its own keeps this statement's redirections open. Any
+			// flags then have nothing to apply to, as in bash.
 			r.keepRedirs = true
 			break
 		}
+		if argv0 == "" {
+			argv0 = args[0]
+		}
+		if login {
+			// A login shell is told an argv[0] prefixed with "-".
+			argv0 = "-" + argv0
+		}
 		r.exit.exiting = true
-		r.exec(ctx, pos, args)
+		if argv0 == args[0] {
+			argv0 = "" // nothing to override
+		}
+		r.execWith(ctx, pos, argv0, clearEnv, args)
 		exit = r.exit
 	case "command":
 		show := false

--- a/interp/handler.go
+++ b/interp/handler.go
@@ -83,6 +83,21 @@ type HandlerContext struct {
 	// so this refers to the command before it.
 	// At the start of a trap callback, it is the status of the command which triggered the trap.
 	LastExitStatus int
+
+	// Argv0, when not empty, is the name the executed program should see as its
+	// own argv[0], which may differ from the file which is looked up and run.
+	// It is set by "exec -a name file" and, for a login shell, by "exec -l".
+	//
+	// An [ExecHandlerFunc] which ignores this field keeps working and simply
+	// does not support those flags; [DefaultExecHandler] honors it.
+	Argv0 string
+
+	// ClearEnv reports whether the executed program should be given an empty
+	// environment rather than the interpreter's. It is set by "exec -c".
+	//
+	// As with [HandlerContext.Argv0], an [ExecHandlerFunc] which ignores this
+	// field keeps working; [DefaultExecHandler] honors it.
+	ClearEnv bool
 }
 
 // CallHandlerFunc is a handler which runs on every [syntax.CallExpr].
@@ -147,7 +162,19 @@ func DefaultExecHandler(killTimeout time.Duration) ExecHandlerFunc {
 		}
 		cmd := exec.CommandContext(ctx, path)
 		cmd.Args = args
-		cmd.Env = execEnv(hc.Env)
+		if hc.Argv0 != "" {
+			// "exec -a name file" and "exec -l" run one file while telling it
+			// a different argv[0]. Multi-call binaries dispatch on that name,
+			// so it decides which program actually runs.
+			cmd.Args = append([]string{hc.Argv0}, args[1:]...)
+		}
+		if hc.ClearEnv {
+			// Not nil, which os/exec would read as "inherit this process's
+			// environment" — the opposite of what "exec -c" asks for.
+			cmd.Env = []string{}
+		} else {
+			cmd.Env = execEnv(hc.Env)
+		}
 		cmd.Dir = hc.Dir
 		cmd.Stdin = hc.Stdin
 		cmd.Stdout = hc.Stdout

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -3677,6 +3677,20 @@ done <<< 2`,
 		"exec $GOSH_PROG 'echo foo'; echo bar",
 		"foo\n",
 	},
+	{
+		"exec -a",
+		"exec: -a: option requires an argument\nexit status 2 #JUSTERR",
+	},
+	{
+		"exec -q foo",
+		"exec: invalid option \"-q\"\nexit status 2 #JUSTERR",
+	},
+	{
+		// Flags with no command to apply to still keep this statement's
+		// redirections open, as bare "exec" does.
+		"exec -a name >/dev/null; echo foo",
+		"",
+	},
 
 	// read
 	{
@@ -3949,6 +3963,34 @@ done <<< 2`,
 
 var runTestsUnix = []runTest{
 	{"[[ -n $PPID && $PPID -ge 0 ]]", ""}, // can be 0 if running as the init process
+
+	// exec's flags, which need a program that reports its own argv[0] and
+	// environment. gosh sets $0 itself, so /bin/sh is the observer here.
+	{
+		// -a runs one file while telling it a different argv[0], which is how
+		// a multi-call binary is dispatched without a wrapper.
+		"(exec -a argv0name /bin/sh -c 'echo $0')",
+		"argv0name\n",
+	},
+	{
+		// -l marks a login shell by prefixing argv[0] with a dash.
+		"(exec -l /bin/sh -c 'case $0 in -*) echo dashed ;; *) echo plain ;; esac')",
+		"dashed\n",
+	},
+	{
+		// -a and -l compose: the dash goes on the overridden name.
+		"(exec -l -a argv0name /bin/sh -c 'echo $0')",
+		"-argv0name\n",
+	},
+	{
+		// -c runs the command with an empty environment.
+		"export FOO=bar; (exec -c /bin/sh -c 'echo ${FOO-unset}')",
+		"unset\n",
+	},
+	{
+		"export FOO=bar; (exec /bin/sh -c 'echo ${FOO-unset}')",
+		"bar\n",
+	},
 	{
 		// no root user on windows
 		"[[ ~root == '~root' ]]",

--- a/interp/runner.go
+++ b/interp/runner.go
@@ -1126,7 +1126,23 @@ func (r *Runner) call(ctx context.Context, pos syntax.Pos, args []string) {
 }
 
 func (r *Runner) exec(ctx context.Context, pos syntax.Pos, args []string) {
-	r.exit.fromHandlerError(r.execHandler(r.handlerCtx(ctx, handlerKindExec, pos), args))
+	r.execWith(ctx, pos, "", false, args)
+}
+
+// execWith is [Runner.exec] with the two things "exec"'s own flags can change
+// about how the program runs: an argv[0] which differs from the file being run
+// ("exec -a name file", and "exec -l"), and an empty environment ("exec -c").
+// An empty argv0 and a false clearEnv mean neither applies, which is every
+// caller other than the exec builtin.
+func (r *Runner) execWith(ctx context.Context, pos syntax.Pos, argv0 string, clearEnv bool, args []string) {
+	hctx := r.handlerCtx(ctx, handlerKindExec, pos)
+	if argv0 != "" || clearEnv {
+		hc := HandlerCtx(hctx)
+		hc.Argv0 = argv0
+		hc.ClearEnv = clearEnv
+		hctx = context.WithValue(hctx, handlerCtxKey{}, hc)
+	}
+	r.exit.fromHandlerError(r.execHandler(hctx, args))
 }
 
 func (r *Runner) open(ctx context.Context, path string, flags int, mode os.FileMode, print bool) (io.ReadWriteCloser, error) {


### PR DESCRIPTION
Fixes #1386.

`exec` took no flags, so the first one was treated as the command to run and failed PATH lookup with a message naming the flag:

```console
$ gosh -c 'exec -a nm /bin/echo hi'
"-a": executable file not found in $PATH
```

`-a` is the one with real consumers: it sets argv[0] without a wrapper binary, and multi-call binaries dispatch on it. A tool shipping several utilities behind one executable and installing them as shell functions has every one of those functions fail, with a diagnostic naming neither the function nor the binary.

## Approach

`-a` and `-l` need an argv[0] that differs from the file being looked up, and `-c` needs an empty environment, so all three need the exec handler's cooperation. `HandlerContext` gains two fields for that:

- `Argv0 string` — the name the program should see as its own argv[0].
- `ClearEnv bool` — run with an empty environment.

Both are **additive**: an `ExecHandlerFunc` that ignores them keeps working and simply does not support the flags; `DefaultExecHandler` honors them. Existing `Runner.exec` callers are untouched — the builtin goes through a new `execWith`, and `exec` delegates to it with the zero values.

`-c` is implemented rather than rejected because bash supports it, and the test suite confirms every case against real bash, which is what caught the first draft refusing it.

## Tests

Portable flag-error cases go in `runTests`; the three behavior cases need a program that reports its own argv[0] and environment, so they use `/bin/sh` in `runTestsUnix` (gosh sets `$0` itself, so it cannot observe argv[0]).

- `-a` overrides argv[0]; `-l` prefixes a dash; the two compose (`-l -a name` → `-name`)
- `-c` runs with an empty environment, and the same command without `-c` does not
- `exec -a` with no argument, and an unknown flag, both exit 2
- `exec -a name >/dev/null` with no command still keeps the redirection open, as bare `exec` does

`go test ./interp/` is at the same 4 pre-existing `TestRunnerRunConfirm` failures as `master` on this machine (three `HOME=…; echo ~` cases and one `>&-` write-error message, all environment-dependent), so no regressions. `gofmt` clean.
