### PR TITLE
interp: implement read's -d, -n and -N, and fix -s and -a

### DIFF
--- a/interp/builtin.go
+++ b/interp/builtin.go
@@ -14,7 +14,6 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"golang.org/x/term"
@@ -666,7 +665,14 @@ func (r *Runner) builtin(ctx context.Context, pos syntax.Pos, name string, args 
 		var prompt string
 		raw := false
 		silent := false
-		readArray := false
+		arrayName := ""
+		delim := byte('\n')
+		// maxChars is the count given to -n or -N; a negative value means that
+		// the read is only stopped by the delimiter or by the end of the input.
+		maxChars := -1
+		// exactly is set by -N, which reads a fixed number of characters,
+		// ignoring the delimiter and doing no field splitting.
+		exactly := false
 		fp := flagParser{remaining: args}
 		for fp.more() {
 			switch flag := fp.flag(); flag {
@@ -675,12 +681,44 @@ func (r *Runner) builtin(ctx context.Context, pos syntax.Pos, name string, args 
 			case "-r":
 				raw = true
 			case "-a":
-				readArray = true
+				// Note that bash takes the array name as this option's
+				// argument, so further options may follow it.
+				if len(fp.remaining) == 0 {
+					return failf(2, "read: -a: option requires an argument\n")
+				}
+				arrayName = fp.value()
+				if !syntax.ValidName(arrayName) {
+					return failf(2, "read: invalid identifier %q\n", arrayName)
+				}
 			case "-p":
 				prompt = fp.value()
 				if prompt == "" {
 					return failf(2, "read: -p: option requires an argument\n")
 				}
+			case "-d":
+				// Note that an empty string is a valid delimiter, so we can't
+				// use the empty return from value to detect a missing argument.
+				if len(fp.remaining) == 0 {
+					return failf(2, "read: -d: option requires an argument\n")
+				}
+				if val := fp.value(); val == "" {
+					// Bash uses an ASCII NUL when given an empty string,
+					// which is how "find -print0" input is consumed.
+					delim = 0
+				} else {
+					delim = val[0]
+				}
+			case "-n", "-N":
+				if len(fp.remaining) == 0 {
+					return failf(2, "read: %s: option requires an argument\n", flag)
+				}
+				val := fp.value()
+				n, err := strconv.Atoi(val)
+				if err != nil || n < 0 {
+					return failf(1, "read: %s: invalid number\n", val)
+				}
+				maxChars = n
+				exactly = flag == "-N"
 			default:
 				return failf(2, "read: invalid option %q\n", flag)
 			}
@@ -699,18 +737,18 @@ func (r *Runner) builtin(ctx context.Context, pos syntax.Pos, name string, args 
 
 		var line []byte
 		var err error
-		if silent {
-			// Note that on Windows, syscall.Stdin is of type uintptr.
-			line, err = term.ReadPassword(int(syscall.Stdin))
+		// -s only has an effect when reading from a terminal, as there is no
+		// echo to suppress when the input is a pipe or a file. Note that we
+		// must use the shell's stdin rather than the process's, as they differ
+		// under a redirect and when the caller supplied its own via [StdIO].
+		if silent && r.stdin != nil && delim == '\n' && maxChars < 0 &&
+			term.IsTerminal(int(r.stdin.Fd())) {
+			line, err = term.ReadPassword(int(r.stdin.Fd()))
 		} else {
-			line, err = r.readLine(ctx, raw)
+			line, err = r.readLine(ctx, raw, delim, maxChars, exactly)
 		}
-		if readArray {
-			// read -a arrayname: split line into fields and assign to indexed array.
-			arrayName := shellReplyVar
-			if len(args) > 0 {
-				arrayName = args[0]
-			}
+		switch {
+		case arrayName != "":
 			// Use -1 as max to get all fields without joining the last ones.
 			values := expand.ReadFields(r.ecfg, string(line), -1, raw)
 			r.setVar(arrayName, expand.Variable{
@@ -718,25 +756,24 @@ func (r *Runner) builtin(ctx context.Context, pos syntax.Pos, name string, args 
 				Kind: expand.Indexed,
 				List: values,
 			})
-		} else if len(args) == 0 {
-			// Bare "read" assigns the whole line to REPLY without any
-			// trimming, only discarding backslash escapes unless raw.
+		case exactly, len(args) == 0:
+			// A bare "read" assigns the whole line to REPLY, and -N assigns
+			// the characters it read to the first name given. Neither does any
+			// trimming nor field splitting; both discard escapes unless raw.
 			val := string(line)
 			if !raw {
-				var sb strings.Builder
-				esc := false
-				for i := range len(val) {
-					if val[i] == '\\' && !esc {
-						esc = true
-						continue
-					}
-					sb.WriteByte(val[i])
-					esc = false
-				}
-				val = sb.String()
+				val = unescapeRead(val)
 			}
-			r.setVarString(shellReplyVar, val)
-		} else {
+			name := shellReplyVar
+			if len(args) > 0 {
+				name = args[0]
+			}
+			r.setVarString(name, val)
+			// Bash leaves any remaining names empty rather than unset.
+			for _, name := range args[min(1, len(args)):] {
+				r.setVarString(name, "")
+			}
+		default:
 			values := expand.ReadFields(r.ecfg, string(line), len(args), raw)
 			for i, name := range args {
 				val := ""
@@ -1042,13 +1079,41 @@ func (r *Runner) printOptLine(name string, enabled, supported bool) {
 	r.outf("%s\t%s\t(%q not supported)\n", name, state, r.optStatusText(!enabled))
 }
 
-func (r *Runner) readLine(ctx context.Context, raw bool) ([]byte, error) {
+// unescapeRead drops the backslashes which escape another character, as "read"
+// does when its -r option is not given.
+func unescapeRead(val string) string {
+	var sb strings.Builder
+	esc := false
+	for i := range len(val) {
+		if val[i] == '\\' && !esc {
+			esc = true
+			continue
+		}
+		sb.WriteByte(val[i])
+		esc = false
+	}
+	return sb.String()
+}
+
+// readLine reads from the shell's stdin until it reaches delim, or maxChars
+// characters when it is not negative, or the end of the input. When exactly is
+// set, delim is not looked for at all, as used by "read -N".
+//
+// Note that the returned line still holds the backslashes which escape another
+// character, as whether they are dropped depends on the caller.
+func (r *Runner) readLine(ctx context.Context, raw bool, delim byte, maxChars int, exactly bool) ([]byte, error) {
 	if r.stdin == nil {
 		return nil, errors.New("interp: can't read, there's no stdin")
+	}
+	if maxChars == 0 {
+		return nil, nil
 	}
 
 	var line []byte
 	esc := false
+	// chars counts the characters that the line will hold once the escaping
+	// backslashes are dropped, which is what -n and -N count.
+	chars := 0
 
 	stopc := make(chan struct{})
 	stop := context.AfterFunc(ctx, func() {
@@ -1072,15 +1137,25 @@ func (r *Runner) readLine(ctx context.Context, raw bool) ([]byte, error) {
 			case !raw && b == '\\':
 				line = append(line, b)
 				esc = !esc
-			case !raw && b == '\n' && esc:
+				if !esc {
+					// A second backslash, so the pair is one character.
+					chars++
+				}
+			case !raw && !exactly && b == delim && esc && delim == '\n':
 				// line continuation; drop the trailing backslash
 				line = line[:len(line)-1]
 				esc = false
-			case b == '\n':
+			case !exactly && b == delim && !esc:
 				return line, nil
 			default:
+				// Note that an escaped delimiter lands here, so it becomes a
+				// literal character rather than ending the line.
 				line = append(line, b)
 				esc = false
+				chars++
+			}
+			if maxChars >= 0 && chars >= maxChars {
+				return line, nil
 			}
 		}
 		if err != nil {

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -3839,6 +3839,91 @@ done <<< 2`,
 		"1 a\\tb\n",
 	},
 	{
+		"read -a",
+		"read: -a: option requires an argument\nexit status 2 #JUSTERR",
+	},
+
+	// read -d
+	{
+		`printf 'a:b:' | { read -r -d : x; echo "[$x]"; read -r -d : y; echo "[$y]"; }`,
+		"[a]\n[b]\n",
+	},
+	{
+		// reaching the end of the input without the delimiter still assigns
+		`printf 'ab' | { read -r -d : x; echo "$? [$x]"; }`,
+		"1 [ab]\n",
+	},
+	{
+		// an empty delimiter means an ASCII NUL, as used with "find -print0"
+		`printf 'a\0b\0' | while read -r -d '' f; do echo "[$f]"; done`,
+		"[a]\n[b]\n",
+	},
+	{
+		// an escaped delimiter is a literal character, so it doesn't end the line
+		`printf 'a\\:b:' | { read -d : x; echo "[$x]"; }`,
+		"[a:b]\n",
+	},
+	{
+		`printf 'a b:' | { read -r -a arr -d :; echo "${#arr[@]} [${arr[0]}] [${arr[1]}]"; }`,
+		"2 [a] [b]\n",
+	},
+	{
+		"read -d",
+		"read: -d: option requires an argument\nexit status 2 #JUSTERR",
+	},
+
+	// read -n and read -N
+	{
+		`printf 'abcd\n' | { read -r -n 2 x; echo "$? [$x]"; read -r rest; echo "[$rest]"; }`,
+		"0 [ab]\n[cd]\n",
+	},
+	{
+		`printf 'ab' | { read -r -N 3 x; echo "$? [$x]"; }`,
+		"1 [ab]\n",
+	},
+	{
+		// -N reads a fixed number of characters, ignoring the delimiter
+		`printf 'ab:cd' | { read -r -N 4 -d : x; echo "[$x]"; }`,
+		"[ab:c]\n",
+	},
+	{
+		// -N does no field splitting nor trimming, unlike -n
+		`printf '  a b\n' | { read -N 5 x y; echo "[$x] [$y]"; }`,
+		"[  a b] []\n",
+	},
+	{
+		`printf '  a b\n' | { read -n 5 x y; echo "[$x] [$y]"; }`,
+		"[a] [b]\n",
+	},
+	{
+		// -N still counts the characters after the escapes are dropped
+		`printf 'a\\bc' | { read -N 3 x; echo "[$x]"; }`,
+		"[abc]\n",
+	},
+	{
+		`printf 'abc\n' | { read -r -n 0 x; echo "$? [$x]"; }`,
+		"0 []\n",
+	},
+	{
+		"read -n",
+		"read: -n: option requires an argument\nexit status 2 #JUSTERR",
+	},
+	{
+		"read -n abc",
+		"read: abc: invalid number\nexit status 1 #JUSTERR",
+	},
+	{
+		"read -N -1",
+		"read: -1: invalid number\nexit status 1 #JUSTERR",
+	},
+
+	// read -s reads from the shell's stdin, which is not the process's stdin
+	// under a redirect; there is no echo to suppress when it isn't a terminal.
+	{
+		`printf 'hi\n' | { read -r -s x; echo "[$x]"; }`,
+		"[hi]\n",
+	},
+	{
 		`a=a; echo | (read a; echo -n "$a")`,
 		"",
 	},

--- a/interp/runner.go
+++ b/interp/runner.go
@@ -578,7 +578,7 @@ func (r *Runner) cmd(ctx context.Context, cm syntax.Command) {
 					}
 					r.errf("%s", ps3)
 
-					line, err := r.readLine(ctx, true)
+					line, err := r.readLine(ctx, true, '\n', -1, false)
 					if err != nil {
 						r.errf("\n")
 						r.exit.code = 1


### PR DESCRIPTION
Fixes part of #1392.

`read` supported `-r`, `-p`, `-a` and `-s`. Four of bash's options were refused with a diagnostic and exit status 2, and two of the four matter beyond missing coverage:

* `read -d ''` is the standard way to consume `find -print0`, so without it a filename-safe loop cannot be written at all.
* `-s` read from `syscall.Stdin` — the process's own descriptor — rather than the shell's stdin. Under a redirect, in a pipeline, or when the caller supplied a reader via `StdIO`, it read the wrong input and assigned nothing. It also called `term.ReadPassword` on a descriptor which usually isn't a terminal, so it failed instead of falling back to a plain read:

```console
$ printf 'hi\n' > in.txt
$ gosh -c 'read -r -s x < in.txt; echo "st=$? x=[$x]"'   # before
st=1 x=[]
$ bash -c 'read -r -s x < in.txt; echo "st=$? x=[$x]"'
st=0 x=[hi]
```

`-a` had a separate bug, present regardless of this change: it did not consume its array name as the option's argument, relying on it being the first operand, so any option written after it was misparsed as an identifier. `read -a arr -d ''` — the print0-into-array idiom — failed with `read: invalid identifier "-d"`.

### What this implements

| option | behavior |
| --- | --- |
| `-d delim` | stop at `delim` instead of newline; an empty string means ASCII NUL, matching `mapfile -d ''` |
| `-n n` | stop after `n` characters or at the delimiter, whichever comes first |
| `-N n` | read exactly `n` characters, ignoring the delimiter, with no field splitting or trimming |
| `-s` | use the shell's stdin, and only suppress the echo when it is a terminal |
| `-a name` | take the array name as the option's argument |

`readLine` now takes the delimiter, a character count, and whether the delimiter should be ignored. The count is of characters that end up assigned rather than bytes read, since the backslashes which escape another character are dropped later — bash counts the same way, so `printf 'a\bc' | read -N 3 x` gives `x=abc` in both.

An escaped delimiter becomes a literal character rather than ending the line, except for the existing newline continuation.

### Still missing

`-t` and `-u` are unimplemented, and `-s` cannot suppress a terminal's echo when combined with `-d`, `-n` or `-N`, as `x/term` only exposes a whole-line password read. I left those out rather than approximate them; happy to follow up if you'd like them in this PR.

### Testing

18 cases added to `runTests`, so they run through `TestRunnerRunConfirm` and are confirmed against real bash 5.3 rather than only against what this commit implements. I also ran a separate 37-case differential harness (patched `gosh` vs bash 5.3.15 on darwin/arm64) covering statuses, IFS trimming, escape handling and the `-n`/`-N`/`-d` interactions: 37/37 agree.

`go test ./...` shows the same four pre-existing `TestRunnerRunConfirm` failures as `master` on this machine (three tilde/`HOME` cases and `echo foo >&- 2>&-`), confirmed by stashing the patch and re-running.
