### PR TITLE
interp: implement the >| and <> redirections, and set -C

### DIFF
--- a/interp/api.go
+++ b/interp/api.go
@@ -618,6 +618,7 @@ var posixOptsTable = [...]posixOpt{
 	// sorted alphabetically by name
 	{'a', "allexport"},
 	{'e', "errexit"},
+	{'C', "noclobber"},
 	{'n', "noexec"},
 	{'f', "noglob"},
 	{'u', "nounset"},
@@ -747,13 +748,14 @@ const (
 	// These correspond to indexes in [shellOptsTable]
 	optAllExport = iota
 	optErrExit
+	optNoClobber
 	optNoExec
 	optNoGlob
 	optNoUnset
 	optXTrace
 	optPipeFail
 
-	// These correspond to indexes (offset by the above seven items) of
+	// These correspond to indexes (offset by the above eight items) of
 	// supported options in [bashOptsTable]
 	optDotGlob
 	optExpandAliases

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -1608,6 +1608,57 @@ var runTests = []runTest{
 		"",
 	},
 	{
+		// `>|` overwrites the file whether or not noclobber is set
+		"echo old >f; echo new >|f; cat f",
+		"new\n",
+	},
+	{
+		// `<>` opens for reading and writing without truncating
+		"echo hi >f; read -r l <>f; echo \"[$l]\"; cat f",
+		"[hi]\nhi\n",
+	},
+
+	// noclobber
+	{
+		`set -C; echo old >f; echo new >f; echo "st=$?"; cat f`,
+		"f: cannot overwrite existing file\nst=1\nold\n #IGNORE bash prefixes its diagnostics",
+	},
+	{
+		// the same without the diagnostic, so that bash confirms the behavior
+		`set -C; echo old >f; echo new 2>/dev/null >f; echo "st=$?"; cat f`,
+		"st=1\nold\n",
+	},
+	{
+		// writing to a file which does not exist yet is allowed
+		`set -C; echo new >f; cat f`,
+		"new\n",
+	},
+	{
+		`set -C; echo old >f; echo new >|f; cat f`,
+		"new\n",
+	},
+	{
+		`set -C; echo old >f; echo new >>f; cat f`,
+		"old\nnew\n",
+	},
+	{
+		`set -C; echo old >f; echo new 2>/dev/null &>f; echo "st=$?"; cat f`,
+		"st=1\nold\n",
+	},
+	{
+		// only regular files are protected
+		`set -C; echo x >/dev/null; echo "st=$?"`,
+		"st=0\n",
+	},
+	{
+		`set -C; set +C; echo old >f; echo new >f; cat f`,
+		"new\n",
+	},
+	{
+		`set -o noclobber; echo old >f; echo new 2>/dev/null >f; echo "st=$?"`,
+		"st=1\n",
+	},
+	{
 		"echo foo | sed $(read line 2>/dev/null; echo 's/o/a/g')",
 		"",
 	},
@@ -2547,6 +2598,7 @@ var runTests = []runTest{
 		"set -a; set +o",
 		`set -o allexport
 set +o errexit
+set +o noclobber
 set +o noexec
 set +o noglob
 set +o nounset

--- a/interp/runner.go
+++ b/interp/runner.go
@@ -1023,7 +1023,7 @@ func (r *Runner) redir(ctx context.Context, rd *syntax.Redirect) (io.Closer, err
 		}
 		return nil, nil
 	case syntax.RdrIn, syntax.RdrOut, syntax.AppOut,
-		syntax.RdrAll, syntax.AppAll:
+		syntax.RdrAll, syntax.AppAll, syntax.RdrClob, syntax.RdrInOut:
 		// done further below
 	case syntax.DplIn:
 		switch arg {
@@ -1036,25 +1036,44 @@ func (r *Runner) redir(ctx context.Context, rd *syntax.Redirect) (io.Closer, err
 	default:
 		return nil, fmt.Errorf("unhandled redirect op: %v", rd.Op)
 	}
+	// noclobber refuses to truncate an existing regular file. ">|" is the
+	// escape hatch which ignores the option, and appending or writing to a file
+	// which does not exist yet is always allowed. Note that bash only protects
+	// regular files, so ">/dev/null" keeps working.
+	if r.opts[optNoClobber] {
+		switch rd.Op {
+		case syntax.RdrOut, syntax.RdrAll:
+			if info, err := r.stat(ctx, arg); err == nil && info.Mode().IsRegular() {
+				// Note that the errors which [Runner.redir] returns are not
+				// reported by its caller, so we must report this one ourselves.
+				err := fmt.Errorf("%s: cannot overwrite existing file", arg)
+				r.errf("%v\n", err)
+				return nil, err
+			}
+		}
+	}
 	mode := os.O_RDONLY
 	switch rd.Op {
 	case syntax.AppOut, syntax.AppAll:
 		mode = os.O_WRONLY | os.O_CREATE | os.O_APPEND
-	case syntax.RdrOut, syntax.RdrAll:
+	case syntax.RdrOut, syntax.RdrAll, syntax.RdrClob:
 		mode = os.O_WRONLY | os.O_CREATE | os.O_TRUNC
+	case syntax.RdrInOut:
+		// "<>" opens for reading and writing without truncating.
+		mode = os.O_RDWR | os.O_CREATE
 	}
 	f, err := r.open(ctx, arg, mode, 0o644, true)
 	if err != nil {
 		return nil, err
 	}
 	switch rd.Op {
-	case syntax.RdrIn:
+	case syntax.RdrIn, syntax.RdrInOut:
 		stdin, err := stdinFile(f)
 		if err != nil {
 			return nil, err
 		}
 		r.stdin = stdin
-	case syntax.RdrOut, syntax.AppOut:
+	case syntax.RdrOut, syntax.AppOut, syntax.RdrClob:
 		*orig = f
 	case syntax.RdrAll, syntax.AppAll:
 		r.stdout = f


### PR DESCRIPTION
Fixes #1394. Also implements the `-C` part of #1392's `set` gaps.

Neither `>|` nor `<>` had a case in the redirect switch, so both fell through to its `default` and returned an error which `stmtSync` drops. They did nothing at all, with no diagnostic, and exit status 1:

```console
$ gosh -c 'echo hi >| f'; echo "st=$?"; cat f
st=1
cat: f: No such file or directory
$ bash -c 'echo hi >| f'; echo "st=$?"; cat f
st=0
hi

$ gosh -c 'echo hi > f; read -r l <> f; echo "[$l]"'
[]
$ bash -c 'echo hi > f; read -r l <> f; echo "[$l]"'
[hi]
```

`>|` is only meaningful as noclobber's escape hatch, and noclobber was itself missing, so this adds `set -C` too — they are two halves of one behavior and implementing either alone leaves the other wrong.

### noclobber

Matching bash: `-C` refuses to truncate an existing **regular** file, appending is unaffected, a file which does not exist yet is fine, and non-regular files such as `/dev/null` are not protected. `>|` ignores the option.

```console
$ gosh -c 'set -C; echo old >f; echo new >f; echo "st=$?"; cat f'
f: cannot overwrite existing file
st=1
old
```

### One implementation note

The diagnostic is printed where it is raised rather than by the caller of `Runner.redir`. I first tried reporting all of `redir`'s errors in `stmtSync`, which is tempting since it would also make `3>` and the unhandled dup arguments stop failing silently — but `Runner.open` already reports its own errors, and the handler's fatal errors go through `exit.fatal`, so a blanket report prints those twice (`TestRunnerHandlers/OpenForbidNonDev` catches it). Untangling that is worth doing, but it belongs with #1389 rather than here, so the sibling gaps in this switch are deliberately left silent.

### Testing

12 cases added to `runTests`. Three assert the diagnostic and are marked `#IGNORE bash prefixes its diagnostics`; each of those has a twin which suppresses stderr *before* the failing redirect, so bash confirms the status and the file contents through `TestRunnerRunConfirm`.

That ordering matters and is not cosmetic: with `2>/dev/null` written *after* the failing redirect, both shells still print the message, because redirections are applied left to right and the failure happens before stderr is replaced. My first draft of these tests put it after and normalized bash's `bash: line N:` prefix away, which hid the message entirely and made a correct implementation look wrong.

`go test ./...` shows the same four pre-existing `TestRunnerRunConfirm` failures as `master` on this machine (three tilde/`HOME` cases and `echo foo >&- 2>&-`), confirmed by stashing and re-running. Separately verified against bash 5.3.15 on darwin/arm64 with an 18-case differential harness: the only two divergences left are `$-` not listing `C` (#1398) and `set -o`'s column padding, neither introduced here.
