### PR TITLE
interp: add ProcSubstOpen handler for process substitution

### DIFF
--- a/interp/api.go
+++ b/interp/api.go
@@ -105,6 +105,10 @@ type Runner struct {
 	// accessHandler is a function responsible for checking file access. It must be non-nil.
 	accessHandler AccessHandlerFunc
 
+	// procSubstOpen is a function responsible for creating the communication
+	// channel for process substitutions. It must be non-nil.
+	procSubstOpen ProcSubstOpenFunc
+
 	stdin  stdinFile // e.g. the read end of a pipe
 	stdout io.Writer
 	stderr io.Writer
@@ -332,6 +336,7 @@ func New(opts ...RunnerOption) (*Runner, error) {
 		readDirHandler:       DefaultReadDirHandler2(),
 		statHandler:          DefaultStatHandler(),
 		accessHandler:        DefaultAccessHandler(),
+		procSubstOpen:        DefaultProcSubstOpen(),
 	}
 	r.dirStack = r.dirBootstrap[:0]
 	// turn "on" the default Bash options
@@ -662,6 +667,15 @@ func AccessHandler(f AccessHandlerFunc) RunnerOption {
 	}
 }
 
+// ProcSubstOpen sets the handler used to implement process substitution.
+// See [ProcSubstOpenFunc] for more info.
+func ProcSubstOpen(f ProcSubstOpenFunc) RunnerOption {
+	return func(r *Runner) error {
+		r.procSubstOpen = f
+		return nil
+	}
+}
+
 // StdIO configures an interpreter's standard input, standard output, and
 // standard error. If out or err are nil, they default to a writer that discards
 // the output.
@@ -953,6 +967,7 @@ func (r *Runner) Reset() {
 		readDirHandler:       r.readDirHandler,
 		statHandler:          r.statHandler,
 		accessHandler:        r.accessHandler,
+		procSubstOpen:        r.procSubstOpen,
 
 		// These can be set by functions like [Dir] or [Params], but
 		// builtins can overwrite them; reset the fields to whatever the
@@ -1146,6 +1161,7 @@ func (r *Runner) subshell(background bool) *Runner {
 		readDirHandler:       r.readDirHandler,
 		statHandler:          r.statHandler,
 		accessHandler:        r.accessHandler,
+		procSubstOpen:        r.procSubstOpen,
 		stdin:                r.stdin,
 		stdout:               r.stdout,
 		stderr:               r.stderr,

--- a/interp/handler.go
+++ b/interp/handler.go
@@ -10,11 +10,14 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	mathrand "math/rand/v2"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"mvdan.cc/sh/v3/expand"
@@ -37,13 +40,14 @@ type handlerCtxKey struct{}
 type handlerKind int
 
 const (
-	_                  handlerKind = iota
-	handlerKindExec                // [ExecHandlerFunc]
-	handlerKindCall                // [CallHandlerFunc]
-	handlerKindOpen                // [OpenHandlerFunc]
-	handlerKindReadDir             // [ReadDirHandlerFunc2]
-	handlerKindStat                // [StatHandlerFunc]
-	handlerKindAccess              // [AccessHandlerFunc]
+	_                    handlerKind = iota
+	handlerKindExec                  // [ExecHandlerFunc]
+	handlerKindCall                  // [CallHandlerFunc]
+	handlerKindOpen                  // [OpenHandlerFunc]
+	handlerKindReadDir               // [ReadDirHandlerFunc2]
+	handlerKindStat                  // [StatHandlerFunc]
+	handlerKindAccess                // [AccessHandlerFunc]
+	handlerKindProcSubst             // [ProcSubstOpenFunc]
 )
 
 // HandlerContext is the data passed to all the handler functions via [context.WithValue].
@@ -378,7 +382,8 @@ func pathExts(env expand.Environ) []string {
 
 // OpenHandlerFunc is a handler which opens files.
 // It is called for all files that are opened directly by the shell,
-// such as in redirects, except for named pipes created by process substitutions.
+// such as in redirects, except for named pipes created by process substitutions;
+// see [ProcSubstOpenFunc] for those.
 // The context includes a [HandlerContext] value.
 // Files opened by executed programs are not included.
 //
@@ -497,4 +502,102 @@ type AccessHandlerFunc func(ctx context.Context, path string, mode AccessMode) e
 // approximates the check via the stat handler and the file's permission bits.
 func DefaultAccessHandler() AccessHandlerFunc {
 	return defaultAccess
+}
+
+// ProcSubstOpenFunc is a handler which creates the communication channel for
+// a process substitution ("<(cmd)" for [syntax.CmdIn], ">(cmd)" for
+// [syntax.CmdOut]). It returns the path to substitute in place of the
+// "<(...)"/">(...)" word, a handle the interpreter reads or writes
+// directly, and a cleanup func run once the subshell goroutine exits.
+//
+// Unlike [OpenHandlerFunc], it owns the full lifecycle (create, open,
+// remove), since named pipes need creation and teardown a plain
+// (path, flag, perm) -> [io.ReadWriteCloser] signature can't express.
+type ProcSubstOpenFunc func(ctx context.Context, op syntax.ProcOperator) (path string, rwc io.ReadWriteCloser, cleanup func(), err error)
+
+// DefaultProcSubstOpen returns the [ProcSubstOpenFunc] used by default.
+// It creates a real named pipe under the runner's temporary directory via
+// mkfifo, and opens it with [os.OpenFile].
+func DefaultProcSubstOpen() ProcSubstOpenFunc {
+	return func(ctx context.Context, op syntax.ProcOperator) (string, io.ReadWriteCloser, func(), error) {
+		mc := HandlerCtx(ctx)
+
+		// We can't atomically create a random unused temporary FIFO.
+		// Similar to [os.CreateTemp],
+		// keep trying new random paths until one does not exist.
+		// We use a uint64 because a uint32 easily runs into retries.
+		var path string
+		try := 0
+		for {
+			path = filepath.Join(mc.runner.tempDir, fifoNamePrefix+strconv.FormatUint(mathrand.Uint64(), 16))
+			err := mkfifo(path, 0o666)
+			if err == nil {
+				break
+			}
+			if !os.IsExist(err) {
+				return "", nil, nil, fmt.Errorf("cannot create fifo: %v", err)
+			}
+			if try++; try > 100 {
+				return "", nil, nil, fmt.Errorf("giving up at creating fifo: %v", err)
+			}
+		}
+
+		cleanup := func() { os.Remove(path) }
+
+		var flag int
+		switch op {
+		case syntax.CmdIn:
+			flag = os.O_WRONLY
+		case syntax.CmdOut:
+			flag = os.O_RDONLY
+		default:
+			cleanup()
+			panic(fmt.Sprintf("unexpected process substitution operator: %q", op))
+		}
+
+		// Opening a FIFO blocks until a peer opens the other end, and
+		// that peer only runs after this returns the substituted path.
+		// Defer the open to the first read/write, once the peer is live.
+		return path, &lazyFifo{path: path, flag: flag}, cleanup, nil
+	}
+}
+
+// lazyFifo opens a FIFO path lazily, on first read, write, or close,
+// since opening it eagerly would block until a peer connects.
+type lazyFifo struct {
+	path string
+	flag int
+
+	once sync.Once
+	f    *os.File
+	err  error
+}
+
+func (l *lazyFifo) open() (*os.File, error) {
+	l.once.Do(func() { l.f, l.err = os.OpenFile(l.path, l.flag, 0) })
+	return l.f, l.err
+}
+
+func (l *lazyFifo) Read(p []byte) (int, error) {
+	f, err := l.open()
+	if err != nil {
+		return 0, err
+	}
+	return f.Read(p)
+}
+
+func (l *lazyFifo) Write(p []byte) (int, error) {
+	f, err := l.open()
+	if err != nil {
+		return 0, err
+	}
+	return f.Write(p)
+}
+
+func (l *lazyFifo) Close() error {
+	f, err := l.open()
+	if err != nil {
+		return err
+	}
+	return f.Close()
 }

--- a/interp/handler_test.go
+++ b/interp/handler_test.go
@@ -55,6 +55,45 @@ func mockFileOpen(ctx context.Context, path string, flags int, mode os.FileMode)
 	return nopWriterCloser{strings.NewReader(fmt.Sprintf("body of %s", path))}, nil
 }
 
+// virtualProcSubst is an in-memory ProcSubstOpenFunc backed by [io.Pipe].
+// It hands the runner one end and keeps the other under a fake path for
+// a paired OpenHandler to serve, so no real filesystem entry is touched.
+type virtualProcSubst struct {
+	counter int
+	ends    map[string]io.ReadWriteCloser
+}
+
+func (v *virtualProcSubst) open(ctx context.Context, op syntax.ProcOperator) (string, io.ReadWriteCloser, func(), error) {
+	v.counter++
+	path := fmt.Sprintf("virtual-procsubst-%d", v.counter)
+	pr, pw := io.Pipe()
+	switch op {
+	case syntax.CmdIn:
+		v.ends[path] = readOnlyRWC{pr}
+		return path, writeOnlyRWC{pw}, nil, nil
+	case syntax.CmdOut:
+		v.ends[path] = writeOnlyRWC{pw}
+		return path, readOnlyRWC{pr}, nil, nil
+	default:
+		panic(fmt.Sprintf("unexpected process substitution operator: %q", op))
+	}
+}
+
+func (v *virtualProcSubst) openHandler(ctx context.Context, path string, flags int, mode os.FileMode) (io.ReadWriteCloser, error) {
+	if rwc, ok := v.ends[path]; ok {
+		return rwc, nil
+	}
+	return interp.DefaultOpenHandler()(ctx, path, flags, mode)
+}
+
+type readOnlyRWC struct{ io.ReadCloser }
+
+func (readOnlyRWC) Write(p []byte) (int, error) { return 0, fmt.Errorf("read-only") }
+
+type writeOnlyRWC struct{ io.WriteCloser }
+
+func (writeOnlyRWC) Read(p []byte) (int, error) { return 0, io.EOF }
+
 func blocklistGlob(ctx context.Context, path string) ([]fs.FileInfo, error) {
 	return nil, fmt.Errorf("blocklisted: glob")
 }
@@ -395,8 +434,8 @@ var modCases = []struct {
 		opts: []interp.RunnerOption{
 			interp.OpenHandler(mockFileOpen),
 		},
-		src:  "echo $(<foo); echo $(< <(echo bar))",
-		want: "body of foo\nbar\n",
+		src:  "echo $(<foo)",
+		want: "body of foo\n",
 	},
 	{
 		name: "CallReplaceWithBlank",
@@ -457,7 +496,18 @@ var modCases = []struct {
 		src:  "cd vdir && echo ok",
 		want: "ok\n",
 	},
+	{
+		name: "ProcSubstVirtual",
+		opts: []interp.RunnerOption{
+			interp.ProcSubstOpen(procSubstVirtual.open),
+			interp.OpenHandler(procSubstVirtual.openHandler),
+		},
+		src:  "read -r line < <(echo bar); echo \"$line\"",
+		want: "bar\n",
+	},
 }
+
+var procSubstVirtual = &virtualProcSubst{ends: map[string]io.ReadWriteCloser{}}
 
 func TestRunnerHandlers(t *testing.T) {
 	t.Parallel()

--- a/interp/runner.go
+++ b/interp/runner.go
@@ -13,9 +13,7 @@ import (
 	"io/fs"
 	"iter"
 	"math"
-	mathrand "math/rand/v2"
 	"os"
-	"path/filepath"
 	"runtime"
 	"slices"
 	"strconv"
@@ -86,24 +84,9 @@ func (r *Runner) fillExpandConfig(ctx context.Context) {
 				return os.DevNull, nil
 			}
 
-			// We can't atomically create a random unused temporary FIFO.
-			// Similar to [os.CreateTemp],
-			// keep trying new random paths until one does not exist.
-			// We use a uint64 because a uint32 easily runs into retries.
-			var path string
-			try := 0
-			for {
-				path = filepath.Join(r.tempDir, fifoNamePrefix+strconv.FormatUint(mathrand.Uint64(), 16))
-				err := mkfifo(path, 0o666)
-				if err == nil {
-					break
-				}
-				if !os.IsExist(err) {
-					return "", fmt.Errorf("cannot create fifo: %v", err)
-				}
-				if try++; try > 100 {
-					return "", fmt.Errorf("giving up at creating fifo: %v", err)
-				}
+			path, rwc, cleanup, err := r.procSubstOpen(r.handlerCtx(ctx, handlerKindProcSubst, todoPos), ps.Op)
+			if err != nil {
+				return "", err
 			}
 
 			r2 := r.subshell(true)
@@ -119,30 +102,28 @@ func (r *Runner) fillExpandConfig(ctx context.Context) {
 				}()
 				switch ps.Op {
 				case syntax.CmdIn:
-					f, err := os.OpenFile(path, os.O_WRONLY, 0)
-					if err != nil {
-						r.errf("cannot open fifo for stdout: %v\n", err)
-						return
-					}
-					r2.stdout = f
+					r2.stdout = rwc
 					defer func() {
-						if err := f.Close(); err != nil {
-							r.errf("closing stdout fifo: %v\n", err)
+						if err := rwc.Close(); err != nil {
+							r.errf("closing process substitution: %v\n", err)
 						}
-						os.Remove(path)
+						if cleanup != nil {
+							cleanup()
+						}
 					}()
 				case syntax.CmdOut:
-					f, err := os.OpenFile(path, os.O_RDONLY, 0)
+					stdin, err := newStdinFile(rwc)
 					if err != nil {
-						r.errf("cannot open fifo for stdin: %v\n", err)
+						r.errf("cannot use process substitution as stdin: %v\n", err)
 						return
 					}
-					r2.stdin = f
+					r2.stdin = stdin
 					r2.stdout = stdout
-
 					defer func() {
-						f.Close()
-						os.Remove(path)
+						rwc.Close()
+						if cleanup != nil {
+							cleanup()
+						}
 					}()
 				default:
 					// Should only happen if we forgot a case above.
@@ -1221,19 +1202,6 @@ func (r *Runner) exec(ctx context.Context, pos syntax.Pos, args []string) {
 }
 
 func (r *Runner) open(ctx context.Context, path string, flags int, mode os.FileMode, print bool) (io.ReadWriteCloser, error) {
-	// If we are opening a FIFO temporary file created by the interpreter itself,
-	// don't pass this along to the open handler as it will not work at all
-	// unless [os.OpenFile] is used directly with it.
-	// Matching by directory and basename prefix isn't perfect, but works.
-	//
-	// If we want FIFOs to use a handler in the future, they probably
-	// need their own separate handler API matching Unix-like semantics.
-	dir, name := filepath.Split(path)
-	dir = strings.TrimSuffix(dir, "/")
-	if dir == r.tempDir && strings.HasPrefix(name, fifoNamePrefix) {
-		return os.OpenFile(path, flags, mode)
-	}
-
 	f, err := r.openHandler(r.handlerCtx(ctx, handlerKindOpen, todoPos), path, flags, mode)
 	// TODO: support wrapped PathError returned from openHandler.
 	switch err.(type) {


### PR DESCRIPTION
Process substitution always creates a real named pipe on disk via mkfifo
and os.OpenFile, no matter what OpenHandler/StatHandler/AccessHandler are
set to, so it's a hole straight to the real filesystem for anyone
sandboxing file I/O.

This is #1120, where you left the door open for a handler:

> perhaps they do need to be split apart from the open handler entirely...
> I think FIFOs could become another handler if users need that.

I've taken a crack at implementing it. ProcSubstOpen owns the whole FIFO
lifecycle (create, open, remove), since a plain (path, flag, perm) open
can't express mkfifo + cleanup. DefaultProcSubstOpen is the old logic
moved into handler.go, same behavior, except the actual open is now
deferred to the first read/write, since opening a FIFO blocks until a
peer connects and that peer isn't running yet when the path is returned.

This also meant removing the bit in r.open that special-cased FIFO
paths to skip OpenHandler, since creation is now handler-owned. Happy
to reconsider that if you'd rather keep it separate.

Updated the tests accordingly, including a new one (ProcSubstVirtual)
that pairs ProcSubstOpen with OpenHandler over an in-memory io.Pipe and
checks nothing touches the real filesystem.


## Motivation

I'm using this shell intepreter package to implement a simple Bash sandbox with WASI as the execution provider which supports [`fs.FS`](https://pkg.go.dev/io/fs#FS). I had implemented the `OpenHandler` based on the `fs.FS` but just for the ProcessSubstitution there seemed to be a sandbox breakage. In this case, I can implement the ProcSub + OpenHandler to handle the Pipe implementation (plan to use channels). Left the DefaultHandler to the original behaviour.