### PR TITLE
syntax: fix parsing a quoted $# in zsh

### DIFF
--- a/syntax/filetests_test.go
+++ b/syntax/filetests_test.go
@@ -2339,6 +2339,14 @@ var fileTests = []fileTestCase{
 		langFile(dblQuoted(litParamExp("!"))),
 	),
 	fileTest(
+		[]string{`"$#"`},
+		langFile(dblQuoted(litParamExp("#"))),
+	),
+	fileTest(
+		[]string{`$#"$foo"`},
+		langFile(word(litParamExp("#"), dblQuoted(litParamExp("foo")))),
+	),
+	fileTest(
 		[]string{`$`, `$ #`},
 		langFile(litWord("$")),
 	),

--- a/syntax/parser.go
+++ b/syntax/parser.go
@@ -1518,22 +1518,22 @@ zshPrefixLoop:
 		// Note that in Zsh, the short form like $#name is allowed too.
 		switch p.r {
 		case '#':
-			if p.paramNameStart() {
+			if p.paramNameStart(pe.Short) {
 				pe.Length = true
 			}
 		case '%':
-			if p.paramNameStart() {
+			if p.paramNameStart(pe.Short) {
 				p.checkLang(pe.Pos(), LangMirBSDKorn, "`${%%foo}`")
 				pe.Width = true
 			}
 		case '!':
 			// Unlike the others, zsh has no $!foo prefix.
-			if !pe.Short && p.paramNameStart() {
+			if !pe.Short && p.paramNameStart(false) {
 				p.checkLang(pe.Pos(), langBashLike|LangMirBSDKorn, "`${!foo}`")
 				pe.Excl = true
 			}
 		case '+':
-			if p.paramNameStart() {
+			if p.paramNameStart(pe.Short) {
 				p.checkLang(pe.Pos(), LangZsh, "`${+foo}`")
 				pe.IsSet = true
 			}
@@ -1674,8 +1674,14 @@ zshPrefixLoop:
 	return pe
 }
 
-func (p *Parser) paramNameStart() bool {
+func (p *Parser) paramNameStart(short bool) bool {
 	r := p.peek()
+	if short && r == '"' {
+		// In the short form like $# or $+, a double quote cannot start
+		// a parameter name; "$#" is the special parameter, and $#"$foo"
+		// is $# followed by a quoted word.
+		return false
+	}
 	if r == utf8.RuneSelf || singleRuneParam(r) || paramNameRune(r) || r == '"' {
 		p.rune()
 		return true


### PR DESCRIPTION
Fixes #1405.

## The problem

In Zsh mode, a double quote directly following `$#` in the short form
was treated as the start of a quoted parameter name. The parser then
consumed both the `#` and the `"` as a length prefix, failed to parse
a parameter name afterwards, and the expansion collapsed to a bare `$`:

```console
$ printf 'if [ "$#" -lt 2 ]; then\n\techo "$#"\nfi\n' | shfmt -ln=zsh  # before
if [ "$" -lt 2 ]; then
	echo "$"
fi
```

This silently changes semantics, as `$` expands to the shell PID in Zsh,
and `zsh -n` cannot detect it.

## Root cause

`paramNameStart` accepted `"` as the start of a parameter name, which
is correct for the long form, where Zsh nested expansions in quotes
like `${#"${foo}"}` exist (#1214). But in the short form the `"` is
never part of the expansion: real Zsh treats `"$#"` as the special
parameter, and `$#"$foo"` as `$#` followed by a quoted word:

```console
% set -- x y; echo "$#"; echo $#"foo"
2
2foo
```

The same applied to the `%` and `+` short prefixes.

## The fix

Pass whether the expansion is the short form into `paramNameStart` and
refuse a leading `"` in that case. The long form keeps accepting
quoted parameter names, so `${#"${foo}"}` still parses as before.

Added parser regression tests for `"$#"` and `$#"$foo"`.