### PR TITLE
README: add PyPI to the list of packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For more information, see [its manpage](cmd/shfmt/shfmt.1.scd), which can be
 viewed directly as Markdown or rendered with [scdoc].
 
 Packages are available on [Alpine], [Arch], [Debian], [Docker], [Fedora], [FreeBSD],
-[Homebrew], [MacPorts], [NixOS], [OpenSUSE], [Scoop], [Snapcraft], [Void] and [webi].
+[Homebrew], [MacPorts], [NixOS], [OpenSUSE], [PyPI], [Scoop], [Snapcraft], [Void] and [webi].
 
 ### Sponsoring
 
@@ -173,6 +173,7 @@ Other noteworthy integrations include:
 [pre-commit-shfmt]: https://github.com/scop/pre-commit-shfmt
 [prettier-plugin-sh]: https://github.com/un-ts/prettier/tree/master/packages/sh
 [prettier]: https://prettier.io
+[PyPI]: https://pypi.org/project/shfmt-py/
 [scdoc]: https://sr.ht/~sircmpwn/scdoc/
 [scoop]: https://github.com/ScoopInstaller/Main/blob/HEAD/bucket/shfmt.json
 [sh-checker]: https://github.com/luizm/action-sh-checker


### PR DESCRIPTION
shfmt-py packages the released shfmt binaries as wheels on PyPI, so `pip install shfmt-py` (or `uv tool install` / `pipx`) puts shfmt on PATH. Packaging only: no patches, no wrapper code, and the wheels ship your BSD-3-Clause notice next to the binary.

I have maintained it since 2021, and Renovate opens the version bumps, so it usually follows a release within a day or two. 3.14.0 is already on master.

Why I think it earns a word in that list: in Python projects and CI images with no Go toolchain and no root for the system package manager, pip is the package manager that is already there. That is a different audience from the distro packages listed.

It does also ship a pre-commit hook, but that is not what I am asking about here, scop/pre-commit-shfmt has that covered. This is only about the PyPI entry.

Fine by me if you would rather keep that list to system package managers.
