### PR TITLE
syntax: preserve indentation in nested tab heredocs

### DIFF
--- a/syntax/printer.go
+++ b/syntax/printer.go
@@ -1620,6 +1620,13 @@ func (e *extraIndenter) WriteString(s string) (int, error) {
 	return len(s), nil
 }
 
+func (e *extraIndenter) Write(b []byte) (int, error) {
+	for i := range len(b) {
+		e.WriteByte(b[i])
+	}
+	return len(b), nil
+}
+
 func startsWithLparen(node Node) bool {
 	switch node := node.(type) {
 	case *Stmt:

--- a/syntax/printer_test.go
+++ b/syntax/printer_test.go
@@ -544,6 +544,7 @@ var printTests = []printCase{
 		"f <<-EOF\n\t{\n\t\ttoo little indented\n\t}\nEOF",
 	},
 	samePrint("<<-EOF\n\t$foo\nEOF\n\n{\n\tbar\n}"),
+	samePrint("f <<-A\n\ta $(\n\t\tg <<-B\n\t\t\tb1\n\t\t\tb2\n\t\tB\n\t)\nA"),
 	samePrint("f <<EOF\nEOF\n# comment"),
 	samePrint("f <<EOF\nEOF\n# comment\nbar"),
 	samePrint("f <<EOF # inline\n$(\n\t# inside\n)\nEOF\n# outside\nbar"),


### PR DESCRIPTION
## Summary

- route byte-slice writes through `extraIndenter.WriteByte`, matching its existing string path
- add a regression case for nested `<<-` heredocs

The bug is specific to nesting because an inner `extraIndenter` flushes each completed line with `e.bufWriter.Write`. When that underlying writer is an outer `extraIndenter`, its embedded `Write` method was promoted and bypassed the outer writer's per-line indentation state. Implementing `Write` on `extraIndenter` keeps every writer entry point on the same path.

## Test

- `go test ./...`

Fixes #1403