### PR TITLE
syntax: fix nested heredoc indentation

### DIFF
--- a/syntax/printer.go
+++ b/syntax/printer.go
@@ -1597,7 +1597,7 @@ func (e *extraIndenter) WriteByte(b byte) error {
 	} else if lineIndent < e.firstIndent {
 		// This line did not have enough indentation; simply indent it
 		// like the first line.
-		lineIndent = e.firstIndent
+		lineIndent = e.baseIndent
 	} else {
 		// This line had plenty of indentation. Add the extra
 		// indentation that the first line had, for consistency.

--- a/syntax/printer.go
+++ b/syntax/printer.go
@@ -1620,6 +1620,13 @@ func (e *extraIndenter) WriteString(s string) (int, error) {
 	return len(s), nil
 }
 
+func (e *extraIndenter) Write(b []byte) (int, error) {
+	for i := range len(b) {
+		e.WriteByte(b[i])
+	}
+	return len(b), nil
+}
+
 func startsWithLparen(node Node) bool {
 	switch node := node.(type) {
 	case *Stmt:

--- a/syntax/printer_test.go
+++ b/syntax/printer_test.go
@@ -545,6 +545,7 @@ var printTests = []printCase{
 	},
 	samePrint("<<-EOF\n\t$foo\nEOF\n\n{\n\tbar\n}"),
 	samePrint("f <<-A\n\ta $(\n\t\tg <<-B\n\t\t\tb1\n\t\t\tb2\n\t\tB\n\t)\nA"),
+	samePrint("f <<-A\n\ta $(\n\t\tg <<-B\n\t\t\tb $(\n\t\t\t\th <<-C\n\t\t\t\t\tc1\n\t\t\t\tC\n\t\t\t)\n\t\tB\n\t)\nA"),
 	samePrint("f <<EOF\nEOF\n# comment"),
 	samePrint("f <<EOF\nEOF\n# comment\nbar"),
 	samePrint("f <<EOF # inline\n$(\n\t# inside\n)\nEOF\n# outside\nbar"),

--- a/syntax/printer_test.go
+++ b/syntax/printer_test.go
@@ -544,6 +544,7 @@ var printTests = []printCase{
 		"f <<-EOF\n\t{\n\t\ttoo little indented\n\t}\nEOF",
 	},
 	samePrint("<<-EOF\n\t$foo\nEOF\n\n{\n\tbar\n}"),
+	samePrint("f <<-A\n\ta $(\n\t\tg <<-B\n\t\t\tb1\n\t\t\tb2\n\t\tB\n\t)\nA"),
 	samePrint("f <<EOF\nEOF\n# comment"),
 	samePrint("f <<EOF\nEOF\n# comment\nbar"),
 	samePrint("f <<EOF # inline\n$(\n\t# inside\n)\nEOF\n# outside\nbar"),


### PR DESCRIPTION
Continuing the explanation from https://github.com/mvdan/sh/issues/1403#issuecomment-5452323702:

The `Write` method is only really used when writing the content of a heredoc. In the normal case, one level of heredoc, this is fine. Everything in it will use `WriteByte` which handles the heredoc indentation.

Where it went wrong is with an inner heredoc. In that situation the inner `extraIndenter` writes only the tabs to the buffer of the outer heredoc, while writing the trimmed content directly to the outer `Write` (which is a `bufio.Writer` I think). This results in the content of the inner heredoc having no tabs, which accumulate in the buffer and are output with the ending marker.

This fix defines a `Write` method for `extraIndenter` that forwards the writes to the `WriteByte` (like `WriteString`) so that all writes are via the same path, as intended, and inner heredocs do not bypass it anymore.

Fixes #1403