### PR TITLE
interp: support shopt -q to query option states

### DIFF
--- a/interp/builtin.go
+++ b/interp/builtin.go
@@ -816,6 +816,7 @@ func (r *Runner) builtin(ctx context.Context, pos syntax.Pos, name string, args 
 
 	case "shopt":
 		mode := ""
+		quiet := false
 		posixOpts := false
 		fp := flagParser{remaining: args}
 		for fp.more() {
@@ -824,7 +825,9 @@ func (r *Runner) builtin(ctx context.Context, pos syntax.Pos, name string, args 
 				mode = flag
 			case "-o":
 				posixOpts = true
-			case "-p", "-q":
+			case "-q":
+				quiet = true
+			case "-p":
 				return failf(2, "shopt: unsupported option %q\n", flag)
 			default:
 				return failf(2, "shopt: invalid option %q\n", flag)
@@ -832,6 +835,10 @@ func (r *Runner) builtin(ctx context.Context, pos syntax.Pos, name string, args 
 		}
 		args := fp.args()
 		if len(args) == 0 {
+			if quiet {
+				// Querying with no names is a no-op, like in Bash.
+				break
+			}
 			if posixOpts {
 				for i, opt := range &posixOptsTable {
 					r.printOptLine(opt.name, r.opts[i], true)
@@ -843,6 +850,7 @@ func (r *Runner) builtin(ctx context.Context, pos syntax.Pos, name string, args 
 			}
 			break
 		}
+		allSet := true
 		for _, arg := range args {
 			opt, supported := (*bool)(nil), true
 			if posixOpts {
@@ -861,9 +869,18 @@ func (r *Runner) builtin(ctx context.Context, pos syntax.Pos, name string, args 
 				}
 				*opt = mode == "-s"
 			default: // ""
-				r.printOptLine(arg, *opt, supported)
+				if quiet {
+					// Query the option's current state without printing;
+					// the exit status below is 0 if all are set, 1 otherwise.
+					if !*opt {
+						allSet = false
+					}
+				} else {
+					r.printOptLine(arg, *opt, supported)
+				}
 			}
 		}
+		exit.oneIf(quiet && mode == "" && !allSet)
 		r.updateExpandOpts()
 
 	case "alias":

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -2812,6 +2812,23 @@ done <<< 2`,
 		"shopt -o -s nosuchname",
 		"shopt: invalid option name \"nosuchname\"\nexit status 1 #JUSTERR",
 	},
+	// shopt -q queries option states without printing
+	{
+		"shopt -s nullglob; shopt -q nullglob; echo q=$?; shopt -u nullglob; shopt -q nullglob; echo q=$?",
+		"q=0\nq=1\n",
+	},
+	{
+		"shopt -s nullglob globstar; shopt -q nullglob globstar; echo q=$?; shopt -u nullglob; shopt -q nullglob globstar; echo q=$?",
+		"q=0\nq=1\n",
+	},
+	{
+		"shopt -q nosuchname",
+		"shopt: invalid option name \"nosuchname\"\nexit status 1 #JUSTERR",
+	},
+	{
+		"shopt -q; echo q=$?",
+		"q=0\n",
+	},
 	{
 		"touch a .b ..c; shopt -u dotglob; echo *",
 		"a\n",
@@ -2851,8 +2868,8 @@ done <<< 2`,
 		"shopt: unsupported option \"-p\"\nexit status 2 #IGNORE",
 	},
 	{
-		"shopt -q",
-		"shopt: unsupported option \"-q\"\nexit status 2 #IGNORE",
+		"shopt -q; echo q=$?",
+		"q=0\n",
 	},
 
 	// IFS


### PR DESCRIPTION
shopt -q was being rejected as an unsupported option like -p, but bash uses it to query the current value of one or more options

it prints nothing, and the exit status is 0 when all of the named options are set and 1 otherwise

so this adds a -q flag to the shopt builtin that reads the option states without printing, and reports the result via the exit status, like bash does

a few things match bash too:
- shopt -q with no names is a no-op that returns 0
- shopt -q -o <opt> queries posix options
- combining -q with -s or -u still does the set or unset, -q only suppresses the output
- an invalid option name still errors

tested against bash 5.2 with the confirm suite, plus new table cases that fail without the change

Signed-off-by: titof <hktitof@gmail.com>