### PR TITLE
interp: implement the enable, compgen, history and logout builtins

### DIFF
--- a/interp/api.go
+++ b/interp/api.go
@@ -206,6 +206,16 @@ type Runner struct {
 	// It is consumed by the enclosing statement once it finishes.
 	keepRedirs bool
 
+	// disabledBuiltins holds the names turned off by `enable -n`, which are
+	// then looked up as external commands like bash does.
+	disabledBuiltins map[string]bool
+
+	// historyList and historyClear back the history builtin. They are nil
+	// unless the embedder supplied them with [History]; this interpreter does
+	// not read input lines itself, so only a line editor above it knows them.
+	historyList  func() []string
+	historyClear func()
+
 	// Fake signal callbacks
 	callbackErr  string
 	callbackExit string
@@ -443,6 +453,20 @@ func Dir(path string) RunnerOption {
 			return fmt.Errorf("%s is not a directory", path)
 		}
 		r.Dir = path
+		return nil
+	}
+}
+
+// History supplies the command history to the history builtin. list returns the
+// history oldest first, and clear, which may be nil, discards it.
+//
+// The interpreter never reads input lines itself, so it has no history of its
+// own; only the line editor above it has one. Without this option, history
+// reports that no history list is available.
+func History(list func() []string, clear func()) RunnerOption {
+	return func(r *Runner) error {
+		r.historyList = list
+		r.historyClear = clear
 		return nil
 	}
 }
@@ -992,6 +1016,8 @@ func (r *Runner) Reset() {
 		accessHandler:        r.accessHandler,
 		procSubstHandler:     r.procSubstHandler,
 		procSubsts:           r.procSubsts,
+		historyList:          r.historyList,
+		historyClear:         r.historyClear,
 
 		// These can be set by functions like [Dir] or [Params], but
 		// builtins can overwrite them; reset the fields to whatever the
@@ -1257,9 +1283,12 @@ func (r *Runner) subshell(background bool) *Runner {
 		usedNew:              r.usedNew,
 		exit:                 r.exit,
 		lastExit:             r.lastExit,
+		historyList:          r.historyList,
+		historyClear:         r.historyClear,
 
 		origStdout: r.origStdout, // used for process substitutions
 	}
+	r2.disabledBuiltins = maps.Clone(r.disabledBuiltins)
 	r2.writeEnv = newOverlayEnviron(r.writeEnv, background)
 	// Funcs are copied, since they might be modified.
 	r2.Funcs = maps.Clone(r.Funcs)

--- a/interp/bashbuiltin.go
+++ b/interp/bashbuiltin.go
@@ -1,0 +1,364 @@
+// Copyright (c) 2017, Daniel Martí <mvdan@mvdan.cc>
+// See LICENSE for licensing information
+
+package interp
+
+// Bash builtins that are not about running commands: enable, compgen, history
+// and logout.
+
+import (
+	"context"
+	"maps"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+
+	"mvdan.cc/sh/v3/expand"
+)
+
+// posixSpecialBuiltins are the ones POSIX calls special, listed by `enable -s`.
+var posixSpecialBuiltins = []string{
+	":", ".", "break", "continue", "eval", "exec", "exit", "export",
+	"readonly", "return", "set", "shift", "source", "times", "trap", "unset",
+}
+
+// builtinDisabled reports whether `enable -n` turned a builtin off, in which
+// case it is looked up as an external command instead.
+func (r *Runner) builtinDisabled(name string) bool {
+	return r.disabledBuiltins[name]
+}
+
+// runEnable implements the enable builtin. Disabling a builtin makes the shell
+// fall through to the exec handler for that name, which is the point of the
+// builtin in bash too — running the real /bin/echo, say.
+func (r *Runner) runEnable(args []string) exitStatus {
+	var disable, printAll, reusable, specialOnly bool
+	rest := args
+	for len(rest) > 0 && strings.HasPrefix(rest[0], "-") && len(rest[0]) > 1 {
+		flag := rest[0]
+		if flag == "--" {
+			rest = rest[1:]
+			break
+		}
+		for _, c := range flag[1:] {
+			switch c {
+			case 'n':
+				disable = true
+			case 'a':
+				printAll = true
+			case 'p':
+				reusable = true
+			case 's':
+				specialOnly = true
+			case 'd', 'f':
+				r.errf("enable: loadable builtins are not supported\n")
+				return exitStatus{code: 2}
+			default:
+				r.errf("enable: -%c: invalid option\n", c)
+				r.errf("enable: usage: %s\n", helpTable["enable"].synopsis)
+				return exitStatus{code: 2}
+			}
+		}
+		rest = rest[1:]
+	}
+
+	if len(rest) == 0 {
+		names := slices.Sorted(maps.Keys(helpTable))
+		if specialOnly {
+			names = posixSpecialBuiltins
+		}
+		for _, name := range names {
+			off := r.builtinDisabled(name)
+			// Without -a or -p, bash lists only the enabled builtins.
+			if off && !printAll && !reusable {
+				continue
+			}
+			if off {
+				r.outf("enable -n %s\n", name)
+			} else {
+				r.outf("enable %s\n", name)
+			}
+		}
+		return exitStatus{}
+	}
+
+	exit := exitStatus{}
+	for _, name := range rest {
+		if !IsBuiltin(name) {
+			r.errf("enable: %s: not a shell builtin\n", name)
+			exit.code = 1
+			continue
+		}
+		if !disable {
+			delete(r.disabledBuiltins, name)
+			continue
+		}
+		if r.disabledBuiltins == nil {
+			r.disabledBuiltins = make(map[string]bool)
+		}
+		r.disabledBuiltins[name] = true
+	}
+	return exit
+}
+
+// runHistory implements the history builtin, over the list the embedder
+// supplied with [History].
+func (r *Runner) runHistory(args []string) exitStatus {
+	clear := false
+	rest := args
+	for len(rest) > 0 && strings.HasPrefix(rest[0], "-") && len(rest[0]) > 1 {
+		switch rest[0] {
+		case "-c":
+			clear = true
+		case "--":
+			rest = rest[1:]
+			goto count
+		default:
+			r.errf("history: %s: invalid option\n", rest[0])
+			r.errf("history: usage: %s\n", helpTable["history"].synopsis)
+			return exitStatus{code: 2}
+		}
+		rest = rest[1:]
+	}
+count:
+
+	if r.historyList == nil {
+		r.errf("history: no history list is available in this shell\n")
+		return exitStatus{code: 1}
+	}
+	if clear {
+		if r.historyClear == nil {
+			r.errf("history: the history list cannot be cleared in this shell\n")
+			return exitStatus{code: 1}
+		}
+		r.historyClear()
+		return exitStatus{}
+	}
+
+	lines := r.historyList()
+	if len(rest) > 0 {
+		n, err := strconv.Atoi(rest[0])
+		if err != nil || n < 0 {
+			r.errf("history: %s: numeric argument required\n", rest[0])
+			return exitStatus{code: 1}
+		}
+		if n < len(lines) {
+			lines = lines[len(lines)-n:]
+		}
+	}
+	// bash numbers the whole list, so a trimmed listing keeps the original
+	// numbers rather than restarting at one.
+	first := len(r.historyList()) - len(lines) + 1
+	for i, line := range lines {
+		r.outf("%5d  %s\n", first+i, line)
+	}
+	return exitStatus{}
+}
+
+// compgenAction is one of compgen's word lists.
+type compgenAction string
+
+// runCompgen implements the compgen builtin, which is where a line editor
+// above this interpreter gets its completions from: it is the only thing that
+// knows the shell's aliases, functions, variables and $PATH.
+func (r *Runner) runCompgen(ctx context.Context, args []string) exitStatus {
+	var actions []compgenAction
+	var wordlist, prefix, suffix string
+	rest := args
+
+	addFlag := func(c rune) bool {
+		action, ok := map[rune]compgenAction{
+			'a': "alias", 'b': "builtin", 'c': "command", 'd': "directory",
+			'e': "export", 'f': "file", 'k': "keyword", 'v': "variable",
+			'g': "group", 'j': "job", 's': "service", 'u': "user",
+		}[c]
+		if !ok {
+			return false
+		}
+		actions = append(actions, action)
+		return true
+	}
+
+	for len(rest) > 0 && strings.HasPrefix(rest[0], "-") && len(rest[0]) > 1 {
+		flag := rest[0]
+		if flag == "--" {
+			rest = rest[1:]
+			break
+		}
+		// The options that take a value are only recognized on their own.
+		switch flag {
+		case "-A", "-W", "-P", "-S":
+			if len(rest) < 2 {
+				r.errf("compgen: %s: option requires an argument\n", flag)
+				return exitStatus{code: 2}
+			}
+			switch flag {
+			case "-A":
+				actions = append(actions, compgenAction(rest[1]))
+			case "-W":
+				wordlist = rest[1]
+			case "-P":
+				prefix = rest[1]
+			case "-S":
+				suffix = rest[1]
+			}
+			rest = rest[2:]
+			continue
+		case "-o", "-C", "-F", "-G", "-X":
+			// Completion specifications and filters, which only mean
+			// something inside a `complete` definition.
+			if len(rest) < 2 {
+				r.errf("compgen: %s: option requires an argument\n", flag)
+				return exitStatus{code: 2}
+			}
+			rest = rest[2:]
+			continue
+		}
+		for _, c := range flag[1:] {
+			if !addFlag(c) {
+				r.errf("compgen: -%c: invalid option\n", c)
+				r.errf("compgen: usage: %s\n", helpTable["compgen"].synopsis)
+				return exitStatus{code: 2}
+			}
+		}
+		rest = rest[1:]
+	}
+
+	word := ""
+	if len(rest) > 0 {
+		word = rest[0]
+	}
+
+	var out []string
+	if wordlist != "" {
+		out = append(out, strings.Fields(wordlist)...)
+	}
+	for _, action := range actions {
+		out = append(out, r.compgenWords(ctx, action, word)...)
+	}
+
+	// bash filters the candidates by the word as a prefix, except for
+	// filenames, which are generated already anchored to it.
+	matched := make([]string, 0, len(out))
+	seen := make(map[string]bool, len(out))
+	for _, cand := range out {
+		if !strings.HasPrefix(cand, word) || seen[cand] {
+			continue
+		}
+		seen[cand] = true
+		matched = append(matched, cand)
+	}
+	if len(matched) == 0 {
+		return exitStatus{code: 1}
+	}
+	for _, cand := range matched {
+		r.outf("%s%s%s\n", prefix, cand, suffix)
+	}
+	return exitStatus{}
+}
+
+// compgenWords generates the candidates for one action. Actions naming things
+// this shell has no notion of — users, groups, services — yield nothing rather
+// than an error, as they do in bash on a machine with none.
+func (r *Runner) compgenWords(ctx context.Context, action compgenAction, word string) []string {
+	var out []string
+	switch action {
+	case "alias":
+		for name := range r.alias {
+			out = append(out, name)
+		}
+	case "builtin":
+		out = append(out, slices.Sorted(maps.Keys(helpTable))...)
+	case "keyword":
+		for _, kw := range shellKeywords {
+			out = append(out, kw)
+		}
+	case "function":
+		for name := range r.Funcs {
+			out = append(out, name)
+		}
+	case "variable", "arrayvar":
+		r.writeEnv.Each(func(name string, vr expand.Variable) bool {
+			out = append(out, name)
+			return true
+		})
+	case "export":
+		r.writeEnv.Each(func(name string, vr expand.Variable) bool {
+			if vr.Exported {
+				out = append(out, name)
+			}
+			return true
+		})
+	case "command":
+		out = append(out, r.compgenWords(ctx, "alias", word)...)
+		out = append(out, r.compgenWords(ctx, "builtin", word)...)
+		out = append(out, r.compgenWords(ctx, "function", word)...)
+		out = append(out, r.commandsInPath(ctx)...)
+	case "file", "directory":
+		out = append(out, r.compgenPaths(ctx, word, action == "directory")...)
+	case "group", "job", "service", "user", "hostname", "setopt", "shopt", "signal":
+		// Nothing this shell has a notion of (or, for job and signal, nothing
+		// until the job control builtins land); yield nothing rather than an
+		// error, as bash does on a machine with none of them.
+	}
+	sort.Strings(out)
+	return out
+}
+
+// commandsInPath lists the executables reachable through $PATH, using the
+// interpreter's directory handler so it sees a virtual filesystem too.
+func (r *Runner) commandsInPath(ctx context.Context) []string {
+	var out []string
+	for _, dir := range filepath.SplitList(r.envGet("PATH")) {
+		if dir == "" {
+			dir = "."
+		}
+		entries, err := r.readDirHandler(r.handlerCtx(ctx, handlerKindReadDir, todoPos), dir)
+		if err != nil {
+			continue
+		}
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				out = append(out, entry.Name())
+			}
+		}
+	}
+	return out
+}
+
+// compgenPaths lists the filesystem entries the word could complete to, in the
+// directory the word names.
+func (r *Runner) compgenPaths(ctx context.Context, word string, dirsOnly bool) []string {
+	dir, base := filepath.Split(word)
+	lookup := dir
+	if lookup == "" {
+		lookup = r.Dir
+	} else if !filepath.IsAbs(lookup) {
+		lookup = filepath.Join(r.Dir, lookup)
+	}
+	entries, err := r.readDirHandler(r.handlerCtx(ctx, handlerKindReadDir, todoPos), lookup)
+	if err != nil {
+		return nil
+	}
+	var out []string
+	for _, entry := range entries {
+		if dirsOnly && !entry.IsDir() {
+			continue
+		}
+		if !strings.HasPrefix(entry.Name(), base) {
+			continue
+		}
+		out = append(out, dir+entry.Name())
+	}
+	return out
+}
+
+// shellKeywords is what `compgen -k` lists. It is bash's list rather than
+// [syntax.IsKeyword]'s, which leaves out elif.
+var shellKeywords = []string{
+	"!", "[[", "]]", "case", "coproc", "do", "done", "elif", "else", "esac",
+	"fi", "for", "function", "if", "in", "select", "then", "time", "until",
+	"while", "{", "}",
+}

--- a/interp/bashbuiltin_test.go
+++ b/interp/bashbuiltin_test.go
@@ -1,0 +1,142 @@
+package interp_test
+
+import (
+	"context"
+	"runtime"
+	"strings"
+	"testing"
+
+	"mvdan.cc/sh/v3/interp"
+	"mvdan.cc/sh/v3/syntax"
+)
+
+// runScript runs src and returns its combined output. These builtins report
+// state that varies (listings, completions), so the cases assert on
+// substrings rather than exact output.
+func runScript(t *testing.T, src string) string {
+	t.Helper()
+	var out strings.Builder
+	r, err := interp.New(interp.StdIO(strings.NewReader(""), &out, &out))
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, err := syntax.NewParser().Parse(strings.NewReader(src), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = r.Run(context.Background(), f)
+	return out.String()
+}
+
+func TestEnableBuiltin(t *testing.T) {
+	t.Parallel()
+	if s := runScript(t, "enable"); !strings.Contains(s, "enable pwd\n") {
+		t.Fatalf("enable = %q", s)
+	}
+	if s := runScript(t, "enable -s"); strings.Contains(s, "enable pwd\n") {
+		t.Fatalf("enable -s listed a non-special builtin: %q", s)
+	}
+	// A disabled builtin is hidden from the plain listing, shown by -a, and
+	// looked up as an external command instead — which for a builtin with no
+	// binary behind it means it is simply not found.
+	if s := runScript(t, "enable -n pwd; enable"); strings.Contains(s, "enable pwd\n") {
+		t.Fatalf("disabled builtin still listed: %q", s)
+	}
+	if s := runScript(t, "enable -n pwd; enable -a"); !strings.Contains(s, "enable -n pwd\n") {
+		t.Fatalf("enable -a = %q", s)
+	}
+	// Skipped on Windows, where `help` is a real external command (cmd.exe's
+	// HELP), so falling through to it succeeds rather than failing to resolve.
+	if runtime.GOOS != "windows" {
+		if s := runScript(t, "enable -n help; help"); !strings.Contains(s, "not found") {
+			t.Fatalf("disabled builtin still ran: %q", s)
+		}
+	}
+	// `builtin` runs one regardless, as in bash.
+	if s := runScript(t, "enable -n pwd; builtin pwd"); strings.Contains(s, "not found") {
+		t.Fatalf("builtin did not bypass enable -n: %q", s)
+	}
+	// Re-enabling restores it.
+	if s := runScript(t, "enable -n pwd; enable pwd; enable"); !strings.Contains(s, "enable pwd\n") {
+		t.Fatalf("re-enable = %q", s)
+	}
+	if s := runScript(t, "enable nosuchbuiltin"); !strings.Contains(s, "not a shell builtin") {
+		t.Fatalf("enable on a non-builtin = %q", s)
+	}
+}
+
+func TestCompgenBuiltin(t *testing.T) {
+	t.Parallel()
+	if s := runScript(t, "compgen -b pw"); strings.TrimSpace(s) != "pwd" {
+		t.Fatalf("compgen -b = %q", s)
+	}
+	if s := runScript(t, "compgen -k wh"); strings.TrimSpace(s) != "while" {
+		t.Fatalf("compgen -k = %q", s)
+	}
+	if s := runScript(t, "compgen -W 'foo bar baz' b"); strings.TrimSpace(s) != "bar\nbaz" {
+		t.Fatalf("compgen -W = %q", s)
+	}
+	if s := runScript(t, "compgen -P '<' -S '>' -W 'foo' f"); strings.TrimSpace(s) != "<foo>" {
+		t.Fatalf("compgen prefix and suffix = %q", s)
+	}
+	if s := runScript(t, "myfunc() { :; }; compgen -A function myf"); strings.TrimSpace(s) != "myfunc" {
+		t.Fatalf("compgen -A function = %q", s)
+	}
+	if s := runScript(t, "shopt -s expand_aliases; alias myalias=pwd; compgen -a myal"); strings.TrimSpace(s) != "myalias" {
+		t.Fatalf("compgen -a = %q", s)
+	}
+	if s := runScript(t, "MYVAR=1; compgen -v MYVA"); strings.TrimSpace(s) != "MYVAR" {
+		t.Fatalf("compgen -v = %q", s)
+	}
+	if s := runScript(t, "MYVAR=1; export MYEXP=1; compgen -e MY"); strings.TrimSpace(s) != "MYEXP" {
+		t.Fatalf("compgen -e = %q", s)
+	}
+	// No match is an error status with no output, as in bash.
+	if s := runScript(t, "compgen -b zzz; echo status=$?"); strings.TrimSpace(s) != "status=1" {
+		t.Fatalf("compgen with no match = %q", s)
+	}
+	if s := runScript(t, "compgen -Z"); !strings.Contains(s, "invalid option") {
+		t.Fatalf("compgen -Z = %q", s)
+	}
+}
+
+func TestHistoryBuiltin(t *testing.T) {
+	t.Parallel()
+	// Without a line editor to supply one, there is no history list.
+	if s := runScript(t, "history"); !strings.Contains(s, "no history list") {
+		t.Fatalf("history without a list = %q", s)
+	}
+
+	lines := []string{"echo one", "echo two", "echo three"}
+	run := func(src string) string {
+		t.Helper()
+		var out strings.Builder
+		r, err := interp.New(
+			interp.StdIO(strings.NewReader(""), &out, &out),
+			interp.History(
+				func() []string { return lines },
+				func() { lines = nil },
+			),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		f, err := syntax.NewParser().Parse(strings.NewReader(src), "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = r.Run(context.Background(), f)
+		return out.String()
+	}
+
+	if s := run("history"); strings.TrimSpace(s) != "1  echo one\n    2  echo two\n    3  echo three" {
+		t.Fatalf("history = %q", s)
+	}
+	// A trimmed listing keeps the original numbering.
+	if s := run("history 2"); strings.TrimSpace(s) != "2  echo two\n    3  echo three" {
+		t.Fatalf("history 2 = %q", s)
+	}
+	if s := run("history -c; history"); strings.TrimSpace(s) != "" {
+		t.Fatalf("history -c = %q", s)
+	}
+}

--- a/interp/builtin.go
+++ b/interp/builtin.go
@@ -162,6 +162,16 @@ func (r *Runner) builtin(ctx context.Context, pos syntax.Pos, name string, args 
 		exit.code = 1
 	case "help":
 		return r.runHelp(args)
+	case "enable":
+		return r.runEnable(args)
+	case "compgen":
+		return r.runCompgen(ctx, args)
+	case "history":
+		return r.runHistory(args)
+	case "logout":
+		// There is no login shell here, so this is bash's error for one that
+		// is not: the user wants exit.
+		return failf(1, "logout: not login shell: use `exit'\n")
 	case "times":
 		// js/wasm has no per-process CPU accounting at all, so report zeros
 		// in bash's format — shell user/sys, then children user/sys — rather

--- a/interp/help.go
+++ b/interp/help.go
@@ -102,10 +102,9 @@ var helpTable = map[string]builtinHelp{
 // helpUnsupported are recognized by this shell but not implemented; `help`
 // stars them the way bash stars disabled builtins.
 var helpUnsupported = map[string]bool{
-	"bg": true, "bind": true, "caller": true, "compgen": true, "complete": true,
-	"compopt": true, "disown": true, "enable": true, "fc": true, "fg": true,
-	"history": true, "jobs": true, "kill": true, "logout": true, "newgrp": true,
-	"suspend": true, "ulimit": true,
+	"bg": true, "bind": true, "caller": true, "complete": true,
+	"compopt": true, "disown": true, "fc": true, "fg": true, "jobs": true,
+	"kill": true, "newgrp": true, "suspend": true, "ulimit": true,
 }
 
 // helpMatch returns the documented names matching a bash-style pattern. An

--- a/interp/runner.go
+++ b/interp/runner.go
@@ -1189,7 +1189,7 @@ func (r *Runner) call(ctx context.Context, pos syntax.Pos, args []string) {
 		r.exit.returning = false
 		return
 	}
-	if IsBuiltin(name) {
+	if IsBuiltin(name) && !r.builtinDisabled(name) {
 		r.reportBgStart(0) // not one external program
 		r.exit = r.builtin(ctx, pos, name, args[1:])
 		return


### PR DESCRIPTION
`enable -n` disables a builtin so the name falls through to the exec handler, which is the point of the builtin in bash too — running the real /bin/echo, say. `builtin` still bypasses it, as in bash, and subshells inherit the disabled set.

`compgen` generates completions from the shell's own aliases, functions, variables, keywords and $PATH — the interpreter is the only thing that knows them, so a line editor above it had no way to ask before. The `-A job` and `-A signal` actions yield nothing for now and fill in when the job control builtins (#1382) land; the two PRs are otherwise independent against master.

`history` reads the list the embedder supplies with the new `interp.History` option, since the interpreter never reads input lines itself and has no history of its own. `logout` is bash's error for a shell that is not a login shell.

Split out of #1382 as requested. Part of #1401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C3X3gvq8ZggMRvzVzWm66i