### PR TITLE
fix: gitAtime build fail on 32-bit FreeBSD and NetBSD

### DIFF
--- a/interp/os_atimespec.go
+++ b/interp/os_atimespec.go
@@ -13,5 +13,6 @@ func getAtime(info fs.FileInfo) time.Time {
 	if !ok {
 		return info.ModTime()
 	}
-	return time.Unix(stat.Atimespec.Sec, stat.Atimespec.Nsec)
+	// Note that these are int32 on some platforms.
+	return time.Unix(int64(stat.Atimespec.Sec), int64(stat.Atimespec.Nsec))
 }


### PR DESCRIPTION
Hey @mvdan! Hopping here from Charm! 

We had an issue with [crush](https://github.com/charmbracelet/crush) not building on BSD due to recent update of your dependency with the error:

```sh
build failed: exit status 1: # mvdan.cc/sh/v3/interp
Error: ../../../go/pkg/mod/mvdan.cc/sh/v3@v3.14.0/interp/os_atimespec.go:16:39: cannot use stat.Atimespec.Nsec (variable of type int32) as int64 value in argument to time.Unix
target=freebsd_arm_7
```

To reproduce locally: `GOOS=freebsd GOARCH=arm GOARM=7 go build .`


This PR casts both fields to `int64`, the same thing `os_atim.go` already does for Linux. 64-bit platforms are unaffected, since the casts are no-ops there.