### PR TITLE
syntax: add explicit semicolons option

### DIFF
--- a/cmd/shfmt/main.go
+++ b/cmd/shfmt/main.go
@@ -84,6 +84,7 @@ var (
 
 	// Printer flags.
 	indent      = flagVal("i", "indent", 0, flag.UintVar)
+	semis       = flagVal("se", "explicit-semicolons", false, flag.BoolVar)
 	binNext     = flagVal("bn", "binary-next-line", false, flag.BoolVar)
 	caseIndent  = flagVal("ci", "case-indent", false, flag.BoolVar)
 	spaceRedirs = flagVal("sr", "space-redirects", false, flag.BoolVar)
@@ -135,6 +136,7 @@ Parser options:
 Printer options:
 
   -i,  --indent uint       0 for tabs (default), >0 for number of spaces
+  -se, --explicit-semicolons  emit semicolons at command boundaries
   -bn, --binary-next-line  binary ops like && and | may start a line
   -ci, --case-indent       switch cases will be indented
   -sr, --space-redirects   redirect operators will be followed by a space
@@ -200,6 +202,7 @@ For more information and to report bugs, see https://github.com/mvdan/sh.
 			posix.short, posix.long,
 			simplify.short, simplify.long,
 			indent.short, indent.long,
+			semis.short, semis.long,
 			binNext.short, binNext.long,
 			caseIndent.short, caseIndent.long,
 			spaceRedirs.short, spaceRedirs.long,
@@ -222,6 +225,7 @@ For more information and to report bugs, see https://github.com/mvdan/sh.
 		}
 
 		syntax.Indent(indent.val)(printer)
+		syntax.ExplicitSemicolons(semis.val)(printer)
 		syntax.BinaryNextLine(binNext.val)(printer)
 		syntax.SwitchCaseIndent(caseIndent.val)(printer)
 		syntax.SpaceRedirects(spaceRedirs.val)(printer)
@@ -433,6 +437,7 @@ func propsOptions(lang syntax.LangVariant, props editorconfig.Section) (_ syntax
 	}
 	syntax.Indent(size)(printer)
 
+	syntax.ExplicitSemicolons(props.Get("explicit_semicolons") == "true")(printer)
 	syntax.BinaryNextLine(props.Get("binary_next_line") == "true")(printer)
 	// TODO(v4): rename to case_indent for consistency with flags
 	syntax.SwitchCaseIndent(props.Get("switch_case_indent") == "true")(printer)

--- a/cmd/shfmt/main.go
+++ b/cmd/shfmt/main.go
@@ -84,7 +84,7 @@ var (
 
 	// Printer flags.
 	indent      = flagVal("i", "indent", 0, flag.UintVar)
-	semis       = flagVal("se", "explicit-semicolons", false, flag.BoolVar)
+	semis       = flagVal("", "explicit-semicolons", false, flag.BoolVar)
 	binNext     = flagVal("bn", "binary-next-line", false, flag.BoolVar)
 	caseIndent  = flagVal("ci", "case-indent", false, flag.BoolVar)
 	spaceRedirs = flagVal("sr", "space-redirects", false, flag.BoolVar)
@@ -136,7 +136,7 @@ Parser options:
 Printer options:
 
   -i,  --indent uint       0 for tabs (default), >0 for number of spaces
-  -se, --explicit-semicolons  emit semicolons at command boundaries
+       --explicit-semicolons  emit semicolons at command boundaries
   -bn, --binary-next-line  binary ops like && and | may start a line
   -ci, --case-indent       switch cases will be indented
   -sr, --space-redirects   redirect operators will be followed by a space

--- a/cmd/shfmt/shfmt.1.scd
+++ b/cmd/shfmt/shfmt.1.scd
@@ -91,6 +91,9 @@ predictable. Some aspects of the format can be configured via printer flags.
 *-i*, *--indent* <uint>
 	Indent: *0* for tabs (default), *>0* for number of spaces.
 
+*-se*, *--explicit-semicolons*
+	Emit semicolons at command boundaries, including before line breaks.
+
 *-bn*, *--binary-next-line*
 	Binary ops like *&&* and *|* may start a line.
 
@@ -160,6 +163,7 @@ indent_size = 4
 # --language-dialect
 shell_variant      = posix
 simplify           = true
+explicit_semicolons = true
 binary_next_line   = true
 # --case-indent
 switch_case_indent = true

--- a/cmd/shfmt/shfmt.1.scd
+++ b/cmd/shfmt/shfmt.1.scd
@@ -91,7 +91,7 @@ predictable. Some aspects of the format can be configured via printer flags.
 *-i*, *--indent* <uint>
 	Indent: *0* for tabs (default), *>0* for number of spaces.
 
-*-se*, *--explicit-semicolons*
+*--explicit-semicolons*
 	Emit semicolons at command boundaries, including before line breaks.
 
 *-bn*, *--binary-next-line*

--- a/cmd/shfmt/testdata/script/editorconfig.txtar
+++ b/cmd/shfmt/testdata/script/editorconfig.txtar
@@ -159,6 +159,9 @@ shell_variant = mksh
 [indent.sh]
 # check its default; we tested "space" above.
 
+[explicit_semicolons.sh]
+explicit_semicolons = true
+
 [binary_next_line.sh]
 binary_next_line = true
 
@@ -191,6 +194,11 @@ coprocess |&
 {
 	indented
 }
+-- otherknobs/explicit_semicolons.sh --
+foo;
+if cond; then
+	bar;
+fi;
 -- otherknobs/binary_next_line.sh --
 foo \
 	| bar

--- a/cmd/shfmt/testdata/script/flags.txtar
+++ b/cmd/shfmt/testdata/script/flags.txtar
@@ -126,6 +126,14 @@ stdin flags-input
 exec shfmt --indent 2
 cmp stdout flags-output.indent-golden
 
+stdin explicit-semicolons-input
+exec shfmt -se
+cmp stdout flags-output.explicit-semicolons-golden
+
+stdin explicit-semicolons-input
+exec shfmt --explicit-semicolons
+cmp stdout flags-output.explicit-semicolons-golden
+
 stdin flags-input
 exec shfmt -bn
 cmp stdout flags-output.binary-next-line-golden
@@ -209,6 +217,16 @@ foo() {
 
 	keep    padding
 }
+-- explicit-semicolons-input --
+foo
+if cond; then
+	bar
+fi
+-- flags-output.explicit-semicolons-golden --
+foo;
+if cond; then
+	bar;
+fi;
 -- flags-output.indent-golden --
 foo() {
   bar &&

--- a/cmd/shfmt/testdata/script/flags.txtar
+++ b/cmd/shfmt/testdata/script/flags.txtar
@@ -8,6 +8,9 @@ stderr 'Utilities' # definitely includes our help text
 exec shfmt --help
 stderr 'usage: shfmt'
 
+! exec shfmt -se
+stderr 'flag provided but not defined'
+
 exec shfmt -version
 stdout 'devel|v3'
 ! stderr .
@@ -125,10 +128,6 @@ cmp stdout flags-output.indent-golden
 stdin flags-input
 exec shfmt --indent 2
 cmp stdout flags-output.indent-golden
-
-stdin explicit-semicolons-input
-exec shfmt -se
-cmp stdout flags-output.explicit-semicolons-golden
 
 stdin explicit-semicolons-input
 exec shfmt --explicit-semicolons

--- a/syntax/printer.go
+++ b/syntax/printer.go
@@ -26,6 +26,12 @@ func Indent(spaces uint) PrinterOption {
 	return func(p *Printer) { p.indentSpaces = spaces }
 }
 
+// ExplicitSemicolons will emit semicolons at command boundaries, including
+// before line breaks.
+func ExplicitSemicolons(enabled bool) PrinterOption {
+	return func(p *Printer) { p.explicitSemis = enabled }
+}
+
 // BinaryNextLine will make binary operators appear on the next line
 // when a binary command, such as a pipe, or a binary test or arithmetic
 // expression spans multiple lines. A backslash is used where newlines
@@ -258,6 +264,7 @@ type Printer struct {
 	cols      colCounter // used for [KeepPadding]
 
 	indentSpaces   uint
+	explicitSemis  bool
 	binNextLine    bool
 	swtCaseIndent  bool
 	spaceRedirects bool
@@ -512,6 +519,7 @@ func (p *Printer) flushHeredocs() {
 
 					// The options need to persist.
 					indentSpaces:   p.indentSpaces,
+					explicitSemis:  p.explicitSemis,
 					binNextLine:    p.binNextLine,
 					swtCaseIndent:  p.swtCaseIndent,
 					spaceRedirects: p.spaceRedirects,
@@ -1160,7 +1168,8 @@ func (p *Printer) elemJoin(elems []*ArrayElem, last []Comment) {
 	p.decLevel()
 }
 
-func (p *Printer) stmt(s *Stmt) {
+// stmt prints s and reports whether it ended with a separator of its own.
+func (p *Printer) stmt(s *Stmt) bool {
 	p.wroteSemi = false
 	if s.Negated {
 		p.spacedString("!", s.Pos())
@@ -1192,7 +1201,8 @@ func (p *Printer) stmt(s *Stmt) {
 		}
 	}
 	sep := s.Semicolon.IsValid() && s.Semicolon.Line() > p.line && !p.singleLine
-	if sep || s.Background || s.Coprocess || s.Disown {
+	terminated := sep || s.Background || s.Coprocess || s.Disown
+	if terminated {
 		if sep {
 			p.bslashNewl()
 		} else if !p.minify {
@@ -1211,6 +1221,7 @@ func (p *Printer) stmt(s *Stmt) {
 		p.wantSpace = spaceRequired
 	}
 	p.decLevel()
+	return terminated
 }
 
 func (p *Printer) printRedirsUntil(redirs []*Redirect, startRedirs int, pos Pos) int {
@@ -1577,7 +1588,11 @@ func (p *Printer) stmtList(stmts []*Stmt, last []Comment) {
 		}
 		p.advanceLine(pos.Line())
 		p.comments(midComs...)
-		p.stmt(s)
+		terminated := p.stmt(s)
+		if p.explicitSemis && !terminated {
+			p.w.WriteByte(';')
+			p.wroteSemi = true
+		}
 		p.comments(endComs...)
 		p.wantNewline = true
 	}

--- a/syntax/printer_test.go
+++ b/syntax/printer_test.go
@@ -942,6 +942,31 @@ func TestPrintBinaryNextLine(t *testing.T) {
 	}
 }
 
+func TestPrintExplicitSemicolons(t *testing.T) {
+	t.Parallel()
+	tests := [...]printCase{
+		{
+			"foo\nbar",
+			"foo;\nbar;",
+		},
+		{
+			"if cond; then\nfoo\nelse\nbar\nfi\n\nf() {\nbaz\n}",
+			"if cond; then\n\tfoo;\nelse\n\tbar;\nfi;\n\nf() {\n\tbaz;\n};",
+		},
+		{
+			"foo # a comment\nbar <<EOF\nbody\nEOF",
+			"foo; # a comment\nbar <<EOF;\nbody\nEOF",
+		},
+	}
+	parser := NewParser(KeepComments(true))
+	printer := NewPrinter(ExplicitSemicolons(true))
+	for _, tc := range tests {
+		t.Run("", func(t *testing.T) {
+			printTest(t, parser, printer, tc.in, tc.want)
+		})
+	}
+}
+
 func TestPrintSwitchCaseIndent(t *testing.T) {
 	t.Parallel()
 	tests := [...]printCase{
@@ -1348,6 +1373,7 @@ func TestPrintOptionsNotBroken(t *testing.T) {
 		name string
 		list []PrinterOption
 	}{
+		{"ExplicitSemicolons", []PrinterOption{ExplicitSemicolons(true)}},
 		{"Minify", []PrinterOption{Minify(true)}},
 		{"SingleLine", []PrinterOption{SingleLine(true)}},
 	} {

--- a/syntax/printer_test.go
+++ b/syntax/printer_test.go
@@ -944,25 +944,74 @@ func TestPrintBinaryNextLine(t *testing.T) {
 
 func TestPrintExplicitSemicolons(t *testing.T) {
 	t.Parallel()
-	tests := [...]printCase{
+	tests := [...]struct {
+		name string
+		in   string
+		want string
+	}{
 		{
-			"foo\nbar",
-			"foo;\nbar;",
+			name: "simple-statements",
+			in:   "foo\nbar",
+			want: "foo;\nbar;\n",
 		},
 		{
-			"if cond; then\nfoo\nelse\nbar\nfi\n\nf() {\nbaz\n}",
-			"if cond; then\n\tfoo;\nelse\n\tbar;\nfi;\n\nf() {\n\tbaz;\n};",
+			name: "binary-and",
+			in:   "foo &&\nbar\nbaz",
+			want: "foo &&\n\tbar;\nbaz;\n",
 		},
 		{
-			"foo # a comment\nbar <<EOF\nbody\nEOF",
-			"foo; # a comment\nbar <<EOF;\nbody\nEOF",
+			name: "pipeline",
+			in:   "foo |\nbar\nbaz",
+			want: "foo |\n\tbar;\nbaz;\n",
+		},
+		{
+			name: "if",
+			in:   "if cond; then\nfoo\nelse\nbar\nfi",
+			want: "if cond; then\n\tfoo;\nelse\n\tbar;\nfi;\n",
+		},
+		{
+			name: "background",
+			in:   "foo &\nbar",
+			want: "foo &\nbar;\n",
+		},
+		{
+			name: "case",
+			in:   "case x in\nx) foo ;;\nesac",
+			want: "case x in\nx) foo; ;;\nesac;\n",
+		},
+		{
+			name: "heredoc",
+			in:   "foo <<EOF\nbody\nEOF\nbar",
+			want: "foo <<EOF;\nbody\nEOF\nbar;\n",
 		},
 	}
 	parser := NewParser(KeepComments(true))
-	printer := NewPrinter(ExplicitSemicolons(true))
+	format := func(t *testing.T, printer *Printer, input string) string {
+		t.Helper()
+		prog, err := parser.Parse(strings.NewReader(input), "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		got, err := strPrint(printer, prog)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return got
+	}
 	for _, tc := range tests {
-		t.Run("", func(t *testing.T) {
-			printTest(t, parser, printer, tc.in, tc.want)
+		t.Run(tc.name, func(t *testing.T) {
+			defaultOutput := format(t, NewPrinter(), tc.in)
+			if got := format(t, NewPrinter(ExplicitSemicolons(false)), tc.in); got != defaultOutput {
+				t.Fatalf("ExplicitSemicolons(false) changed the default output:\nwant:\n%q\ngot:\n%q", defaultOutput, got)
+			}
+
+			got := format(t, NewPrinter(ExplicitSemicolons(true)), tc.in)
+			if got != tc.want {
+				t.Fatalf("ExplicitSemicolons(true) mismatch:\nwant:\n%q\ngot:\n%q", tc.want, got)
+			}
+			if gotAgain := format(t, NewPrinter(ExplicitSemicolons(true)), got); gotAgain != got {
+				t.Fatalf("formatting was not idempotent:\nwant:\n%q\ngot:\n%q", got, gotAgain)
+			}
 		})
 	}
 }


### PR DESCRIPTION
  Add -se / --explicit-semicolons to emit semicolons at command boundaries. The option is also
  available through EditorConfig with explicit_semicolons = true.

  This covers control-flow statements, case clauses, and heredocs, with CLI, EditorConfig,
  documentation, and syntax test coverage included.