### PR TITLE
fix(printer): keep inline command with heredoc in command substitution

### DIFF
--- a/syntax/printer.go
+++ b/syntax/printer.go
@@ -1500,7 +1500,8 @@ func (p *Printer) nestedStmts(stmts []*Stmt, last []Comment, closing Pos) {
 		//     { stmt; stmt; }
 		p.wantNewline = true
 	case closing.Line() > p.line && len(stmts) > 0 &&
-		stmtsEnd(stmts, last).Line() < closing.Line():
+		stmtsEnd(stmts, last).Line() < closing.Line() &&
+		!lastStmtHeredocForcesClosing(stmts, last):
 		// Force a newline if we find:
 		//     { stmt
 		//     }
@@ -1618,6 +1619,28 @@ func (e *extraIndenter) WriteString(s string) (int, error) {
 		e.WriteByte(s[i])
 	}
 	return len(s), nil
+}
+
+// lastStmtHeredocForcesClosing reports whether the gap between the end of the
+// last statement and a following closing token, such as `)` or `}`, is caused
+// solely by a heredoc terminator, which mandates a newline before the closing
+// token. In that case the command was written inline alongside its heredoc and
+// should stay inline rather than being pushed onto its own line. A bare heredoc
+// redirect with no command is left to the usual layout rules.
+func lastStmtHeredocForcesClosing(stmts []*Stmt, last []Comment) bool {
+	if len(last) > 0 {
+		return false
+	}
+	s := stmts[len(stmts)-1]
+	if s.Cmd == nil {
+		return false
+	}
+	for _, r := range s.Redirs {
+		if r.Op == Hdoc || r.Op == DashHdoc {
+			return true
+		}
+	}
+	return false
 }
 
 func startsWithLparen(node Node) bool {

--- a/syntax/printer_test.go
+++ b/syntax/printer_test.go
@@ -462,6 +462,9 @@ var printTests = []printCase{
 		"<(<<EOF\nbody\nEOF\n)",
 		"<(\n\t<<EOF\nbody\nEOF\n)",
 	},
+	samePrint("a=$(foo <<EOF\nbar\nEOF\n)"),
+	samePrint("eval \"$(foo <<EOF\nbar\nEOF\n)\""),
+	samePrint("eval \"$(docopts -A ARGS : \"$@\" <<EOF\nusage\nEOF\n)\""),
 	{
 		"( (foo) )\n$( (foo) )\n<( (foo) )",
 		"( (foo) )\n$( (foo) )\n<((foo))",


### PR DESCRIPTION

## Problem

- Repo: mvdan/sh
- Base: mvdan:master
- Head: dualfroz:fix/quoted-subshell-heredoc
- Closes: #1282


## Problem

A command written inline inside a command substitution, when it carries a
heredoc, was reformatted onto its own indented line. Reported in #1282 with
`eval "$(docopts ... <<EOF ... EOF)"`.

Before (input, and the wanted output):

```bash
eval "$(docopts --help=- -A ARGS : "$@" <<EOF
usage
EOF
)"
```

After (what shfmt produced, unwanted):

```bash
eval "$(
	docopts --help=- -A ARGS : "$@" <<EOF
usage
EOF
)"
```

## Root cause

`nestedStmts` forces a newline before the first statement when the closing
token (`)` here) sits on a line after the statements end:

```go
case closing.Line() > p.line && len(stmts) > 0 &&
	stmtsEnd(stmts, last).Line() < closing.Line():
	p.wantNewline = true
```

That heuristic is meant to preserve a deliberate layout such as:

```
$(stmt
)
```

When the last statement ends with a heredoc, `stmtsEnd` is the heredoc body
end, and the closing `)` is necessarily on the line after the heredoc
terminator. So the condition always fires, even though that newline is
mandatory shell syntax rather than a stylistic choice, and the command is
pushed onto its own line.

## Fix

Skip that heuristic when the last statement has a command and ends with a
heredoc redirect (`<<` or `<<-`). In that case only the heredoc terminator
forces the newline before the closing token, so the command stays inline.

A bare heredoc redirect with no command (for example `<(<<EOF ... EOF)`) is
left to the existing layout rules, so its current break-out behaviour and the
golden test that pins it are unchanged. A genuine user layout that puts the
command on its own line after `$(` is still preserved, because that is driven
by the statement's own position, not by this heuristic.
