### PR TITLE
syntax: allow Zsh brace groups without a surrounding blank

### DIFF
--- a/syntax/filetests_test.go
+++ b/syntax/filetests_test.go
@@ -1992,6 +1992,18 @@ var fileTests = []fileTestCase{
 		langFile(block(litStmt("foo")), LangZsh),
 	),
 	fileTest(
+		// Zsh also allows omitting the blank around "{" and "}",
+		// as well as the semicolon before "}", to form a brace group.
+		[]string{
+			"{\n\techo FOO\n\tseq 3\n}",
+			"{echo FOO; seq 3}",
+			"{echo FOO; seq 3;}",
+			"{echo FOO; seq 3 }",
+			"{ echo FOO; seq 3}",
+		},
+		langFile(block(litStmt("echo", "FOO"), litStmt("seq", "3")), LangZsh),
+	),
+	fileTest(
 		[]string{"{ }"},
 		langErr2("1:1: `{` must be followed by a statement list"),
 		langFile(block(), LangZsh|LangMirBSDKorn),

--- a/syntax/parser.go
+++ b/syntax/parser.go
@@ -2182,6 +2182,14 @@ func (p *Parser) gotStmtPipe(s *Stmt, binCmd bool) *Stmt {
 	redirsStart := len(s.Redirs)
 	switch p.tok {
 	case _LitWord:
+		if rest, ok := p.zshLeadingBrace(p.val); ok {
+			b := &Block{Lbrace: p.pos}
+			p.pos = posAddCol(b.Lbrace, 1)
+			p.val = rest
+			p.spaced = false
+			p.blockBody(s, b)
+			break
+		}
 		switch p.val {
 		case "{":
 			p.block(s)
@@ -2264,6 +2272,14 @@ func (p *Parser) gotStmtPipe(s *Stmt, binCmd bool) *Stmt {
 		}
 		if p.hasValidIdent() {
 			p.callExpr(s, nil, true)
+			break
+		}
+		if rest, ok := p.zshTrailingBrace(p.val); ok {
+			name := p.lit(p.pos, rest)
+			p.pos = posAddCol(p.pos, len(rest))
+			p.val = "}"
+			p.spaced = false
+			p.callExpr(s, p.wordOne(name), false)
 			break
 		}
 		name := p.lit(p.pos, p.val)
@@ -2386,6 +2402,10 @@ func (p *Parser) arithmExpCmd(s *Stmt) {
 func (p *Parser) block(s *Stmt) {
 	b := &Block{Lbrace: p.pos}
 	p.next()
+	p.blockBody(s, b)
+}
+
+func (p *Parser) blockBody(s *Stmt, b *Block) {
 	b.Stmts, b.Last = p.followStmts("{", b.Lbrace, "}")
 	if pos, ok := p.gotRsrv("}"); ok {
 		b.Rbrace = pos
@@ -2395,6 +2415,36 @@ func (p *Parser) block(s *Stmt) {
 		p.matchingErr(b.Lbrace, leftBrace, rightBrace)
 	}
 	s.Cmd = b
+}
+
+// zshLeadingBrace reports whether val is a Zsh brace group's "{" glued to the
+// word that follows it without a separating blank, such as the "{echo" in
+// "{echo foo}". Zsh does not require a blank after the opening brace, unlike
+// the other shells this package supports. On success it returns the word
+// content found after the brace.
+func (p *Parser) zshLeadingBrace(val string) (rest string, ok bool) {
+	if !p.lang.in(LangZsh) || len(val) < 2 {
+		return "", false
+	}
+	if val[0] != '{' || val[len(val)-1] == '}' {
+		return "", false
+	}
+	return val[1:], true
+}
+
+// zshTrailingBrace reports whether val is a Zsh brace group's "}" glued to
+// the word that precedes it without a separating blank, such as the "3}" in
+// "{echo foo; seq 3}". Zsh does not require a blank, nor a semicolon, before
+// the closing brace. On success it returns the word content found before
+// the brace.
+func (p *Parser) zshTrailingBrace(val string) (rest string, ok bool) {
+	if !p.lang.in(LangZsh) || len(val) < 2 {
+		return "", false
+	}
+	if val[len(val)-1] != '}' || val[0] == '{' {
+		return "", false
+	}
+	return val[:len(val)-1], true
 }
 
 func (p *Parser) ifClause(s *Stmt) {
@@ -2919,6 +2969,14 @@ loop:
 			}
 			// Zsh does not require a semicolon to close a block.
 			if p.lang.in(LangZsh) && p.val == "}" {
+				break loop
+			}
+			// Nor does it require a blank before the closing brace.
+			if rest, ok := p.zshTrailingBrace(p.val); ok {
+				ce.Args = append(ce.Args, p.wordOne(p.lit(p.pos, rest)))
+				p.pos = posAddCol(p.pos, len(rest))
+				p.val = "}"
+				p.spaced = false
 				break loop
 			}
 			w := p.wordOne(p.lit(p.pos, p.val))


### PR DESCRIPTION

## Problem

Fixes: https://github.com/mvdan/sh/issues/1295

## Problem

In the Zsh language dialect, `shfmt` requires a blank around the `{` and `}`
of a brace group (command grouping), and a semicolon before the closing
`}`. Real zsh does not require either. Depending on which of the two is
missing, `shfmt --language-dialect zsh` either:

- silently mis-parses the input as two unrelated simple commands instead of
  a brace group (no error, wrong output), or
- fails to parse at all with a confusing `` `}` can only be used to close a
  block `` or `reached EOF without matching \`{\` with \`}\`` error.

## Root cause

Verified directly against zsh 5.9 (not just the issue's write-up): zsh's
grammar recognizes a brace-group `{` or `}` as its own token even when it is
glued to the adjacent word, e.g. `{echo` opens a group whose first word is
`echo`, and `3}` is the number `3` followed by the group's closing brace.

`shfmt`'s lexer instead treats `{` and `}` as ordinary word characters
outside of a couple of narrow, already-existing special cases (the closing
`}` was only recognized when it arrived as its own separated token, i.e.
preceded by whitespace or a semicolon; see the existing "Zsh does not
require a semicolon to close a block" comment in `syntax/parser.go`). So
`{echo`, and separately `3}`, were read as single, indivisible literal
words, and the parser had no chance to recognize the group boundaries.
The issue's own root-cause guess (missing space handling around `{`/`}` in
Zsh mode) was correct.

## Fix

Added two small, Zsh-only helpers in `syntax/parser.go`:

- `zshLeadingBrace`: splits a leading `{` off a literal word such as
  `{echo`, used where a new statement can start (`gotStmtPipe`), to open a
  `Block` the same way the already-separated `{` token does
  (`block`/`blockBody`, factored out of `block` for reuse).
- `zshTrailingBrace`: splits a trailing `}` off a literal word such as
  `3}`, used both at the call name position and while scanning further
  call arguments, to close the enclosing `Block` the same way the
  already-separated `}` token does.

Both helpers deliberately skip words that are self-contained brace pairs
(start with `{` and end with `}` in the very same token, e.g. `{foo}` or
Zsh brace expansions like `{a,b}` and `{1..5}`), so:

- the pre-existing, deliberately-unfixed `{foo}` single-word case (see the
  adjacent `TODO` comment in the test file) keeps its current behaviour, and
- brace expansion words such as `echo {a,b}c` or `echo {1..5}` keep being
  preserved as plain literals, unaffected.

Only the Zsh dialect is touched; Bash, POSIX, mksh and Bats keep parsing
these inputs exactly as before.

## How tested

Built `shfmt` from this branch and ran all four inputs from the issue plus
the already-working control cases, confirming they now produce the same,
idempotent output as the canonical spaced form:


Also checked, against a real `zsh 5.9` install, that stray/self-contained
brace-adjacent literals keep their current (already correct) behaviour:
`echo {a,b}c`, `echo {1..5}` (brace expansion preserved), `{foo}` (left as
the pre-existing literal-word parse), and `echo foo}` at the top level
(still a parse error, matching both real zsh and shfmt's pre-existing
behaviour for the already-separated `echo foo }` case).

Added a new `syntax/filetests_test.go` case covering all four
issue inputs (plus the already-working spaced form) parsing to the same
`Block` AST for `LangZsh` only.

Gate:

exit code: 0

exit code: 0, no output (nothing to reformat)

exit code: 0

Counterfactual (required check that the new test actually catches a
regression): with the `syntax/parser.go` changes reverted and only the new
test kept, `go test ./syntax/... -run 'TestParseFiles|TestPrintFiles'`
fails with exactly the four inputs from the issue, reproducing the
original bug:

```
--- FAIL: TestParseFiles/zsh/OK/168-1  input: {echo FOO; seq 3}     (parses to two CallExprs instead of a Block)
--- FAIL: TestParseFiles/zsh/OK/168-2  input: {echo FOO; seq 3;}    (`}` can only be used to close a block)
--- FAIL: TestParseFiles/zsh/OK/168-3  input: {echo FOO; seq 3 }    (`}` can only be used to close a block)
--- FAIL: TestParseFiles/zsh/OK/168-4  input: { echo FOO; seq 3}    (reached EOF without matching `{` with `}`)
```
exit code: 1

Restoring `syntax/parser.go` makes the same command pass again with exit
code 0.

## Known follow-up (out of scope for this PR)

Nested, fully-glued combinations of brace expansion and brace groups in the
same word (e.g. `{echo {a,b}}`, where a brace-expansion pattern and the
group's closing brace are glued into the same trailing literal) are not
handled and still produce a parse error, same as before this change. This
was not part of the reported issue and needs proper brace-nesting depth
tracking in the lexer to resolve correctly.
