### PR TITLE
interp: Fix brace expansion test case on 32-bit

### DIFF
--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -3763,7 +3763,7 @@ done <<< 2`,
 		"brace expansion would exceed 16384 elements\n #IGNORE bash has no defensive limit below MaxInt",
 	},
 	{
-		"echo a{0..9999999999}b",
+		"echo a{0..1999999999}b",
 		"brace expansion would exceed 16384 elements\n #JUSTERR bash errors with a different message",
 	},
 


### PR DESCRIPTION
9999999999 exceeds 32-bit range and does not lead to an error on 32-bit platforms. This can be observed in the debian package:

https://buildd.debian.org/status/fetch.php?pkg=golang-mvdan-sh&arch=armhf&ver=3.14.0-1&stamp=1788648229&raw=0

Change this to a sufficiently large value 1999999999 which still correctly triggers the stderr and fits in 32-bit range.