### PR TITLE
interp: detach an interactive runner's jobs from the statement's context

### DIFF
--- a/cmd/gosh/main.go
+++ b/cmd/gosh/main.go
@@ -84,6 +84,11 @@ func runPath(r *interp.Runner, path string) error {
 
 func runInteractive(r *interp.Runner, stdin io.Reader, stdout, stderr io.Writer) error {
 	parser := syntax.NewParser()
+	// Background jobs outlive their command line in an interactive runner;
+	// end them when the shell itself is done, like bash's SIGHUP on exit.
+	// The default exec handler kills stubborn processes after a timeout, so
+	// this cannot block for long.
+	defer r.StopJobs(context.Background())
 	fmt.Fprintf(stdout, "$ ")
 	for stmts, err := range parser.InteractiveSeq(stdin) {
 		if err != nil {

--- a/interp/api.go
+++ b/interp/api.go
@@ -292,6 +292,28 @@ type bgProc struct {
 	// the process ID when the background statement started exactly one
 	// external program, and zero otherwise.
 	started chan int
+
+	// cmd is the source text of the backgrounded statement, as the jobs
+	// builtin prints it. It is empty for the shells behind process
+	// substitutions, which bash does not list as jobs either.
+	cmd string
+
+	// cancel stops the background shell. A job here is a goroutine rather
+	// than an operating system process, so the kill builtin cancels its
+	// context instead of sending a signal.
+	cancel context.CancelFunc
+
+	// signal is the name of the signal kill delivered, so that jobs can
+	// report Terminated rather than Done.
+	signal string
+
+	// disowned jobs are hidden from jobs and are not waited for by a bare
+	// wait, as after bash's disown.
+	disowned bool
+
+	// notified records that this job's completion has already been reported
+	// by `jobs -n`.
+	notified bool
 }
 
 // newBgProc returns a background job with the next fake PID.

--- a/interp/api.go
+++ b/interp/api.go
@@ -180,6 +180,11 @@ type Runner struct {
 
 	opts runnerOpts
 
+	// interactive records the [Interactive] option: whether the runner
+	// behaves like an interactive shell. Among other things, it decides
+	// whether background jobs are detached from the statement's context.
+	interactive bool
+
 	origDir    string
 	origParams []string
 	origOpts   runnerOpts
@@ -460,11 +465,14 @@ func Dir(path string) RunnerOption {
 }
 
 // Interactive configures the interpreter to behave like an interactive shell,
-// akin to Bash. Currently, this only enables the expansion of aliases,
-// but later on it should also change other behavior.
+// akin to Bash. It enables the expansion of aliases, and detaches background
+// jobs from the context of the statement that started them, so that a job
+// outlives its command line the way it would in an interactive shell; see
+// [Runner.StopJobs] for how such jobs end.
 func Interactive(enabled bool) RunnerOption {
 	return func(r *Runner) error {
 		r.opts[optExpandAliases] = enabled
+		r.interactive = enabled
 		return nil
 	}
 }
@@ -991,6 +999,10 @@ func (r *Runner) Reset() {
 		// Clean it as we will later do a string prefix match.
 		r.tempDir = filepath.Clean(r.tempDir)
 	}
+	// A detached background job would survive the reset with its cancel func
+	// dropped, leaving it running with no way to reach it, so end them all
+	// first; a fresh shell has no jobs.
+	r.StopJobs(context.Background())
 	// reset the internal state
 	*r = Runner{
 		Env:                  r.Env,
@@ -1027,6 +1039,8 @@ func (r *Runner) Reset() {
 
 		dirStack: r.dirStack[:0],
 		usedNew:  r.usedNew,
+
+		interactive: r.interactive,
 	}
 	// Ensure we stop referencing any pointers before we reuse bgProcs.
 	clear(r.bgProcs)

--- a/interp/builtin.go
+++ b/interp/builtin.go
@@ -162,6 +162,16 @@ func (r *Runner) builtin(ctx context.Context, pos syntax.Pos, name string, args 
 		exit.code = 1
 	case "help":
 		return r.runHelp(args)
+	case "jobs":
+		return r.runJobs(args)
+	case "kill":
+		return r.runKill(args)
+	case "disown":
+		return r.runDisown(args)
+	case "fg":
+		return r.runFg(ctx, args)
+	case "bg":
+		return r.runBg(args)
 	case "times":
 		// js/wasm has no per-process CPU accounting at all, so report zeros
 		// in bash's format — shell user/sys, then children user/sys — rather
@@ -349,6 +359,9 @@ func (r *Runner) builtin(ctx context.Context, pos syntax.Pos, name string, args 
 		if len(args) == 0 {
 			// Note that "wait" without arguments always returns exit status zero.
 			for _, bg := range r.bgProcs {
+				if bg.disowned {
+					continue
+				}
 				<-bg.done
 			}
 			break

--- a/interp/builtin.go
+++ b/interp/builtin.go
@@ -362,7 +362,9 @@ func (r *Runner) builtin(ctx context.Context, pos syntax.Pos, name string, args 
 				if bg.disowned {
 					continue
 				}
-				<-bg.done
+				if !bg.await(ctx) {
+					return exitStatus{code: 130}
+				}
 			}
 			break
 		}
@@ -371,7 +373,9 @@ func (r *Runner) builtin(ctx context.Context, pos syntax.Pos, name string, args 
 			if !ok {
 				return failf(1, "wait: pid %s is not a child of this shell\n", arg)
 			}
-			<-bg.done
+			if !bg.await(ctx) {
+				return exitStatus{code: 130}
+			}
 			exit = *bg.exit
 		}
 	case "builtin":

--- a/interp/help.go
+++ b/interp/help.go
@@ -25,6 +25,17 @@ type builtinHelp struct {
 	desc     string
 }
 
+// helpNotes says how a builtin differs from bash's, for the ones that cannot
+// mean quite the same thing without processes or a controlling terminal.
+// `help NAME` prints the note after the description.
+var helpNotes = map[string]string{
+	"bg":    "background jobs already run in the background here, so this reports on the job rather than resuming it",
+	"fg":    "there is no controlling terminal here, so this waits for the job and returns its exit status",
+	"jobs":  "nothing is ever stopped without a controlling terminal, so -s lists nothing",
+	"kill":  "a job is a goroutine, not a process: terminating signals cancel it, and stop/continue are rejected; a PID that is not a job is signalled like any process",
+	"times": "there is no per-process CPU accounting on every target this shell runs on, so the times are zero",
+}
+
 // helpTable is keyed by builtin name. Synopses follow bash 5's wording so the
 // output is familiar; descriptions are ours, and say where this shell differs.
 var helpTable = map[string]builtinHelp{
@@ -102,10 +113,9 @@ var helpTable = map[string]builtinHelp{
 // helpUnsupported are recognized by this shell but not implemented; `help`
 // stars them the way bash stars disabled builtins.
 var helpUnsupported = map[string]bool{
-	"bg": true, "bind": true, "caller": true, "compgen": true, "complete": true,
-	"compopt": true, "disown": true, "enable": true, "fc": true, "fg": true,
-	"history": true, "jobs": true, "kill": true, "logout": true, "newgrp": true,
-	"suspend": true, "ulimit": true,
+	"bind": true, "caller": true, "compgen": true, "complete": true,
+	"compopt": true, "enable": true, "fc": true, "history": true,
+	"logout": true, "newgrp": true, "suspend": true, "ulimit": true,
 }
 
 // helpMatch returns the documented names matching a bash-style pattern. An
@@ -205,6 +215,8 @@ patterns:
 				r.outf("    %s\n", h.desc)
 				if helpUnsupported[name] {
 					r.out("    (recognized by this shell but not implemented)\n")
+				} else if note := helpNotes[name]; note != "" {
+					r.outf("    (%s)\n", note)
 				}
 				r.out("\n")
 			}

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -241,8 +241,25 @@ var runTests = []runTest{
 	{"help -q", "help: -q: invalid option\nhelp: usage: help [-dms] [pattern ...]\nexit status 2 #IGNORE bash prefixes its errors with `bash: line N:'"},
 	// a builtin we recognize but do not implement is starred, so that help is
 	// an honest statement of what this shell can do
-	{"help -s jobs", "jobs: jobs [-lnprs] [jobspec ...]\n #IGNORE bash implements jobs, and its synopsis differs"},
-	{"help jobs", "jobs: jobs [-lnprs] [jobspec ...]\n    Display status of jobs.\n    (recognized by this shell but not implemented)\n\n #IGNORE bash implements jobs"},
+	{"help -s jobs", "jobs: jobs [-lnprs] [jobspec ...]\n #IGNORE bash's synopsis differs"},
+	{"help -s ulimit", "ulimit: ulimit [-SHabcdefiklmnpqrstuvxPRT] [limit]\n #IGNORE bash implements ulimit"},
+
+	// job control builtins; the cases needing a job that is still running are
+	// in jobs_test.go, since here the exec middleware backgrounds goroutines
+	// that cancellation cannot interrupt
+	{"jobs", ""},
+	{"kill -l 9", "KILL\n"},
+	{"kill -l TERM", "15\n"},
+	{"kill -l NOPE", "kill: NOPE: invalid signal specification\nexit status 1 #IGNORE bash prefixes its errors with `bash: line N:'"},
+	{"kill", "kill: usage: kill [-s sigspec | -n signum] pid | jobspec ...\nexit status 2 #IGNORE bash prefixes its errors with `bash: line N:'"},
+	{"kill %9", "kill: %9: no such job\nexit status 1 #IGNORE bash prefixes its errors with `bash: line N:'"},
+	{"jobs -Z", "jobs: -Z: invalid option\njobs: usage: jobs [-lnprs] [jobspec ...]\nexit status 2 #IGNORE bash prefixes its errors with `bash: line N:'"},
+	{"sleep 0 & wait; jobs", "[1]+  Done                    sleep 0\n #IGNORE bash formats the job listing differently"},
+	{"(exit 3) & wait; jobs", "[1]+  Exit 3                  (exit 3)\n #IGNORE bash formats the job listing differently"},
+	{"true & kill -0 $!; echo st=$?", "st=0\n #IGNORE bash uses real PIDs"},
+	{"sleep 0 & disown; jobs", " #IGNORE bash also lists nothing after disown"},
+	{"(exit 4) & fg; echo st=$?", "(exit 4)\nst=4\n #IGNORE bash prints the job text differently"},
+	{"sleep 0 & wait; bg", "bg: job 1 has terminated\nexit status 1 #IGNORE bash phrases the error differently"},
 
 	// times
 	{"times", "0m0.000s 0m0.000s\n0m0.000s 0m0.000s\n #IGNORE we report zeros; bash reports real CPU time"},

--- a/interp/jobs.go
+++ b/interp/jobs.go
@@ -27,6 +27,31 @@ import (
 	"mvdan.cc/sh/v3/syntax"
 )
 
+// StopJobs cancels every background job this runner started, disowned ones
+// included, and waits for them to finish, giving up early if ctx is done
+// first. An interactive runner's jobs outlive the command line that started
+// them, so an embedder should call this when the shell itself goes away — the
+// closest thing here to the SIGHUP bash sends its jobs on exit. The shells
+// behind process substitutions are not jobs and cannot be cancelled here:
+// they follow the context of the [Runner.Run] call that started them.
+func (r *Runner) StopJobs(ctx context.Context) {
+	for _, bg := range r.bgProcs {
+		if bg.cancel != nil {
+			bg.cancel()
+		}
+	}
+	for _, bg := range r.bgProcs {
+		if bg.cancel == nil {
+			continue
+		}
+		select {
+		case <-bg.done:
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
 // jobText renders a backgrounded statement the way jobs prints it.
 func jobText(st *syntax.Stmt) string {
 	var b strings.Builder
@@ -44,6 +69,19 @@ func (bg bgProc) running() bool {
 		return false
 	default:
 		return true
+	}
+}
+
+// await blocks until the job finishes, reporting false if the caller's
+// context was cancelled first. An interactive runner's jobs are detached from
+// the caller's context, so waiting for one must watch the caller's separately
+// or an interrupted shell would block on a job that will not stop.
+func (bg bgProc) await(ctx context.Context) bool {
+	select {
+	case <-bg.done:
+		return true
+	case <-ctx.Done():
+		return false
 	}
 }
 
@@ -487,10 +525,8 @@ func (r *Runner) runFg(ctx context.Context, args []string) exitStatus {
 	}
 	bg := r.bgProcs[i]
 	r.outf("%s\n", bg.cmd)
-	select {
-	case <-ctx.Done():
+	if !bg.await(ctx) {
 		return exitStatus{code: 130}
-	case <-bg.done:
 	}
 	exit := *bg.exit
 	exit.exiting = false

--- a/interp/jobs.go
+++ b/interp/jobs.go
@@ -1,0 +1,524 @@
+// Copyright (c) 2017, Daniel Martí <mvdan@mvdan.cc>
+// See LICENSE for licensing information
+
+package interp
+
+// Job control: the jobs, kill, disown, fg and bg builtins.
+//
+// A background job in this interpreter is a goroutine running a subshell, not
+// an operating system process, which shapes what these builtins can honestly
+// do. Jobs can be listed, waited for and cancelled — kill terminates a job by
+// cancelling its context, which is what every fatal signal would have amounted
+// to here. There is no controlling terminal and no process group, so nothing
+// is ever *stopped*: fg waits for a job rather than handing it the terminal,
+// bg reports on a job that is already running, and SIGSTOP/SIGCONT are
+// rejected rather than faked.
+//
+// This is also what lets the builtins work on js/wasm, where there are no
+// processes and no signals to send.
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+
+	"mvdan.cc/sh/v3/syntax"
+)
+
+// jobText renders a backgrounded statement the way jobs prints it.
+func jobText(st *syntax.Stmt) string {
+	var b strings.Builder
+	printer := syntax.NewPrinter(syntax.SingleLine(true))
+	if err := printer.Print(&b, st); err != nil {
+		return "<job>"
+	}
+	return b.String()
+}
+
+// running reports whether a job has not finished yet.
+func (bg bgProc) running() bool {
+	select {
+	case <-bg.done:
+		return false
+	default:
+		return true
+	}
+}
+
+// status is the second column of the jobs listing, following bash: Done for a
+// job that succeeded, "Exit N" for one that failed, Terminated for one kill
+// cancelled.
+func (bg bgProc) status() string {
+	if bg.running() {
+		return "Running"
+	}
+	if bg.signal != "" {
+		return "Terminated"
+	}
+	if bg.exit.code != 0 {
+		return fmt.Sprintf("Exit %d", bg.exit.code)
+	}
+	return "Done"
+}
+
+// jobIndexes returns the indexes of the jobs the builtins act on, oldest
+// first. Disowned jobs and the shells behind process substitutions are not
+// jobs as far as the user is concerned, so they are left out.
+func (r *Runner) jobIndexes() []int {
+	var out []int
+	for i, bg := range r.bgProcs {
+		if bg.disowned || bg.cmd == "" {
+			continue
+		}
+		out = append(out, i)
+	}
+	return out
+}
+
+// currentJob and previousJob are bash's %+ and %-. bash tracks these as the
+// two most recently *stopped* jobs, falling back to the most recent running
+// ones; with nothing ever stopped here, the two most recent jobs are all that
+// distinction can mean.
+func (r *Runner) currentJob() int {
+	live := r.jobIndexes()
+	if len(live) == 0 {
+		return -1
+	}
+	return live[len(live)-1]
+}
+
+func (r *Runner) previousJob() int {
+	live := r.jobIndexes()
+	if len(live) < 2 {
+		return r.currentJob()
+	}
+	return live[len(live)-2]
+}
+
+// jobMark is the +/- column bash prints after the job number.
+func (r *Runner) jobMark(i int) string {
+	switch i {
+	case r.currentJob():
+		return "+"
+	case r.previousJob():
+		return "-"
+	}
+	return " "
+}
+
+// jobSpec resolves a job specification to an index into bgProcs. It accepts
+// bash's % forms — %1, %+, %%, %-, %string and %?string — as well as what $!
+// expands to: the real PID when the background statement started exactly one
+// external program, and a "gN" fake PID otherwise. A spec without a leading %
+// is a PID, never a job number, matching bash.
+func (r *Runner) jobSpec(spec string) (int, error) {
+	if spec == "" {
+		return -1, fmt.Errorf("no such job")
+	}
+	byNumber := func(n int) (int, error) {
+		if n <= 0 || n > len(r.bgProcs) {
+			return -1, fmt.Errorf("no such job")
+		}
+		if bg := r.bgProcs[n-1]; bg.cmd == "" || bg.disowned {
+			return -1, fmt.Errorf("no such job")
+		}
+		return n - 1, nil
+	}
+	rest, ok := strings.CutPrefix(spec, "%")
+	if !ok {
+		// Not a % form, so a PID: find the job by what $! reported, like
+		// [Runner.lookupBgProc]. A PID names the job directly, so a disowned
+		// job is still found — bash's kill also still reaches a disowned
+		// job's process by PID.
+		for i := range slices.Backward(r.bgProcs) {
+			if r.bgProcs[i].cmd != "" && r.bgProcID(i) == spec {
+				return i, nil
+			}
+		}
+		return -1, fmt.Errorf("no such job")
+	}
+	switch rest {
+	case "%", "+":
+		if i := r.currentJob(); i >= 0 {
+			return i, nil
+		}
+		return -1, fmt.Errorf("no such job")
+	case "-":
+		if i := r.previousJob(); i >= 0 {
+			return i, nil
+		}
+		return -1, fmt.Errorf("no such job")
+	}
+	if n, err := strconv.Atoi(rest); err == nil {
+		return byNumber(n)
+	}
+	// %?string matches anywhere in the command, %string only at its start.
+	substring := false
+	if s, ok := strings.CutPrefix(rest, "?"); ok {
+		substring, rest = true, s
+	}
+	match := -1
+	for _, i := range r.jobIndexes() {
+		cmd := r.bgProcs[i].cmd
+		if (substring && strings.Contains(cmd, rest)) || (!substring && strings.HasPrefix(cmd, rest)) {
+			if match >= 0 {
+				return -1, fmt.Errorf("ambiguous job spec")
+			}
+			match = i
+		}
+	}
+	if match < 0 {
+		return -1, fmt.Errorf("no such job")
+	}
+	return match, nil
+}
+
+// runJobs implements the jobs builtin.
+func (r *Runner) runJobs(args []string) exitStatus {
+	var long, pidsOnly, newOnly, runningOnly, stoppedOnly bool
+	rest := args
+	for len(rest) > 0 && strings.HasPrefix(rest[0], "-") && len(rest[0]) > 1 {
+		flag := rest[0]
+		if flag == "--" {
+			rest = rest[1:]
+			break
+		}
+		for _, c := range flag[1:] {
+			switch c {
+			case 'l':
+				long = true
+			case 'p':
+				pidsOnly = true
+			case 'n':
+				newOnly = true
+			case 'r':
+				runningOnly = true
+			case 's':
+				stoppedOnly = true
+			default:
+				r.errf("jobs: -%c: invalid option\n", c)
+				r.errf("jobs: usage: %s\n", helpTable["jobs"].synopsis)
+				return exitStatus{code: 2}
+			}
+		}
+		rest = rest[1:]
+	}
+
+	indexes := r.jobIndexes()
+	if len(rest) > 0 {
+		indexes = nil
+		for _, spec := range rest {
+			i, err := r.jobSpec(spec)
+			if err != nil {
+				r.errf("jobs: %s: %v\n", spec, err)
+				return exitStatus{code: 1}
+			}
+			indexes = append(indexes, i)
+		}
+	}
+
+	for _, i := range indexes {
+		bg := r.bgProcs[i]
+		// Nothing is ever stopped without a controlling terminal.
+		if stoppedOnly || (runningOnly && !bg.running()) {
+			continue
+		}
+		if newOnly {
+			if bg.running() || bg.notified {
+				continue
+			}
+			r.bgProcs[i].notified = true
+		}
+		if pidsOnly {
+			r.outf("%s\n", r.bgProcID(i))
+			continue
+		}
+		prefix := fmt.Sprintf("[%d]%s  ", i+1, r.jobMark(i))
+		if long {
+			prefix = fmt.Sprintf("[%d]%s %-6s", i+1, r.jobMark(i), r.bgProcID(i))
+		}
+		r.outf("%s%-24s%s\n", prefix, bg.status(), bg.cmd)
+	}
+	return exitStatus{}
+}
+
+// signalNames is the standard signal table, used by kill and `kill -l`. The
+// interpreter never delivers these to anything: they are here so that scripts
+// written for a real shell name a signal and get the behaviour that signal
+// would have had.
+var signalNames = [...]string{
+	1: "HUP", 2: "INT", 3: "QUIT", 4: "ILL", 5: "TRAP", 6: "ABRT", 7: "BUS",
+	8: "FPE", 9: "KILL", 10: "USR1", 11: "SEGV", 12: "USR2", 13: "PIPE",
+	14: "ALRM", 15: "TERM", 16: "STKFLT", 17: "CHLD", 18: "CONT", 19: "STOP",
+	20: "TSTP", 21: "TTIN", 22: "TTOU", 23: "URG", 24: "XCPU", 25: "XFSZ",
+	26: "VTALRM", 27: "PROF", 28: "WINCH", 29: "IO", 30: "PWR", 31: "SYS",
+}
+
+// signalByName resolves "TERM", "SIGTERM" or "15" to a number and canonical
+// name.
+func signalByName(spec string) (int, string, bool) {
+	if n, err := strconv.Atoi(spec); err == nil {
+		if n == 0 {
+			return 0, "", true
+		}
+		if n > 0 && n < len(signalNames) && signalNames[n] != "" {
+			return n, signalNames[n], true
+		}
+		return 0, "", false
+	}
+	name := strings.TrimPrefix(strings.ToUpper(spec), "SIG")
+	for n, known := range signalNames {
+		if known != "" && known == name {
+			return n, known, true
+		}
+	}
+	return 0, "", false
+}
+
+// signalEffect says what a signal does to a job here. Since a job is a
+// goroutine, anything whose default action would end a process cancels it, and
+// job control signals have no meaning without a terminal.
+type signalEffect int
+
+const (
+	signalTerminates  signalEffect = iota
+	signalTests                    // signal 0: only check that the job exists
+	signalUnsupported              // stop and continue, which need job control
+)
+
+func effectOf(num int) signalEffect {
+	switch num {
+	case 0:
+		return signalTests
+	case 17, 18, 19, 20, 21, 22: // CHLD, CONT, STOP, TSTP, TTIN, TTOU
+		return signalUnsupported
+	}
+	return signalTerminates
+}
+
+// runKill implements the kill builtin.
+func (r *Runner) runKill(args []string) exitStatus {
+	signum, signame := 15, "TERM"
+	rest := args
+	for len(rest) > 0 {
+		arg := rest[0]
+		if arg == "--" {
+			rest = rest[1:]
+			break
+		}
+		if len(arg) < 2 || arg[0] != '-' {
+			break
+		}
+		switch {
+		case arg == "-l" || arg == "-L":
+			return r.killList(rest[1:])
+		case arg == "-s" || arg == "-n":
+			if len(rest) < 2 {
+				r.errf("kill: %s: option requires an argument\n", arg)
+				return exitStatus{code: 2}
+			}
+			num, name, ok := signalByName(rest[1])
+			if !ok {
+				r.errf("kill: %s: invalid signal specification\n", rest[1])
+				return exitStatus{code: 1}
+			}
+			signum, signame = num, name
+			rest = rest[2:]
+			continue
+		default:
+			num, name, ok := signalByName(arg[1:])
+			if !ok {
+				r.errf("kill: %s: invalid signal specification\n", arg[1:])
+				return exitStatus{code: 1}
+			}
+			signum, signame = num, name
+		}
+		rest = rest[1:]
+	}
+
+	if len(rest) == 0 {
+		r.errf("kill: usage: %s\n", helpTable["kill"].synopsis)
+		return exitStatus{code: 2}
+	}
+
+	exit := exitStatus{}
+	for _, spec := range rest {
+		i, err := r.jobSpec(spec)
+		if err != nil {
+			// A PID that is not one of our jobs still names a process, and
+			// before kill was a builtin these reached the system's kill
+			// program, so signal the process where the platform lets us.
+			if pid, aerr := strconv.Atoi(spec); aerr == nil {
+				if kerr := killProcess(pid, signum); kerr != nil {
+					r.errf("kill: (%d) - %v\n", pid, kerr)
+					exit.code = 1
+				}
+				continue
+			}
+			r.errf("kill: %s: %v\n", spec, err)
+			exit.code = 1
+			continue
+		}
+		switch effectOf(signum) {
+		case signalTests:
+			// Existence already confirmed by resolving the spec.
+		case signalUnsupported:
+			r.errf("kill: %s: no job control\n", spec)
+			exit.code = 1
+		default:
+			if r.bgProcs[i].running() {
+				r.bgProcs[i].signal = signame
+				r.bgProcs[i].cancel()
+			}
+		}
+	}
+	return exit
+}
+
+// killList implements `kill -l`, which either names one signal or lists them
+// all in bash's five-per-row layout.
+func (r *Runner) killList(args []string) exitStatus {
+	if len(args) > 0 {
+		exit := exitStatus{}
+		for _, arg := range args {
+			num, name, ok := signalByName(arg)
+			if !ok || num == 0 {
+				r.errf("kill: %s: invalid signal specification\n", arg)
+				exit.code = 1
+				continue
+			}
+			// `kill -l NUMBER` names the signal, `kill -l NAME` numbers it.
+			if _, err := strconv.Atoi(arg); err == nil {
+				r.outf("%s\n", name)
+			} else {
+				r.outf("%d\n", num)
+			}
+		}
+		return exit
+	}
+	col := 0
+	for num, name := range signalNames {
+		if name == "" {
+			continue
+		}
+		r.outf("%2d) SIG%-9s", num, name)
+		if col++; col%5 == 0 {
+			r.out("\n")
+		}
+	}
+	if col%5 != 0 {
+		r.out("\n")
+	}
+	return exitStatus{}
+}
+
+// runDisown implements the disown builtin.
+func (r *Runner) runDisown(args []string) exitStatus {
+	var all, runningOnly bool
+	rest := args
+	for len(rest) > 0 && strings.HasPrefix(rest[0], "-") && len(rest[0]) > 1 {
+		flag := rest[0]
+		if flag == "--" {
+			rest = rest[1:]
+			break
+		}
+		for _, c := range flag[1:] {
+			switch c {
+			case 'a':
+				all = true
+			case 'r':
+				runningOnly = true
+			case 'h':
+				// Marks a job to survive SIGHUP. Nothing sends one here, so
+				// the job is simply left in the table, as bash leaves it.
+			default:
+				r.errf("disown: -%c: invalid option\n", c)
+				r.errf("disown: usage: %s\n", helpTable["disown"].synopsis)
+				return exitStatus{code: 2}
+			}
+		}
+		rest = rest[1:]
+	}
+
+	var indexes []int
+	switch {
+	case len(rest) > 0:
+		for _, spec := range rest {
+			i, err := r.jobSpec(spec)
+			if err != nil {
+				r.errf("disown: %s: %v\n", spec, err)
+				return exitStatus{code: 1}
+			}
+			indexes = append(indexes, i)
+		}
+	case all || runningOnly:
+		indexes = r.jobIndexes()
+	default:
+		if i := r.currentJob(); i >= 0 {
+			indexes = []int{i}
+		} else {
+			r.errf("disown: current: no such job\n")
+			return exitStatus{code: 1}
+		}
+	}
+	for _, i := range indexes {
+		if runningOnly && !r.bgProcs[i].running() {
+			continue
+		}
+		r.bgProcs[i].disowned = true
+	}
+	return exitStatus{}
+}
+
+// runFg implements the fg builtin. Without a controlling terminal there is no
+// foreground to move a job to, so this waits for the job and reports its exit
+// status, which is what a caller of fg is ultimately after.
+func (r *Runner) runFg(ctx context.Context, args []string) exitStatus {
+	spec := "%+"
+	if len(args) > 0 {
+		spec = args[0]
+	}
+	i, err := r.jobSpec(spec)
+	if err != nil {
+		r.errf("fg: %s: %v\n", spec, err)
+		return exitStatus{code: 1}
+	}
+	bg := r.bgProcs[i]
+	r.outf("%s\n", bg.cmd)
+	select {
+	case <-ctx.Done():
+		return exitStatus{code: 130}
+	case <-bg.done:
+	}
+	exit := *bg.exit
+	exit.exiting = false
+	return exit
+}
+
+// runBg implements the bg builtin. Jobs here always run in the background
+// already, so this reports on the job rather than resuming it, and fails on a
+// job that has finished the way bash fails on one it cannot continue.
+func (r *Runner) runBg(args []string) exitStatus {
+	specs := args
+	if len(specs) == 0 {
+		specs = []string{"%+"}
+	}
+	exit := exitStatus{}
+	for _, spec := range specs {
+		i, err := r.jobSpec(spec)
+		if err != nil {
+			r.errf("bg: %s: %v\n", spec, err)
+			exit.code = 1
+			continue
+		}
+		if !r.bgProcs[i].running() {
+			r.errf("bg: job %d has terminated\n", i+1)
+			exit.code = 1
+			continue
+		}
+		r.outf("[%d]%s %s &\n", i+1, r.jobMark(i), r.bgProcs[i].cmd)
+	}
+	return exit
+}

--- a/interp/jobs_test.go
+++ b/interp/jobs_test.go
@@ -1,0 +1,164 @@
+package interp_test
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"mvdan.cc/sh/v3/interp"
+	"mvdan.cc/sh/v3/syntax"
+)
+
+// syncBuffer collects output from the shell and from its background jobs,
+// which write concurrently.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf strings.Builder
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// runSrc runs src with the default exec handler, so background commands are
+// real processes with real PIDs, and returns the combined output. The
+// deterministic job control cases live in runTests; these tests cover jobs
+// that are genuinely running concurrently, and each src must end all jobs it
+// starts — `kill ...; wait` — so no processes outlive the test.
+func runSrc(t *testing.T, src string) string {
+	t.Helper()
+	var out syncBuffer
+	r, err := interp.New(interp.StdIO(strings.NewReader(""), &out, &out))
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, err := syntax.NewParser().Parse(strings.NewReader(src), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = r.Run(context.Background(), f)
+	return out.String()
+}
+
+// needsSubprocesses skips tests that background an external command. js/wasm
+// has no subprocesses, so those commands fail to run rather than becoming
+// jobs, and the job state under test never arises.
+func needsSubprocesses(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "js" {
+		t.Skip("js/wasm has no subprocesses")
+	}
+}
+
+func TestJobsBuiltin(t *testing.T) {
+	needsSubprocesses(t)
+	t.Parallel()
+	// A running job reports Running, and -p prints the PIDs that $! also
+	// reports — real ones, since each of these jobs is one external program.
+	if s := runSrc(t, "sleep 30 & jobs; kill %1; wait"); !strings.Contains(s, "Running") {
+		t.Fatalf("jobs while running = %q", s)
+	}
+	s := runSrc(t, "sleep 30 & jobs -p; kill %1; wait")
+	if pid, err := strconv.Atoi(strings.TrimSpace(s)); err != nil || pid <= 0 {
+		t.Fatalf("jobs -p = %q, want a real PID", s)
+	}
+	// The two most recent jobs are marked + and -.
+	s = runSrc(t, "sleep 30 & sleep 30 & jobs; kill %1 %2; wait")
+	if !strings.Contains(s, "[1]-") || !strings.Contains(s, "[2]+") {
+		t.Fatalf("job marks = %q", s)
+	}
+}
+
+func TestKillBuiltin(t *testing.T) {
+	needsSubprocesses(t)
+	t.Parallel()
+	// Killing a job cancels it, which jobs then reports as Terminated.
+	// Job specs: by job number, by the real PID $! reports, by command
+	// prefix, and by substring.
+	for _, spec := range []string{"%1", "$!", "%sleep", "%?leep"} {
+		s := runSrc(t, "sleep 30 & kill "+spec+"; wait; jobs")
+		if !strings.Contains(s, "Terminated") {
+			t.Fatalf("kill %s = %q", spec, s)
+		}
+	}
+	// A job that is not exactly one external program keeps its fake gN pid,
+	// which resolves the same way.
+	if s := runSrc(t, "(sleep 30) & kill $!; wait; jobs"); !strings.Contains(s, "Terminated") {
+		t.Fatalf("kill on a gN job = %q", s)
+	}
+	// A bare integer is a PID, not a job number: a PID belonging to no job
+	// does not touch job 1.
+	s := runSrc(t, "sleep 30 & kill 99999999; echo st=$?; jobs; kill %1; wait")
+	if !strings.Contains(s, "st=1") || !strings.Contains(s, "Running") {
+		t.Fatalf("kill on a non-job PID = %q", s)
+	}
+	// Signal 0 only tests that the job exists.
+	if s := runSrc(t, "sleep 30 & kill -0 %1; echo status=$?; jobs; kill %1; wait"); !strings.Contains(s, "status=0") || !strings.Contains(s, "Running") {
+		t.Fatalf("kill -0 = %q", s)
+	}
+	// Stopping and continuing need job control, which does not exist here.
+	if s := runSrc(t, "sleep 30 & kill -STOP %1; kill %1; wait"); !strings.Contains(s, "no job control") {
+		t.Fatalf("kill -STOP = %q", s)
+	}
+	// Both spellings of the signal reach the job.
+	for _, flag := range []string{"-9", "-KILL", "-SIGKILL", "-s KILL", "-n 9"} {
+		s := runSrc(t, "sleep 30 & kill "+flag+" %1; wait; jobs")
+		if !strings.Contains(s, "Terminated") {
+			t.Fatalf("kill %s = %q", flag, s)
+		}
+	}
+}
+
+func TestKillNonJobPID(t *testing.T) {
+	needsSubprocesses(t)
+	if runtime.GOOS == "windows" || runtime.GOOS == "plan9" {
+		t.Skip("no signals to send on this platform")
+	}
+	t.Parallel()
+	// A PID the shell did not start still names a process, which kill
+	// signals the way bash's builtin does.
+	cmd := exec.Command("sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	if s := runSrc(t, fmt.Sprintf("kill %d; echo st=$?", cmd.Process.Pid)); !strings.Contains(s, "st=0") {
+		cmd.Process.Kill()
+		cmd.Wait()
+		t.Fatalf("kill on a foreign PID = %q", s)
+	}
+	if err := cmd.Wait(); err == nil {
+		t.Fatal("process survived kill")
+	}
+}
+
+func TestDisownFgBg(t *testing.T) {
+	needsSubprocesses(t)
+	t.Parallel()
+	// A disowned job leaves the job table, and its % spec stops resolving,
+	// but its PID still does — which is also how these tests end it.
+	s := runSrc(t, "sleep 30 & p=$!; disown; jobs; kill $p; wait $p")
+	if strings.TrimSpace(s) != "" {
+		t.Fatalf("jobs after disown = %q", s)
+	}
+	s = runSrc(t, "sleep 30 & p=$!; disown %1; kill %1; kill $p; wait $p")
+	if !strings.Contains(s, "no such job") {
+		t.Fatalf("kill by job spec after disown = %q", s)
+	}
+	// bg reports on a job that is already running.
+	if s := runSrc(t, "sleep 30 & bg; kill %1; wait"); !strings.Contains(s, "[1]+ sleep 30 &") {
+		t.Fatalf("bg = %q", s)
+	}
+}

--- a/interp/jobs_test.go
+++ b/interp/jobs_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"mvdan.cc/sh/v3/interp"
 	"mvdan.cc/sh/v3/syntax"
@@ -31,6 +32,15 @@ func (b *syncBuffer) String() string {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	return b.buf.String()
+}
+
+// takeString drains the buffer, for tests that assert on one step at a time.
+func (b *syncBuffer) takeString() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	s := b.buf.String()
+	b.buf.Reset()
+	return s
 }
 
 // runSrc runs src with the default exec handler, so background commands are
@@ -160,5 +170,139 @@ func TestDisownFgBg(t *testing.T) {
 	// bg reports on a job that is already running.
 	if s := runSrc(t, "sleep 30 & bg; kill %1; wait"); !strings.Contains(s, "[1]+ sleep 30 &") {
 		t.Fatalf("bg = %q", s)
+	}
+}
+
+func TestJobsOutliveTheirContext(t *testing.T) {
+	needsSubprocesses(t)
+	t.Parallel()
+	var out syncBuffer
+	r, err := interp.New(interp.Interactive(true), interp.StdIO(strings.NewReader(""), &out, &out))
+	if err != nil {
+		t.Fatal(err)
+	}
+	run := func(ctx context.Context, src string) {
+		t.Helper()
+		f, err := syntax.NewParser().Parse(strings.NewReader(src), "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = r.Run(ctx, f)
+	}
+
+	// An interactive shell cancels each line's context once the line is
+	// done; the job it started must survive that.
+	ctx, cancel := context.WithCancel(context.Background())
+	run(ctx, "sleep 30 &")
+	cancel()
+
+	run(context.Background(), "jobs")
+	if s := out.takeString(); !strings.Contains(s, "Running") {
+		t.Fatalf("job did not outlive its context: %q", s)
+	}
+
+	// Waiting for one still gives up when the caller's context is cancelled,
+	// rather than blocking on a job that no longer dies with it.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		waitCtx, waitCancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		defer waitCancel()
+		run(waitCtx, "wait")
+	}()
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("wait did not return when its context was cancelled")
+	}
+
+	// StopJobs is how the embedder ends them when the shell goes away.
+	out.takeString()
+	r.StopJobs(context.Background())
+	run(context.Background(), "jobs")
+	if s := out.takeString(); strings.Contains(s, "Running") {
+		t.Fatalf("StopJobs left the job running: %q", s)
+	}
+}
+
+func TestNonInteractiveJobsDieWithContext(t *testing.T) {
+	needsSubprocesses(t)
+	t.Parallel()
+	// Without Interactive, jobs keep master's behavior: an embedder bounding
+	// a script with a timeout reaps its background children on cancel.
+	var out syncBuffer
+	r, err := interp.New(interp.StdIO(strings.NewReader(""), &out, &out))
+	if err != nil {
+		t.Fatal(err)
+	}
+	run := func(ctx context.Context, src string) {
+		t.Helper()
+		f, err := syntax.NewParser().Parse(strings.NewReader(src), "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = r.Run(ctx, f)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	run(ctx, "sleep 30 &")
+	cancel()
+	run(context.Background(), "wait; jobs")
+	if s := out.String(); strings.Contains(s, "Running") {
+		t.Fatalf("non-interactive job survived its context: %q", s)
+	}
+}
+
+func TestStopJobsSkipsProcessSubstitutions(t *testing.T) {
+	needsSubprocesses(t)
+	if runtime.GOOS == "windows" {
+		t.Skip("no process substitutions on windows")
+	}
+	t.Parallel()
+	// The shells behind process substitutions are not jobs and have no
+	// cancel func; StopJobs must not block on them.
+	var out syncBuffer
+	r, err := interp.New(interp.Interactive(true), interp.StdIO(strings.NewReader(""), &out, &out))
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, err := syntax.NewParser().Parse(strings.NewReader("echo <(sleep 20) >/dev/null"), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel() // ends the substitution's shell, which follows Run's context
+	_ = r.Run(ctx, f)
+	start := time.Now()
+	r.StopJobs(context.Background())
+	if d := time.Since(start); d > 10*time.Second {
+		t.Fatalf("StopJobs blocked on a process substitution for %v", d)
+	}
+}
+
+func TestResetStopsJobs(t *testing.T) {
+	needsSubprocesses(t)
+	if runtime.GOOS == "windows" || runtime.GOOS == "plan9" {
+		t.Skip("checking process liveness needs signals")
+	}
+	t.Parallel()
+	// Reset drops the job table, so it must end the jobs first: a detached
+	// job surviving it would be unreachable and unstoppable.
+	var out syncBuffer
+	r, err := interp.New(interp.Interactive(true), interp.StdIO(strings.NewReader(""), &out, &out))
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, err := syntax.NewParser().Parse(strings.NewReader("sleep 30 & echo pid=$!"), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	_ = r.Run(ctx, f)
+	cancel()
+	pid := strings.TrimSpace(strings.TrimPrefix(out.String(), "pid="))
+	r.Reset()
+	// Reset waited for the job, so its process is gone and reaped.
+	if s := runSrc(t, "kill -0 "+pid+"; echo st=$?"); !strings.Contains(s, "st=1") {
+		t.Fatalf("job survived Reset: kill -0 = %q", s)
 	}
 }

--- a/interp/os_notunix.go
+++ b/interp/os_notunix.go
@@ -58,3 +58,8 @@ func isETXTBSY(err error) bool { return false }
 
 func (waitStatus) Signaled() bool { return false }
 func (waitStatus) Signal() int    { return 0 }
+
+// killProcess is a no-op on plan9 and windows, which have no signals to send.
+func killProcess(pid, signum int) error {
+	return fmt.Errorf("cannot signal processes on this platform")
+}

--- a/interp/os_unix.go
+++ b/interp/os_unix.go
@@ -54,3 +54,9 @@ func isENOEXEC(err error) bool { return errors.Is(err, syscall.ENOEXEC) }
 // isETXTBSY reports whether the kernel refused to execute a file
 // with ETXTBSY, i.e. a process holds it open for writing.
 func isETXTBSY(err error) bool { return errors.Is(err, syscall.ETXTBSY) }
+
+// killProcess sends a signal to a process that is not one of this runner's
+// jobs, for the kill builtin given a PID it does not know.
+func killProcess(pid, signum int) error {
+	return unix.Kill(pid, unix.Signal(signum))
+}

--- a/interp/runner.go
+++ b/interp/runner.go
@@ -296,6 +296,12 @@ func (r *Runner) stmt(ctx context.Context, st *syntax.Stmt) {
 		st2.Background = false
 		st2.Disown = false
 		bg := r.newBgProc()
+		// A job is a goroutine, so kill cancels its context rather than
+		// signalling a process.
+		bgCtx, cancel := context.WithCancel(ctx)
+		bg.cmd = jobText(&st2)
+		bg.cancel = cancel
+		bg.disowned = st.Disown
 		// A plain command call may amount to starting exactly one external
 		// program, in which case $! expands to its real PID like in other
 		// shells, which fork background statements as child processes.
@@ -308,7 +314,8 @@ func (r *Runner) stmt(ctx context.Context, st *syntax.Stmt) {
 		}
 		r.bgProcs = append(r.bgProcs, bg)
 		go func() {
-			r2.Run(ctx, &st2)
+			defer cancel()
+			r2.Run(bgCtx, &st2)
 			r2.reportBgStart(0)     // in case we didn't get to start a program
 			r2.exit.exiting = false // subshells don't exit the parent shell
 			*bg.exit = r2.exit

--- a/interp/runner.go
+++ b/interp/runner.go
@@ -298,7 +298,20 @@ func (r *Runner) stmt(ctx context.Context, st *syntax.Stmt) {
 		bg := r.newBgProc()
 		// A job is a goroutine, so kill cancels its context rather than
 		// signalling a process.
-		bgCtx, cancel := context.WithCancel(ctx)
+		//
+		// An interactive shell runs each command line under its own context,
+		// and a background job outlives the line that started it: in bash,
+		// the interrupt that ends a foreground command leaves the background
+		// jobs alone. So an interactive runner detaches the job's context
+		// from the statement's, and the job ends via kill, [Runner.StopJobs],
+		// or the shell process exiting. Anywhere else jobs keep dying with
+		// the caller's context, so that an embedder bounding a script with a
+		// timeout does not leak them.
+		bgBase := ctx
+		if r.interactive {
+			bgBase = context.WithoutCancel(ctx)
+		}
+		bgCtx, cancel := context.WithCancel(bgBase)
 		bg.cmd = jobText(&st2)
 		bg.cancel = cancel
 		bg.disowned = st.Disown


### PR DESCRIPTION
Split out of #1382 per review — this is the risky half, carrying only the lifecycle change; the builtins stay there. Stacked on that branch, so the first commit here is #1382's and the diff to review is the last commit.

What changed since the version reviewed in #1382:

- **Gated on `Interactive(true)`.** Only an interactive runner detaches a job's context (`context.WithoutCancel`); everywhere else jobs keep dying with the caller's context, so an embedder bounding a script with a timeout still reaps its children on cancel. `Interactive` gains a real flag on the Runner (its doc already promised it would grow behavior beyond alias expansion), and there is a regression test pinning the non-interactive behavior to master's.
- **`StopJobs(ctx)`.** Takes a context so a caller can bound the wait, and skips the shells behind process substitutions — they have no cancel func and are not jobs; they follow their `Run` call's context. `echo <(sleep 20) >/dev/null` followed by `StopJobs` returns immediately now, with a test.
- **`Reset` ends jobs first.** A detached job surviving `Reset` would be unreachable with its cancel func dropped, so `Reset` stops them before the table is cleared, with a test that checks the process is actually gone.
- **`cmd/gosh` is updated**: the interactive loop stops its jobs on the way out, the closest thing here to bash's SIGHUP-on-exit. (Bash's default is actually `huponexit` off, but a goroutine job cannot survive its process anyway, and killing the leftover child processes is the honest version of that.)

`wait` and `fg` watch the caller's context themselves since a detached job no longer dies with it — that part is unchanged from what was reviewed.