### PR TITLE
syntax: support zsh try and always blocks

### DIFF
--- a/syntax/filetests_test.go
+++ b/syntax/filetests_test.go
@@ -186,6 +186,12 @@ func langErr2(wantErr string, langSets ...LangVariant) func(*fileTestCase) {
 }
 
 var fileTests = []fileTestCase{
+	fileTest([]string{"{ foo; } always { bar; }"},
+		langFile(&TryClause{Body: block(litStmt("foo")), Always: block(litStmt("bar"))}, LangZsh),
+	),
+	fileTest([]string{"{ } always { }", "{} always {}"},
+		langFile(&TryClause{Body: block(), Always: block()}, LangZsh),
+	),
 	fileTest(
 		[]string{"", " ", "\t", "\n \n", "\r \r\n"},
 		langFile(&File{}),
@@ -5718,6 +5724,8 @@ func (c sanityChecker) visit(node Node) bool {
 	case *Block:
 		c.checkPos(node, node.Lbrace, "{")
 		c.checkPos(node, node.Rbrace, "}")
+	case *TryClause:
+		c.checkPos(node, node.AlwaysPos, "always")
 	case *IfClause:
 		if node.ThenPos.IsValid() {
 			c.checkPos(node, node.Position, "if", "elif")

--- a/syntax/nodes.go
+++ b/syntax/nodes.go
@@ -261,7 +261,7 @@ func (s *Stmt) End() Pos {
 // function declarations.
 //
 // These are [*CallExpr], [*IfClause], [*WhileClause], [*ForClause], [*CaseClause],
-// [*Block], [*Subshell], [*BinaryCmd], [*FuncDecl], [*ArithmCmd], [*TestClause],
+// [*Block], [*TryClause], [*Subshell], [*BinaryCmd], [*FuncDecl], [*ArithmCmd], [*TestClause],
 // [*DeclClause], [*LetClause], [*TimeClause], and [*CoprocClause].
 type Command interface {
 	Node
@@ -274,6 +274,7 @@ func (*WhileClause) commandNode()  {}
 func (*ForClause) commandNode()    {}
 func (*CaseClause) commandNode()   {}
 func (*Block) commandNode()        {}
+func (*TryClause) commandNode()    {}
 func (*Subshell) commandNode()     {}
 func (*BinaryCmd) commandNode()    {}
 func (*FuncDecl) commandNode()     {}
@@ -401,6 +402,20 @@ type Block struct {
 
 func (b *Block) Pos() Pos { return b.Lbrace }
 func (b *Block) End() Pos { return posAddCol(b.Rbrace, 1) }
+
+// TryClause represents a Zsh try/always construct. Always is executed even
+// when control leaves Body via return, break, or continue.
+//
+// This node is only used with [LangZsh].
+type TryClause struct {
+	Body           *Block
+	AlwaysPos      Pos
+	Always         *Block
+	AlwaysComments []Comment // comments between "always" and its block
+}
+
+func (t *TryClause) Pos() Pos { return t.Body.Pos() }
+func (t *TryClause) End() Pos { return t.Always.End() }
 
 // IfClause represents an if statement.
 type IfClause struct {

--- a/syntax/parser.go
+++ b/syntax/parser.go
@@ -2189,11 +2189,12 @@ func (p *Parser) gotStmtPipe(s *Stmt, binCmd bool) *Stmt {
 		switch p.val {
 		case "{":
 			p.block(s)
+			p.tryClause(s)
 		case "{}":
 			// Zsh treats closing braces in a special way, allowing this.
 			if p.lang.in(LangZsh) {
-				s.Cmd = &Block{Lbrace: p.pos, Rbrace: posAddCol(p.pos, 1)}
-				p.next()
+				p.block(s)
+				p.tryClause(s)
 			}
 		case "if":
 			p.ifClause(s)
@@ -2204,7 +2205,6 @@ func (p *Parser) gotStmtPipe(s *Stmt, binCmd bool) *Stmt {
 			p.forClause(s)
 		case "case":
 			p.caseClause(s)
-		// TODO(zsh): { try-list } "always" { always-list }
 		case "}":
 			p.curErr(`%#q can only be used to close a block`, rightBrace)
 		case "then", "elif":
@@ -2387,7 +2387,29 @@ func (p *Parser) arithmExpCmd(s *Stmt) {
 	s.Cmd = ar
 }
 
+func (p *Parser) tryClause(s *Stmt) {
+	if !p.lang.in(LangZsh) || p.tok != _LitWord || p.val != "always" {
+		return
+	}
+	clause := &TryClause{Body: s.Cmd.(*Block), AlwaysPos: p.pos}
+	p.next()
+	p.got(_Newl)
+	clause.AlwaysComments, p.accComs = p.accComs, nil
+	if p.tok != _LitWord || (p.val != "{" && p.val != "{}") {
+		p.curErr("`always` must be followed by a brace block")
+		return
+	}
+	p.block(s)
+	clause.Always = s.Cmd.(*Block)
+	s.Cmd = clause
+}
+
 func (p *Parser) block(s *Stmt) {
+	if p.lang.in(LangZsh) && p.val == "{}" {
+		s.Cmd = &Block{Lbrace: p.pos, Rbrace: posAddCol(p.pos, 1)}
+		p.next()
+		return
+	}
 	b := &Block{Lbrace: p.pos}
 	p.next()
 	b.Stmts, b.Last = p.followStmts("{", b.Lbrace, "}")

--- a/syntax/printer.go
+++ b/syntax/printer.go
@@ -1261,6 +1261,16 @@ func (p *Printer) command(cmd Command, redirs []*Redirect) (startRedirs int) {
 		p.wantNewline = p.wantNewline || p.funcNextLine
 		p.nestedStmts(cmd.Stmts, cmd.Last, cmd.Rbrace)
 		p.semiRsrv("}", cmd.Rbrace)
+	case *TryClause:
+		p.command(cmd.Body, nil)
+		p.spacedString("always", cmd.AlwaysPos)
+		p.comments(cmd.AlwaysComments...)
+		if p.wantsNewline(cmd.Always.Pos(), false) {
+			p.newlines(cmd.Always.Pos())
+		} else {
+			p.space()
+		}
+		p.command(cmd.Always, nil)
 	case *IfClause:
 		p.ifClause(cmd, false)
 	case *Subshell:

--- a/syntax/typedjson/json.go
+++ b/syntax/typedjson/json.go
@@ -318,6 +318,7 @@ var nodeByName = map[string]reflect.Type{
 	"WhileClause":  reflect.TypeFor[syntax.WhileClause](),
 	"CaseClause":   reflect.TypeFor[syntax.CaseClause](),
 	"Block":        reflect.TypeFor[syntax.Block](),
+	"TryClause":    reflect.TypeFor[syntax.TryClause](),
 	"Subshell":     reflect.TypeFor[syntax.Subshell](),
 	"FuncDecl":     reflect.TypeFor[syntax.FuncDecl](),
 	"TestClause":   reflect.TypeFor[syntax.TestClause](),

--- a/syntax/typedjson/json_test.go
+++ b/syntax/typedjson/json_test.go
@@ -51,7 +51,8 @@ var allNodeNames = []string{
 	"CoprocClause", "DblQuoted", "DeclClause", "ExtGlob", "File", "FlagsArithm",
 	"ForClause", "FuncDecl", "IfClause", "LetClause", "Lit", "ParamExp",
 	"ParenArithm", "ParenTest", "ProcSubst", "Redirect", "SglQuoted", "Stmt",
-	"Subshell", "TestClause", "TestDecl", "TimeClause", "UnaryArithm",
+	"Subshell", "TestClause", "TestDecl", "TimeClause",
+	"TryClause", "UnaryArithm",
 	"UnaryTest", "WhileClause", "Word", "WordIter",
 }
 
@@ -88,6 +89,7 @@ coproc foo
 `},
 		// ${a[(r)foo]} produces a FlagsArithm node, which only appears with zsh.
 		{syntax.LangZsh, "echo ${a[(r)foo]}\n"},
+		{syntax.LangZsh, "{ foo; } always { bar; }\n"},
 		// TestDecl only appears with bats.
 		{syntax.LangBats, "@test \"name\" {\n\tfoo\n}\n"},
 	}

--- a/syntax/walk.go
+++ b/syntax/walk.go
@@ -54,6 +54,10 @@ func Walk(node Node, f func(Node) bool) {
 	case *Block:
 		walkList(node.Stmts, f)
 		walkComments(node.Last, f)
+	case *TryClause:
+		Walk(node.Body, f)
+		walkComments(node.AlwaysComments, f)
+		Walk(node.Always, f)
 	case *IfClause:
 		walkList(node.Cond, f)
 		walkComments(node.CondLast, f)

--- a/syntax/zsh_always_test.go
+++ b/syntax/zsh_always_test.go
@@ -4,6 +4,7 @@
 package syntax
 
 import (
+	"os/exec"
 	"strings"
 	"testing"
 
@@ -12,7 +13,64 @@ import (
 
 func TestZshAlways(t *testing.T) {
 	t.Parallel()
-	// This records the current rejection of valid Zsh syntax.
-	_, err := NewParser(Variant(LangZsh)).Parse(strings.NewReader("{ :; } always { :; }"), "")
-	qt.Assert(t, qt.IsNotNil(err))
+	inputs := []string{
+		"{ print try; } always { print cleanup; }",
+		"{} always {}",
+		"{ :; } always\n{ :; }",
+		"{ :; } always # comment\n{ :; }",
+		"{ } always { }",
+		"{\n# try\nprint try\n} always {\n# cleanup\nprint cleanup\n}",
+		"{ { print nested; } always { print inner; }; } always { print outer; }",
+		"f() { { return 7; } always { print cleanup; }; }; f; print $?",
+		"f() { { return 7; } always { print cleanup; }; }; f",
+		"for x in a b; do\n{\nprint $x\nbreak\n} always {\nprint cleanup\n}\ndone",
+		"for x in a b; do\n{\nprint $x\ncontinue\n} always {\nprint cleanup\n}\ndone",
+		"{ print redirected; } always { print cleanup; } >/dev/null",
+		"{ cat <<EOF\ntry\nEOF\n} always { print cleanup; }",
+	}
+	for _, src := range inputs {
+		t.Run(src, func(t *testing.T) {
+			for _, opts := range [][]PrinterOption{nil, {Minify(true)}, {SingleLine(true)}, {KeepPadding(true)}, {BinaryNextLine(true)}, {FunctionNextLine(true)}} {
+				parser := NewParser(Variant(LangZsh), KeepComments(true))
+				node, err := parser.Parse(strings.NewReader(src), "")
+				qt.Assert(t, qt.IsNil(err))
+				out, err := strPrint(NewPrinter(opts...), node)
+				qt.Assert(t, qt.IsNil(err))
+				again, err := parser.Parse(strings.NewReader(out), "")
+				qt.Assert(t, qt.IsNil(err), qt.Commentf("formatted: %s", out))
+				out2, err := strPrint(NewPrinter(opts...), again)
+				qt.Assert(t, qt.IsNil(err))
+				qt.Assert(t, qt.Equals(out2, out))
+				t.Run("zsh", func(t *testing.T) {
+					external := externalShells[LangZsh]
+					external.require(t)
+					type result struct {
+						stdout, stderr string
+						status         int
+					}
+					run := func(source string) result {
+						t.Helper()
+						cmd := exec.Command(external.cmd, "-f", "-c", source)
+						var stdout, stderr strings.Builder
+						cmd.Stdout, cmd.Stderr = &stdout, &stderr
+						err := cmd.Run()
+						qt.Assert(t, qt.IsNotNil(cmd.ProcessState), qt.Commentf("run: %v", err))
+						status := cmd.ProcessState.ExitCode()
+						qt.Assert(t, qt.IsTrue(status >= 0), qt.Commentf("run: %v", err))
+						return result{stdout.String(), stderr.String(), status}
+					}
+					before, after := run(src), run(out)
+					qt.Assert(t, qt.Equals(after, before), qt.Commentf("formatted: %s", out))
+				})
+			}
+		})
+	}
+	for _, src := range []string{"{ :; } always", "{ :; } always echo bad", "{ :; } always {", "{ :; } always { :; } always { :; }"} {
+		_, err := NewParser(Variant(LangZsh)).Parse(strings.NewReader(src), "")
+		qt.Assert(t, qt.IsNotNil(err), qt.Commentf("source: %s", src))
+	}
+	for _, lang := range []LangVariant{LangBash, LangPOSIX, LangMirBSDKorn} {
+		_, err := NewParser(Variant(lang)).Parse(strings.NewReader("{ :; } always { :; }"), "")
+		qt.Assert(t, qt.IsNotNil(err), qt.Commentf("language: %s", lang))
+	}
 }

--- a/syntax/zsh_always_test.go
+++ b/syntax/zsh_always_test.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2026, Daniel Martí <mvdan@mvdan.cc>
+// See LICENSE for licensing information
+
+package syntax
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/go-quicktest/qt"
+)
+
+func TestZshAlways(t *testing.T) {
+	t.Parallel()
+	// This records the current rejection of valid Zsh syntax.
+	_, err := NewParser(Variant(LangZsh)).Parse(strings.NewReader("{ :; } always { :; }"), "")
+	qt.Assert(t, qt.IsNotNil(err))
+}


### PR DESCRIPTION
`shfmt -ln=zsh` currently rejects `{ ... } always { ... }`, preventing formatting of scripts such as zsh-autosuggestions that use it for resource cleanup. This change preserves the construct and its cleanup semantics in formatted output.

Add a Zsh-only `TryClause` command containing the try and cleanup blocks, the `always` position, and comments before the cleanup block. Extend the parser, printer, AST walker, and typed JSON codec. The printer keeps `always` on the same line as the preceding closing brace. Other language variants continue to reject this syntax.

The commits first record the existing rejection, then add support and replace that expectation with positive regressions.

Validation:

- `go test ./...` and `go vet ./...`.
- A 20-second `FuzzParsePrint` run.
- Zsh 5.9 behavior comparisons for normal cleanup and cleanup after return, break, and continue; nested/empty blocks, comments, redirections, heredocs, and printer options.
- The complete zsh-autosuggestions v0.7.1-based file formats and passes `zsh -n`.
- Assertions use `qt`; Zsh subtests use the existing requirement helper, comparing stdout, stderr, and exact exit status. Missing-Zsh checks verify skipping normally and failing with `REQUIRE_SHELLS=1`.

This adds a public AST command type; its naming and shape need API review. It implements parsing and formatting, not Zsh execution support in `interp`.

Fixes #1211.
