### PR TITLE
cmd/shfmt,syntax: preserve zsh associative keys

### DIFF
--- a/cmd/shfmt/main.go
+++ b/cmd/shfmt/main.go
@@ -210,7 +210,7 @@ For more information and to report bugs, see https://github.com/mvdan/sh.
 			useEditorConfig = false
 		}
 	})
-	parser = syntax.NewParser(syntax.KeepComments(true))
+	parser = syntax.NewParser(syntax.KeepComments(true), syntax.ZshSubscriptsAsWords(true))
 	printer = syntax.NewPrinter(syntax.Minify(minify.val))
 
 	syntax.RecoverErrors(expRecover.val)(parser)

--- a/cmd/shfmt/testdata/script/zsh-subscripts.txtar
+++ b/cmd/shfmt/testdata/script/zsh-subscripts.txtar
@@ -1,0 +1,30 @@
+stdin keys.zsh
+exec shfmt -ln=zsh
+cmp stdout keys.zsh
+! stderr .
+
+exec shfmt keys.zsh
+cmp stdout keys.zsh
+! stderr .
+
+stdin keys.zsh
+exec shfmt -ln=zsh -mn
+cmp stdout keys.zsh
+! stderr .
+
+stdin index.sh
+exec shfmt -ln=bash
+cmp stdout index.golden
+! stderr .
+
+-- keys.zsh --
+typeset -A h
+h[foo-bar]=1
+h[a/b]=2
+h[a:b]=3
+h[a+b]=4
+print -r -- "${h[a - b]}" $h[foo-bar]
+-- index.sh --
+a[i+1]=2
+-- index.golden --
+a[i + 1]=2

--- a/syntax/lexer.go
+++ b/syntax/lexer.go
@@ -202,6 +202,20 @@ func (p *Parser) nextKeepSpaces() {
 	switch p.quote {
 	case runeByRune:
 		p.tok = illegalTok
+	case zshSubscript:
+		switch r {
+		case ']':
+			if p.zshSubscriptDepth == 0 {
+				p.tok = rightBrack
+				p.rune()
+				break
+			}
+			p.advanceLitZshSubscript(r)
+		case '`', '"', '$', '\'':
+			p.tok = p.regToken(r)
+		default:
+			p.advanceLitZshSubscript(r)
+		}
 	case dblQuotes:
 		switch r {
 		case '`', '"', '$':
@@ -1414,4 +1428,28 @@ func testBinaryOp(val string) BinTestOperator {
 	default:
 		return 0
 	}
+}
+
+// Zsh decides at runtime whether a subscript is an arithmetic expression or
+// an associative key. Preserve literal operators and whitespace in either case.
+func (p *Parser) advanceLitZshSubscript(r rune) {
+	tok := _LitWord
+loop:
+	for p.newLit(r); r != runeEOF; r = p.rune() {
+		switch r {
+		case '\\':
+			p.rune()
+		case '\'', '"', '`', '$':
+			tok = _Lit
+			break loop
+		case '[':
+			p.zshSubscriptDepth++
+		case ']':
+			if p.zshSubscriptDepth == 0 {
+				break loop
+			}
+			p.zshSubscriptDepth--
+		}
+	}
+	p.tok, p.val = tok, p.endLit()
 }

--- a/syntax/parser.go
+++ b/syntax/parser.go
@@ -24,6 +24,20 @@ func KeepComments(enabled bool) ParserOption {
 	return func(p *Parser) { p.keepComments = enabled }
 }
 
+// ZshSubscriptsAsWords preserves unflagged Zsh subscripts as words rather
+// than interpreting their literal operators as arithmetic. Zsh determines at
+// runtime whether an array is associative, so formatting an arithmetic tree
+// can otherwise change its keys. Shell expansions remain structured nodes.
+//
+// This option only affects [LangZsh]. It is disabled by default to preserve
+// the v3 AST representation. Enable it when formatting Zsh source.
+// Flagged subscripts retain their existing representation.
+func ZshSubscriptsAsWords(enabled bool) ParserOption {
+	return func(p *Parser) { p.zshSubscriptsAsWords = enabled }
+}
+
+// TODO(v4): enable ZshSubscriptsAsWords by default.
+
 // LangVariant describes a shell language variant to use when tokenizing and
 // parsing shell code. The zero value is [LangBash].
 //
@@ -499,6 +513,9 @@ type Parser struct {
 
 	pos Pos // position of tok
 
+	zshSubscriptDepth    int
+	zshSubscriptsAsWords bool
+
 	quote   quoteState // current lexer state
 	eqlOffs int        // position of '=' in [Parser.val] when [Parser.tok].isLit is true
 
@@ -680,6 +697,7 @@ const (
 	// paramExpArithm is a subscript like ${a[i]}, which can be a string key
 	// rather than an arithmetic expression when the array is associative.
 	paramExpArithm
+	zshSubscript
 	// paramExpSlice is a slice like ${a:i:j}, which is always arithmetic.
 	paramExpSlice
 	paramExpRepl
@@ -687,7 +705,7 @@ const (
 	arrayElems
 
 	allKeepSpaces = runeByRune | paramExpRepl | dblQuotes | hdocBody |
-		hdocBodyTabs | paramExpRepl | paramExpExp
+		hdocBodyTabs | paramExpRepl | paramExpExp | zshSubscript
 	allRegTokens = noState | unquotedWordCont | subCmd | subCmdBckquo | subCmdBraces |
 		hdocWord | switchCase | arrayElems | testExpr
 	allArithmExpr = arithmExpr | arithmExprLet | arithmExprCmd |
@@ -1826,6 +1844,20 @@ func (p *Parser) paramExpExp() *Expansion {
 func (p *Parser) eitherIndex() ArithmExpr {
 	old := p.quote
 	lpos := p.pos
+	if p.lang.in(LangZsh) && p.zshSubscriptsAsWords && p.r != '(' {
+		depth := p.zshSubscriptDepth
+		p.zshSubscriptDepth = 0
+		p.quote = zshSubscript
+		p.next()
+		word := p.getWord()
+		if word == nil {
+			p.followErrExp(lpos, leftBrack)
+		}
+		p.quote = old
+		p.zshSubscriptDepth = depth
+		p.matchedArithm(lpos, leftBrack, rightBrack)
+		return word
+	}
 	p.quote = paramExpArithm
 	p.next()
 	if p.tok == star || p.tok == at {

--- a/syntax/zsh_subscripts_test.go
+++ b/syntax/zsh_subscripts_test.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2026, Daniel Martí <mvdan@mvdan.cc>
+// See LICENSE for licensing information
+
+package syntax
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/go-quicktest/qt"
+)
+
+func TestZshSubscripts(t *testing.T) {
+	t.Parallel()
+	node, err := NewParser(Variant(LangZsh)).Parse(strings.NewReader("h[foo-bar]=1"), "")
+	qt.Assert(t, qt.IsNil(err))
+	out, err := strPrint(NewPrinter(), node)
+	// This records the current corruption of a valid associative key.
+	qt.Assert(t, qt.IsNil(err))
+	qt.Assert(t, qt.Equals(out, "h[foo - bar]=1\n"))
+}

--- a/syntax/zsh_subscripts_test.go
+++ b/syntax/zsh_subscripts_test.go
@@ -4,18 +4,111 @@
 package syntax
 
 import (
+	"io"
+	"os/exec"
 	"strings"
 	"testing"
+	"testing/iotest"
 
 	"github.com/go-quicktest/qt"
 )
 
 func TestZshSubscripts(t *testing.T) {
 	t.Parallel()
-	node, err := NewParser(Variant(LangZsh)).Parse(strings.NewReader("h[foo-bar]=1"), "")
-	qt.Assert(t, qt.IsNil(err))
-	out, err := strPrint(NewPrinter(), node)
-	// This records the current corruption of a valid associative key.
-	qt.Assert(t, qt.IsNil(err))
-	qt.Assert(t, qt.Equals(out, "h[foo - bar]=1\n"))
+	inputs := []string{
+		`typeset -A h; h[foo-bar]=1; print -r -- $h[foo-bar]`,
+		`typeset -A h; h[a/b]=2; print -r -- "${h[a/b]}"`,
+		`typeset -A h; h[a:b]=3; print -r -- "${h[a:b]}"`,
+		`typeset -A h; h[a+b]=4; print -r -- "${h[a+b]}"`,
+		`typeset -A h; h[-n]=5; print -r -- "$h[-n]"`,
+		`typeset -A h; h=("a - b" 6 a-b 7); print -r -- "${h[a - b]}" "${h[a-b]}"`,
+		`typeset -A h; h[foo-bar]=8; print -r -- $(( $+h[foo-bar] ))`,
+		`a=(one two three); i=1; print -r -- "${a[i+1]}" "${a[1,2]}" "${a[-1]}"`,
+		`a=(one two three); print -r -- "${a[$((1+1))]}" "${a[$(print 2)]}"`,
+		`a=(one two three); b=(2); print -r -- "${a[b[1]]}" "${a[${b[1]}]}"`,
+		`a=(one two three); print -r -- "${a[(r)t*]}"`,
+		`typeset -A h; h=("a]b" 9); print -r -- "${h[a\]b]}"`,
+	}
+	key := strings.Repeat("key-", 2048) + "end"
+	inputs = append(inputs, "typeset -A h; h["+key+"]=10; print -r -- ${h["+key+"]}")
+	for _, src := range inputs {
+		t.Run(src, func(t *testing.T) {
+			for _, opts := range [][]PrinterOption{nil, {Minify(true)}, {SingleLine(true)}} {
+				node, err := NewParser(Variant(LangZsh), ZshSubscriptsAsWords(true)).Parse(iotest.OneByteReader(strings.NewReader(src)), "")
+				qt.Assert(t, qt.IsNil(err))
+				out, err := strPrint(NewPrinter(opts...), node)
+				qt.Assert(t, qt.IsNil(err))
+				again, err := NewParser(Variant(LangZsh), ZshSubscriptsAsWords(true)).Parse(strings.NewReader(out), "")
+				qt.Assert(t, qt.IsNil(err), qt.Commentf("formatted: %s", out))
+				out2, err := strPrint(NewPrinter(opts...), again)
+				qt.Assert(t, qt.IsNil(err))
+				qt.Assert(t, qt.Equals(out2, out))
+				t.Run("zsh", func(t *testing.T) {
+					external := externalShells[LangZsh]
+					external.require(t)
+					type result struct {
+						stdout, stderr string
+						status         int
+					}
+					run := func(source string) result {
+						t.Helper()
+						cmd := exec.Command(external.cmd, "-f", "-c", source)
+						var stdout, stderr strings.Builder
+						cmd.Stdout, cmd.Stderr = &stdout, &stderr
+						err := cmd.Run()
+						qt.Assert(t, qt.IsNotNil(cmd.ProcessState), qt.Commentf("run: %v", err))
+						status := cmd.ProcessState.ExitCode()
+						qt.Assert(t, qt.IsTrue(status >= 0), qt.Commentf("run: %v", err))
+						return result{stdout.String(), stderr.String(), status}
+					}
+					before, after := run(src), run(out)
+					qt.Assert(t, qt.Equals(after, before), qt.Commentf("formatted: %s", out))
+				})
+			}
+		})
+	}
+}
+
+func TestZshSubscriptsAsWords(t *testing.T) {
+	t.Parallel()
+	for _, lang := range []LangVariant{LangZsh, LangBash, LangMirBSDKorn} {
+		t.Run(lang.String(), func(t *testing.T) {
+			parser := NewParser(Variant(lang))
+			for _, enabled := range []bool{false, true, false} {
+				ZshSubscriptsAsWords(enabled)(parser)
+				var index ArithmExpr = &BinaryArithm{Op: Sub, X: litWord("foo"), Y: litWord("bar")}
+				if lang == LangZsh && enabled {
+					index = litWord("foo-bar")
+				}
+				want := fullProg(&CallExpr{Assigns: []*Assign{{Name: lit("h"), Index: index, Value: litWord("1")}}})
+				singleParse(parser, "h[foo-bar]=1", want)(t)
+			}
+		})
+	}
+	for _, key := range []string{"foo-bar", "a/b", "a:b", "a+b", "a - b", "a[1]", `a\]b`} {
+		parser := NewParser(Variant(LangZsh), ZshSubscriptsAsWords(true))
+		singleParse(parser, "${h["+key+"]}", fullProg(&ParamExp{Param: lit("h"), Index: litWord(key)}))(t)
+	}
+}
+
+func FuzzZshSubscripts(f *testing.F) {
+	for _, source := range []string{
+		"h[foo-bar]=1", "${h[a:b]}", "${h[a - b]}", "${a[b[1]]}",
+		"${a[${b[1]}]}", "${a[$(echo 1)]}", "${a[$((1+1))]}",
+		`${h[a\]b]}`, "${a[(r)t*]}", "${a[", "h[]",
+	} {
+		f.Add(source)
+	}
+	f.Fuzz(func(t *testing.T, source string) {
+		parser := NewParser(Variant(LangZsh), ZshSubscriptsAsWords(true), KeepComments(true))
+		node, err := parser.Parse(strings.NewReader(source), "")
+		if err != nil {
+			t.Skip()
+		}
+		// Match FuzzParsePrint's invariant: parsing and printing arbitrary
+		// accepted source must not panic. Fixed cases above check idempotence.
+		for _, opts := range [][]PrinterOption{nil, {Minify(true)}} {
+			qt.Assert(t, qt.IsNil(NewPrinter(opts...).Print(io.Discard, node)))
+		}
+	})
 }


### PR DESCRIPTION
Formatting `h[foo-bar]=1` in Zsh mode currently inserts spaces and breaks a valid associative-array assignment. The same assumption corrupts keys containing `/` or `+` and rejects `:`. Zsh determines whether a subscript is arithmetic or an associative key at runtime, so the parser cannot safely infer its meaning from the expression or a preceding declaration.

Add the opt-in parser option `ZshSubscriptsAsWords` and enable it in shfmt. It parses unflagged Zsh subscripts as words, preserving literal operators and whitespace while continuing to parse nested shell expansions. Track nested and escaped brackets in the lexer. Retain existing flagged-subscript parsing and Bash/mksh arithmetic parsing.

The library default remains unchanged for v3 compatibility. Existing parser fixtures retain their original expectations; new tests cover opt-in word nodes, disabling the option on a reused parser, and unchanged Bash/mksh behavior. A `TODO(v4)` records switching the default in a future major version. The first commit records the current incorrect output; the second fixes CLI formatting and adds behavior regressions.

Validation:

- Full Go package tests, `go vet ./...`, and a 20-second `FuzzZshSubscripts` run covering the opt-in path.
- Zsh 5.9 comparisons for associative keys, indexed arithmetic, slices, negative indices, flags, nested subscripts, command/arithmetic expansions, and escaped brackets.
- Default, minified, and single-line printing; one-byte readers and a long key crossing lexer buffers.
- CLI testscript coverage of explicit Zsh mode, filename detection, minification, and unchanged Bash formatting.
- Assertions use `qt`; external-shell subtests use the existing Zsh requirement helper. Missing-Zsh checks verify skipping normally and failing with `REQUIRE_SHELLS=1`.

This adds a parser option without changing existing exported signatures or the default AST. Library callers formatting Zsh should explicitly enable the option; callers using the legacy arithmetic AST can keep their existing configuration. The proposed option still needs the usual upstream API review.

Fixes #1233.
